### PR TITLE
GH-108 [fix] reset lesson sessions and persist word progress

### DIFF
--- a/openspec/changes/archive/2026-04-09-fix-lesson-session-reset-and-progress/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-09-fix-lesson-session-reset-and-progress/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-09

--- a/openspec/changes/archive/2026-04-09-fix-lesson-session-reset-and-progress/design.md
+++ b/openspec/changes/archive/2026-04-09-fix-lesson-session-reset-and-progress/design.md
@@ -1,0 +1,53 @@
+## Context
+
+Lesson traffic in the PWA runs through the client/service-worker route layer, not a separate server-side lesson session. The current lesson document is stored locally in `device-db` with a fixed `_id`, and lesson entry currently reuses that stored document via `ensure!`. That makes lesson entry behave like implicit resume, which matches the reported “same session every time” symptom on production.
+
+Word progress is derived from review documents in `user-db`. The current `check-answer!` path already attempts to write review documents for word trials, so this bug should be addressed by making lesson entry deterministic and by adding regression coverage around review persistence and observed progress.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make lesson entry from the UI start a fresh lesson session every time.
+- Preserve the existing in-lesson answer and next-step flow.
+- Confirm through tests that word-trial answers continue to create review data and influence progress.
+
+**Non-Goals:**
+- Redesign the broader offline sync architecture.
+- Introduce multi-session lesson history.
+- Change example-trial review semantics.
+
+## Decisions
+
+### Start a fresh lesson at route entry
+Use the lesson entry route as the boundary for reset semantics. On `GET /lesson`, remove any existing lesson document before creating a new one.
+
+Why this approach:
+- It directly matches the intended UX: tapping the lesson entry point starts a new session.
+- It keeps lesson progression logic unchanged after the lesson starts.
+- It avoids adding age-based or heuristic cleanup rules for stale local sessions.
+
+Alternative considered:
+- Keep `ensure!` and try to detect “broken” or “old” lessons. Rejected because it keeps ambiguous resume semantics and leaves stale-session behavior hard to reason about.
+
+### Keep review persistence in the answer path
+Retain the current model where word-trial answers create review documents during `check-answer!`.
+
+Why this approach:
+- It already matches the retention model used by vocabulary ordering.
+- The bug report can be covered by proving this path still runs and is visible after a fresh lesson restart.
+
+Alternative considered:
+- Move review persistence to lesson completion. Rejected because it delays progress updates and changes existing semantics.
+
+### Cover the bug with route-level and app-level tests
+Add tests that exercise repeated lesson entry and verify that review data exists after word-trial answers.
+
+Why this approach:
+- The stale-session symptom appears at the route boundary, not just in pure domain logic.
+- The progress complaint needs evidence at the persistence boundary, not only in UI rendering.
+
+## Risks / Trade-offs
+
+- Re-entering lesson will discard an unfinished local lesson session by design. -> This is intentional and matches the selected UX.
+- If progress still appears stale after a fresh lesson reset, there may be a second bug in review persistence or retention reads. -> Cover `check-answer!` and post-answer state with regression tests before declaring the fix complete.
+- Existing tests may assume `ensure!`-style resume semantics at route entry. -> Update route-facing expectations while leaving low-level helpers intact where appropriate.

--- a/openspec/changes/archive/2026-04-09-fix-lesson-session-reset-and-progress/proposal.md
+++ b/openspec/changes/archive/2026-04-09-fix-lesson-session-reset-and-progress/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+On production, lesson entry can reuse a stale local lesson session instead of starting a fresh session from the current vocabulary state. Word progress also appears not to update after lesson answers, which undermines retention-based ordering and makes lesson behavior look stuck.
+
+## What Changes
+
+- Start a fresh lesson session when the user enters lesson flow from the UI instead of silently resuming an older local lesson document.
+- Preserve in-lesson answer and next-step behavior while making lesson entry deterministic and reset-safe.
+- Ensure word-trial answers continue to record review data that affects retention/progress and is visible on subsequent lesson entry.
+- Add regression coverage for stale lesson reuse and review-driven progress updates.
+
+## Capabilities
+
+### New Capabilities
+<!-- None -->
+
+### Modified Capabilities
+- `lesson`: entering a lesson from the UI must start a new lesson session, and lesson answers must continue to update review-backed progress consistently.
+
+## Impact
+
+- Affected code: `src/client/application.cljs`, `src/client/lesson.cljs`, `src/client/domain/lesson.cljs`, and lesson-related tests under `test/client/`.
+- Affected behavior: lesson entry, persisted local lesson session handling, review persistence for word trials, and progress observed after re-entering a lesson.
+- Validation focus: repeated lesson entry on prod-like service-worker flow, word-trial review creation, and regression-free lesson progression.

