### PR TITLE
GH-90 [ui] Replace add-word flash JS with class-tools OOB

### DIFF
--- a/resources/public/css/blocks/home.css
+++ b/resources/public/css/blocks/home.css
@@ -71,6 +71,15 @@
   width: 100%;
 }
 
+@keyframes home-add-success-flash {
+  0%   { background: rgb(var(--color-sea-sponge), 0.2);}
+  100% { background: rgb(255 255 255 / 0.7);}
+}
+
+.home__add--success {
+  animation: home-add-success-flash 1.2s ease-out forwards;
+}
+
 .home__add {
   background: rgb(255 255 255 / 0.7);
   border: 1px solid rgb(0 0 0 / 0.08);

--- a/resources/public/js/htmx/class-tools.js
+++ b/resources/public/js/htmx/class-tools.js
@@ -1,0 +1,97 @@
+(function() {
+  function splitOnWhitespace(trigger) {
+    return trigger.split(/\s+/)
+  }
+
+  function parseClassOperation(trimmedValue) {
+    var split = splitOnWhitespace(trimmedValue)
+    if (split.length > 1) {
+      var operation = split[0]
+      var classDef = split[1].trim()
+      var cssClass
+      var delay
+      if (classDef.indexOf(':') > 0) {
+        var splitCssClass = classDef.split(':')
+        cssClass = splitCssClass[0]
+        delay = htmx.parseInterval(splitCssClass[1])
+      } else {
+        cssClass = classDef
+        delay = 100
+      }
+      return {
+        operation,
+        cssClass,
+        delay
+      }
+    } else {
+      return null
+    }
+  }
+
+  function performOperation(elt, classOperation, classList, currentRunTime) {
+    setTimeout(function() {
+      elt.classList[classOperation.operation].call(elt.classList, classOperation.cssClass)
+    }, currentRunTime)
+  }
+
+  function toggleOperation(elt, classOperation, classList, currentRunTime) {
+    setTimeout(function() {
+      setInterval(function() {
+        elt.classList[classOperation.operation].call(elt.classList, classOperation.cssClass)
+      }, classOperation.delay)
+    }, currentRunTime)
+  }
+
+  function processClassList(elt, classList) {
+    var runs = classList.split('&')
+    for (var i = 0; i < runs.length; i++) {
+      var run = runs[i]
+      var currentRunTime = 0
+      var classOperations = run.split(',')
+      for (var j = 0; j < classOperations.length; j++) {
+        var value = classOperations[j]
+        var trimmedValue = value.trim()
+        var classOperation = parseClassOperation(trimmedValue)
+        if (classOperation) {
+          if (classOperation.operation === 'toggle') {
+            toggleOperation(elt, classOperation, classList, currentRunTime)
+            currentRunTime = currentRunTime + classOperation.delay
+          } else {
+            currentRunTime = currentRunTime + classOperation.delay
+            performOperation(elt, classOperation, classList, currentRunTime)
+          }
+        }
+      }
+    }
+  }
+
+  function maybeProcessClasses(elt) {
+    if (elt.getAttribute) {
+      var classList = elt.getAttribute('classes') || elt.getAttribute('data-classes')
+      if (classList) {
+        processClassList(elt, classList)
+      }
+    }
+  }
+
+  htmx.defineExtension('class-tools', {
+    onEvent: function(name, evt) {
+      if (name === 'htmx:afterProcessNode') {
+        var elt = evt.detail.elt
+        maybeProcessClasses(elt)
+        var classList = elt.getAttribute('apply-parent-classes') || elt.getAttribute('data-apply-parent-classes')
+        if (classList) {
+          var parent = elt.parentElement
+          parent.removeChild(elt)
+          parent.setAttribute('classes', classList)
+          maybeProcessClasses(parent)
+        } else if (elt.querySelectorAll) {
+          var children = elt.querySelectorAll('[classes], [data-classes]')
+          for (var i = 0; i < children.length; i++) {
+            maybeProcessClasses(children[i])
+          }
+        }
+      }
+    }
+  })
+})()

--- a/src/client/application.cljs
+++ b/src/client/application.cljs
@@ -41,6 +41,7 @@
      [:link {:rel "manifest" :href "/manifest.json"}]
      [:link {:rel "stylesheet" :href "/css/styles.css"}]
      [:script {:src "/js/htmx/htmx.min.js" :defer true}]
+     [:script {:src "/js/htmx/class-tools.js" :defer true}]
      [:script {:src "/js/word-autocomplete.js" :defer true}]
      [:script {:src "/js/virtual-keyboard.js" :defer true}]
      head]
