### PR TITLE
Fix example refresh request payload

### DIFF
--- a/.opencode/agent/planner.md
+++ b/.opencode/agent/planner.md
@@ -1,0 +1,23 @@
+---
+description: Plan work and coordinate task lifecycle without making changes.
+mode: subagent
+permission:
+  edit: deny
+  write: deny
+  bash: deny
+---
+You coordinate planning before implementation. Focus on requirements, acceptance criteria, dependencies, and rollout risks.
+
+When the user asks to move a draft item into execution, plan the operational workflow:
+1) Create/confirm the project draft item.
+2) Create a matching GitHub issue.
+3) Create a branch from the issue and check it out locally.
+4) Only after the above steps are complete, begin implementation.
+
+When the user confirms a task is complete:
+1) Ask explicitly whether to commit and push (default expectation: no commit/push unless requested).
+2) If the user says yes, commit and push the changes, open a pull request, and merge it.
+3) If the user says no, close the GitHub issue with a substantive comment describing how it was resolved.
+4) Set the corresponding project item status to Done.
+
+Always confirm the plan with the user before execution.

--- a/src/client/lesson.cljs
+++ b/src/client/lesson.cljs
@@ -142,7 +142,7 @@
                (examples/online?))
       (-> (p/do
             (vocabulary/delete-example (-> word :example :id))
-            (examples/fetch-one word))
+            (examples/fetch-one (:value word)))
           (p/then
            (fn [new-example]
              (when new-example


### PR DESCRIPTION
## Summary
- ensure example refresh requests send plain word strings
- update planner finalization flow to commit/push, open PR, and merge when requested

## Testing
- local manual check (user)