--- a/openspec/changes/archive/2026-04-09-fix-lesson-session-reset-and-progress/specs/lesson/spec.md
+++ b/openspec/changes/archive/2026-04-09-fix-lesson-session-reset-and-progress/specs/lesson/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Lesson entry starts a fresh session
+The system SHALL start a new lesson session when the user enters the lesson flow from the UI, rather than silently reusing an older persisted lesson document.
+
+#### Scenario: Re-entering lesson after leaving an unfinished session
+- **WHEN** a user enters the lesson flow while a previous local lesson document still exists
+- **THEN** the system creates a new lesson session from the current vocabulary state
+- **AND** the newly rendered lesson does not reuse the stale persisted session
+
+### Requirement: Word-trial answers record review progress
+The system SHALL record review data for word-trial answers so retention-based progress updates are reflected after lesson activity.
+
+#### Scenario: Answering a word trial
+- **WHEN** a user submits an answer for a word trial
+- **THEN** the system records a review for that word using the answer result
+- **AND** subsequent progress calculations can observe the updated review data
+
+#### Scenario: Answering an example trial
+- **WHEN** a user submits an answer for an example trial
+- **THEN** the system does not create a vocabulary review document for that answer

--- a/openspec/changes/archive/2026-04-09-fix-lesson-session-reset-and-progress/tasks.md
+++ b/openspec/changes/archive/2026-04-09-fix-lesson-session-reset-and-progress/tasks.md
@@ -1,0 +1,14 @@
+## 1. Lesson Entry Reset
+
+- [x] 1.1 Change lesson entry so `GET /lesson` starts a fresh lesson session instead of reusing a persisted local lesson document.
+- [x] 1.2 Add regression coverage for repeated lesson entry with an existing unfinished lesson state.
+
+## 2. Review Progress Integrity
+
+- [x] 2.1 Verify and, if needed, fix word-trial answer handling so it persists review data for retention/progress updates.
+- [x] 2.2 Add regression coverage that word-trial answers create review documents while example-trial answers do not.
+
+## 3. Verification
+
+- [x] 3.1 Run lesson-related client tests and fix regressions.
+- [x] 3.2 Manually confirm the production-like lesson flow no longer reopens the same stale session.

--- a/openspec/specs/lesson/spec.md
+++ b/openspec/specs/lesson/spec.md
@@ -55,3 +55,23 @@ The system SHALL store lesson state without a separate `:words` collection.
 - **THEN** it includes `:trials`, `:remaining-trials`, `:current-trial`, and `:last-result`
 - **AND** it omits a `:words` field
 
+### Requirement: Lesson entry starts a fresh session
+The system SHALL start a new lesson session when the user enters the lesson flow from the UI, rather than silently reusing an older persisted lesson document.
+
+#### Scenario: Re-entering lesson after leaving an unfinished session
+- **WHEN** a user enters the lesson flow while a previous local lesson document still exists
+- **THEN** the system creates a new lesson session from the current vocabulary state
+- **AND** the newly rendered lesson does not reuse the stale persisted session
+
+### Requirement: Word-trial answers record review progress
+The system SHALL record review data for word-trial answers so retention-based progress updates are reflected after lesson activity.
+
+#### Scenario: Answering a word trial
+- **WHEN** a user submits an answer for a word trial
+- **THEN** the system records a review for that word using the answer result
+- **AND** subsequent progress calculations can observe the updated review data
+
+#### Scenario: Answering an example trial
+- **WHEN** a user submits an answer for an example trial
+- **THEN** the system does not create a vocabulary review document for that answer
+

--- a/src/client/application.cljs
+++ b/src/client/application.cljs
@@ -211,7 +211,7 @@
 
     ["/lesson"
      {:get    (fn [{:keys [dbs]}]
-                (p/let [{:keys [lesson-state error]} (lesson/ensure! dbs {:trial-selector :random})]
+                (p/let [{:keys [lesson-state error]} (lesson/restart! dbs {:trial-selector :random})]
                   (cond
                     lesson-state
                     {:html/body (views.lesson/page lesson-state) :status 200}

--- a/src/client/domain/lesson.cljs
+++ b/src/client/domain/lesson.cljs
@@ -37,7 +37,7 @@
    Word summary has :id, :value, :translation, :retention-level."
   [word]
   {:type    trial-type-word
-   :word-id (:_id word)
+   :word-id (:id word)
    :prompt  (->> (:translation word)
                  (filter #(= "ru" (:lang %)))
                  (map :value)

--- a/src/client/lesson.cljs
+++ b/src/client/lesson.cljs
@@ -56,16 +56,22 @@
        {:error :lesson-start-failed}))))
 
 
-(defn ensure!
-  "Returns existing lesson or starts a new one.
+(defn finish!
+  [dbs]
+  (p/let [existing (state dbs)]
+    (when existing
+      (dbs/remove dbs existing))))
+
+
+(defn restart!
+  "Always starts a fresh lesson session by removing any persisted lesson first.
    Returns {:lesson-state ...} or {:error ...}."
   ([dbs]
-   (ensure! dbs {}))
+   (restart! dbs {}))
   ([dbs opts]
-   (p/let [existing (state dbs)]
-     (if existing
-       {:lesson-state existing}
-       (start! dbs opts)))))
+   (p/do
+     (finish! dbs)
+     (start! dbs opts))))
 
 
 (defn check-answer!
@@ -114,9 +120,3 @@
             (log/error :advance-lesson/save-failed {:error (ex-message err)})
             {:error :lesson-save-failed}))))))
 