@@ -107,9 +108,9 @@
                    {:html/body (views.dictionary/suggestions suggestions prefill)
                     :status    200})
                  (p/catch
-                  (fn [_err]
-                    {:html/body (views.dictionary/suggestions [] nil)
-                     :status    200}))))}]
+                   (fn [_err]
+                     {:html/body (views.dictionary/suggestions [] nil)
+                      :status    200}))))}]
 
     ["/words"
      {:head (fn [{:keys [dbs]}]
@@ -144,8 +145,8 @@
 
                                   :else
                                   (views.word/page
-                                   {:empty? (zero? total)
-                                    :words words
+                                   {:empty?     (zero? total)
+                                    :words      words
                                     :show-more? show-more?}))}))))
 
       :post (fn [{:keys [dbs params]}]
@@ -156,7 +157,8 @@
                    :status    400}
                   (p/let [word-id (vocabulary/add! dbs value translation)]
                     (examples/create-fetch-task! word-id)
-                    {:status 201}))))}]
+                    {:html/body (views.home/add-success)
+                     :status    201}))))}]
 
     ["/words/:id"
      {:get    (fn [{:keys [dbs path-params params]}]

--- a/src/client/sw.cljs
+++ b/src/client/sw.cljs
@@ -43,6 +43,7 @@
     "/fonts/Nunito/nunito-v26-cyrillic_latin-700.woff2"
     "/fonts/Nunito/nunito-v26-cyrillic_latin-800.woff2"
     "/js/htmx/htmx.min.js"
+    "/js/htmx/class-tools.js"
     "/favicon.ico"
     "/icons.svg"
     "/icons/ue-192.png"

--- a/src/client/views/home.cljs
+++ b/src/client/views/home.cljs
@@ -2,6 +2,84 @@
   "Home page view.")
 
 
+(def add-panel-id
+  "home-add-panel")
+
+
+(def add-form-id
+  "home-add-form")
+
+
+(defn- add-form
+  [{:keys [oob?]}]
+  [:form.home__add-form
+   (cond-> {:id            add-form-id
+            :hx-post       "/words"
+            :hx-push-url   "false"
+            :hx-swap       "none"
+            :hx-disabled-elt "find button[type='submit']"
+            :hx-disinherit "hx-disabled-elt"}
+     oob? (assoc :hx-swap-oob (str "outerHTML:#" add-form-id)))
+   [:fieldset.home__add-fieldset
+    [:legend.home__add-legend
+     "Добавить слово"]
+    [:word-autocomplete
+     [:div.home__add-form-row
+      [:div.autocomplete
+       [:label.home__add-form-label
+        {:for "new-word-value"}
+        "Слово (немецкий)"]
+       [:input.home__add-form-input
+        {:id             "new-word-value"
+         :name           "value"
+         :autocapitalize "off"
+         :autocomplete   "off"
+         :autocorrect    "off"
+         :data-ac-role   "word"
+         :hx-get         "/dictionary-entries"
+         :hx-include     "this"
+         :hx-sync        "this:replace"
+         :hx-target      "next [data-ac-role='list']"
+         :hx-trigger     "input changed delay:300ms"
+         :hx-swap        "innerHTML"
+         :required       true
+         :lang           "de"
+         :placeholder    "Новое слово"}]
+       [:ul.suggestions
+        {:data-ac-role "list"}]]
+      [:span.home__add-form-arrow
+       "→"]
+      [:div.home__add-translation
+       [:label.home__add-form-label
+        {:for "new-word-translation"}
+        "Перевод (русский)"]
+       [:input.home__add-form-input
+        {:id           "new-word-translation"
+         :name         "translation"
+         :autocapitalize "off"
+         :autocomplete "off"
+         :autocorrect  "off"
+         :data-ac-role "translation"
+         :lang         "ru"
+         :placeholder  "Перевод"
+         :required     true}]]]]
+
+    [:button.home__add-form-submit.big-button.big-button--request-stable
+     {:type "submit"}
+     "ДОБАВИТЬ"]]])
+
+
+(defn add-success
+  []
+  (list
+   (add-form {:oob? true})
+   [:div
+    {:hx-swap-oob (str "beforeend:#" add-panel-id)}
+    [:div
+     {:hx-ext "class-tools"
+      :apply-parent-classes "add home__add--success, remove home__add--success:300ms"}]]))
+
+
 (defn page
   []
   [:div.home
@@ -12,7 +90,7 @@
      "Быстро добавляйте слова и учите немецкий даже без сети."]]
 
    [:main.home__content
-    [:section.home__add
+    [:section#home-add-panel.home__add
      [:header.home__add-header
       [:h2.home__panel-title
        "Быстрое добавление"]
@@ -24,61 +102,7 @@
         :hx-target   "#app"}
        "Список слов"]]
 
-     [:form.home__add-form
-      {:hx-on:htmx:after-request
-       "if(event.detail.successful && event.detail.elt===this) {this.reset();}"
-       :hx-post         "/words"
-       :hx-push-url     "false"
-       :hx-swap         "none"
-       :hx-disabled-elt "find button[type='submit']"
-       :hx-disinherit   "hx-disabled-elt"}
-      [:fieldset.home__add-fieldset
-       [:legend.home__add-legend
-        "Добавить слово"]
-       [:word-autocomplete
-        [:div.home__add-form-row
-         [:div.autocomplete
-          [:label.home__add-form-label
-           {:for "new-word-value"}
-           "Слово (немецкий)"]
-          [:input.home__add-form-input
-           {:id             "new-word-value"
-            :name           "value"
-            :autocapitalize "off"
-            :autocomplete   "off"
-            :autocorrect    "off"
-            :data-ac-role   "word"
-            :hx-get         "/dictionary-entries"
-            :hx-include     "this"
-            :hx-sync        "this:replace"
-            :hx-target      "next [data-ac-role='list']"
-            :hx-trigger     "input changed delay:300ms"
-            :hx-swap        "innerHTML"
-            :required       true
-            :lang           "de"
-            :placeholder    "Новое слово"}]
-          [:ul.suggestions
-           {:data-ac-role "list"}]]
-         [:span.home__add-form-arrow
-          "→"]
-         [:div.home__add-translation
-          [:label.home__add-form-label
-           {:for "new-word-translation"}
-           "Перевод (русский)"]
-          [:input.home__add-form-input
-           {:id           "new-word-translation"
-            :name         "translation"
-            :autocapitalize "off"
-            :autocomplete "off"
-            :autocorrect  "off"
-            :data-ac-role "translation"
-            :lang         "ru"
-            :placeholder  "Перевод"
-            :required     true}]]]]
-
-       [:button.home__add-form-submit.big-button.big-button--request-stable
-        {:type "submit"}
-        "ДОБАВИТЬ"]]]]]
+     (add-form {:oob? false})]]
 
    [:footer.home__footer
     [:h2.home__lesson-title


### PR DESCRIPTION
## Summary
- replace inline `hx-on` JS on the home add-word form with HTMX OOB updates
- add local `class-tools` extension and wire it into the app shell + service worker precache for offline support
- return OOB form reset + panel flash payload from `POST /words` success response

## Verification
- npx shadow-cljs compile node-test
- npx shadow-cljs compile app