### PR TITLE
Fix PATCH /lesson response format

### DIFF
--- a/src/client/application.cljs
+++ b/src/client/application.cljs
@@ -568,7 +568,7 @@
 
     {:data {:interceptors [(parameters/parameters-interceptor)
                            (keyword-parameters/keyword-parameters-interceptor)
-                           (hiccup/interceptor)
+                           (hiccup/interceptor {:layout-fn nil})
                            page-layout-interceptor]}})
 
    (constantly {:status 404 :body ""})

--- a/src/client/sw.cljs
+++ b/src/client/sw.cljs
@@ -115,7 +115,8 @@
   [request]
   (let [request    (.clone request)
         url-object (js/URL. (.-url request))
-        headers    (-> request .-headers .entries js/Object.fromEntries js->clj)]
+        headers    (-> request .-headers .entries js/Object.fromEntries js->clj)
+        headers    (update-keys headers str/lower-case)]
     {:server-port (.-port url-object)
      :server-name (.-hostname url-object)
      :uri (.-pathname url-object)


### PR DESCRIPTION
## Summary
- disable default layout wrapper for HTMX/non-GET fragments
- normalize service worker request headers for HX detection

## Testing
- manual (user)