-
-(defn finish!
-  [dbs]
-  (p/let [existing (state dbs)]
-    (when existing
-      (dbs/remove dbs existing))))

--- a/test/client/lesson_test.cljs
+++ b/test/client/lesson_test.cljs
@@ -107,42 +107,40 @@
 
 
 ;; =============================================================================
-;; ensure!
+;; restart!
 ;; =============================================================================
 
 
-(deftest ensure-returns-existing-lesson
-  (async-testing "`ensure!` returns existing lesson"
+(deftest restart-replaces-existing-lesson-with-fresh-session
+  (async-testing "`restart!` discards persisted lesson state and starts fresh"
     (with-test-dbs
      (fn [dbs]
        (p/do
-         (db-seed/seed-vocabulary! (:user/db dbs) [{:_id "word-1" :value "der Hund" :translation "пёс"}])
-         (p/let [start-result  (sut/start! dbs {:trial-selector :first})
-                 ensure-result (sut/ensure! dbs {:trial-selector :first})]
-           ;; Should return the same lesson, not create a new one
-           (is (some? (:lesson-state ensure-result)))
-           (is (= (:_id (:lesson-state start-result))
-                  (:_id (:lesson-state ensure-result))))))))))
+         (db-seed/seed-vocabulary!
+          (:user/db dbs)
+          [{:_id "word-1" :value "der Hund" :translation "пёс"}
+           {:_id "word-2" :value "die Katze" :translation "кошка"}])
+         (p/let [start-result (sut/start! dbs {:trial-selector :first})
+                 first-trial  (domain/current-trial (:lesson-state start-result))
+                 _            (sut/check-answer! dbs (:answer first-trial))
+                 restarted    (sut/restart! dbs {:trial-selector :first})
+                 lessons      (db-queries/fetch-by-type (:device/db dbs) "lesson")
+                 lesson-state (:lesson-state restarted)]
+           (is (some? lesson-state))
+           (is (nil? (:error restarted)))
+           (is (= 1 (count lessons)))
+           (is (= (count (:trials lesson-state))
+                  (count (:remaining-trials lesson-state))))
+           (is (nil? (domain/last-result lesson-state)))))))))
 
 
-(deftest ensure-starts-new-lesson-when-none-exists
-  (async-testing "`ensure!` creates lesson when none exists"
+(deftest restart-returns-error-when-no-words
+  (async-testing "`restart!` propagates start errors"
     (with-test-dbs
      (fn [dbs]
-       (p/do
-         (db-seed/seed-vocabulary! (:user/db dbs) [{:_id "word-1" :value "der Hund" :translation "пёс"}])
-         (p/let [result (sut/ensure! dbs {:trial-selector :first})]
-           (is (some? (:lesson-state result)))
-           (is (nil? (:error result)))))))))
-
-
-(deftest ensure-returns-error-when-start-fails
-  (async-testing "`ensure!` propagates start errors"
-    (with-test-dbs
-     (fn [dbs]
-       ;; No words seeded, so start! should fail
-       (p/let [result (sut/ensure! dbs)]
-         (is (= :no-words-available (:error result))))))))
+       (p/let [result (sut/restart! dbs)]
+         (is (= :no-words-available (:error result)))
+         (is (nil? (:lesson-state result))))))))
 
 
 ;; =============================================================================
@@ -165,7 +163,13 @@
              (is (= "der Hund" (:answer last-result)))))
          ;; Verify a review was created for the word trial
          (p/let [reviews (db-queries/fetch-by-type (:user/db dbs) "review")]
-           (is (= 2 (count reviews)))))))))
+           (is (= 2 (count reviews)))
+           (is (= ["word-1"]
+                  (->> reviews
+                       (map :word-id)
+                       (remove nil?)
+                       distinct
+                       vec)))))))))
 
 
 (deftest check-answer-wrong-word-trial

--- a/test/client/support/fixtures.cljs
+++ b/test/client/support/fixtures.cljs
@@ -42,14 +42,14 @@
 
 
 (def lesson-words
-  "Word rows as returned by vocabulary/list (raw docs with :retention-level)."
-  [{:_id         "word-1"
-    :value       "der Hund"
-    :translation [{:lang "ru" :value "пёс"}]
+  "Word rows as denormalized into lesson state before trial generation."
+  [{:id              "word-1"
+    :value           "der Hund"
+    :translation     [{:lang "ru" :value "пёс"}]
     :retention-level 20}
-   {:_id         "word-2"
-    :value       "die Katze"
-    :translation [{:lang "ru" :value "кошка"}]
+   {:id              "word-2"
+    :value           "die Katze"
+    :translation     [{:lang "ru" :value "кошка"}]
     :retention-level 50}])
 
 


### PR DESCRIPTION
## Summary
- reset lesson entry so the UI always starts a fresh session
- preserve word review progress by keeping the correct word id in lesson trials
- archive the OpenSpec change and update the main lesson spec

## Verification
- npx shadow-cljs release node-test
- local browser flow: added 6 words, completed a lesson, reopened lesson and observed a different fresh session

Fixes #108