### PR TITLE
GH-110 [ui] restore desktop add-word focus

### DIFF
--- a/openspec/changes/archive/2026-04-09-restore-home-add-form-focus/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-09-restore-home-add-form-focus/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-09

--- a/openspec/changes/archive/2026-04-09-restore-home-add-form-focus/design.md
+++ b/openspec/changes/archive/2026-04-09-restore-home-add-form-focus/design.md
@@ -1,0 +1,49 @@
+## Context
+
+The home add-word flow submits with `hx-swap="none"` and returns an out-of-band replacement of the form shell. After the OOB swap, the fresh form instance has no explicit focus restoration, so desktop users lose caret position even though the UI is otherwise ready for the next entry.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Return focus to `#new-word-value` after a successful submit on desktop-style devices.
+- Keep the behavior local to the home add flow without changing routing or broader HTMX update strategy.
+- Avoid reopening the soft keyboard automatically on touch-first/mobile devices.
+
+**Non-Goals:**
+- Redesigning the add-word form.
+- Adding a general-purpose client-side focus manager.
+- Changing validation or autocomplete behavior.
+
+## Decisions
+
+### 1) Restore focus from the OOB replacement itself
+- Attach the post-submit focus behavior to the OOB-rendered home add form.
+- Run the focus logic after HTMX has settled the replacement so the new input element exists.
+
+### 2) Gate focus restoration to desktop-style pointers
+- Use a pointer capability heuristic (`matchMedia('(pointer:fine)')`) to focus only where persistent keyboard entry is expected.
+- Do not force focus on coarse-pointer/mobile devices.
+
+### 3) Keep the implementation local and low-risk
+- Implement the behavior as a tiny view-level HTMX hook in `views.home`.
+- Verify the result with a real browser add-word flow instead of introducing extra runtime infrastructure.
+
+## Risks / Trade-offs
+
+- **Risk:** Some hybrid devices may report an unexpected pointer type.  
+  **Mitigation:** Use a conservative desktop-oriented heuristic and verify the common desktop path first.
+
+- **Risk:** Focus restoration could run on error responses if attached too broadly.  
+  **Mitigation:** Keep it on the success-path OOB form replacement only.
+
+## Migration Plan
+
+1. Add desktop-only focus restoration to the OOB home add form.
+2. Run a browser flow that adds multiple words in sequence and confirm the German field keeps focus after each successful submit.
+3. Sanity-check that mobile behavior is not explicitly forced by the new hook.
+
+Rollback: remove the new HTMX focus hook from the OOB home add form.
+
+## Open Questions
+
+- Do we want the same desktop focus-restoration behavior for inline vocabulary editing later, or should it remain scoped to home add flow?

--- a/openspec/changes/archive/2026-04-09-restore-home-add-form-focus/proposal.md
+++ b/openspec/changes/archive/2026-04-09-restore-home-add-form-focus/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+On desktop, successful add-word submit resets the form but does not return focus to the German word input. This slows down repeated entry because keyboard users and fast typists must manually refocus the field after every submit.
+
+## What Changes
+
+- Restore focus to the German word input after a successful home add-word submit on desktop-style pointer devices.
+- Keep mobile behavior unchanged so the soft keyboard is not reopened unexpectedly after submit.
+- Verify the behavior in the real browser flow used for repeated word entry.
+
+## Capabilities
+
+### New Capabilities
+- `home-add-form-focus`: Defines post-submit focus behavior for the home add-word flow.
+
+### Modified Capabilities
+- _(none)_
+
+## Impact
+
+- Affected code: `src/client/views/home.cljs`.
+- Affected behavior: repeated word entry on the home screen after successful submit.
+- Validation focus: desktop browser submit/focus loop and a sanity check that mobile-like behavior is not forced.

--- a/openspec/changes/archive/2026-04-09-restore-home-add-form-focus/specs/home-add-form-focus/spec.md
+++ b/openspec/changes/archive/2026-04-09-restore-home-add-form-focus/specs/home-add-form-focus/spec.md
@@ -1,0 +1,20 @@
+## Purpose
+Define post-submit focus behavior for the home add-word flow so desktop repeated entry stays fast without changing mobile ergonomics.
+
+## ADDED Requirements
+
+### Requirement: Successful desktop add-word submit restores primary input focus
+The system SHALL restore focus to the German word input after a successful home add-word submit on desktop-style pointer devices.
+
+#### Scenario: Desktop repeated entry stays in the German input
+- **WHEN** a user successfully submits the home add-word form on a desktop-style pointer device
+- **THEN** the form is reset through the normal success flow
+- **AND** focus returns to the `#new-word-value` input
+
+### Requirement: Mobile submit does not force focus restoration
+The system SHALL avoid forcing focus restoration on touch-first/mobile devices after a successful home add-word submit.
+
+#### Scenario: Mobile success does not reopen the keyboard
+- **WHEN** a user successfully submits the home add-word form on a coarse-pointer or touch-first device
+- **THEN** the success flow completes without explicitly focusing the German input
+- **AND** the implementation does not intentionally reopen the soft keyboard

--- a/openspec/changes/archive/2026-04-09-restore-home-add-form-focus/tasks.md
+++ b/openspec/changes/archive/2026-04-09-restore-home-add-form-focus/tasks.md
@@ -1,0 +1,13 @@
+## 1. Specify Desired Focus Behavior
+
+- [x] 1.1 Capture the expected desktop and mobile post-submit focus behavior in proposal, design, and spec artifacts.
+
+## 2. Implement Desktop-Only Focus Restoration
+
+- [x] 2.1 Restore focus to `#new-word-value` from the successful OOB add-form replacement.
+- [x] 2.2 Gate the behavior so mobile/touch-first devices are not forced to refocus the input.
+
+## 3. Verify
+
+- [x] 3.1 Run a real desktop browser add-word flow with repeated submits and confirm focus returns after each success.
+- [x] 3.2 Run `npx shadow-cljs compile app` and address regressions.

--- a/openspec/specs/home-add-form-focus/spec.md
+++ b/openspec/specs/home-add-form-focus/spec.md
@@ -1,0 +1,21 @@
+# home-add-form-focus Specification
+
+## Purpose
+TBD - created by archiving change restore-home-add-form-focus. Update Purpose after archive.
+## Requirements
+### Requirement: Successful desktop add-word submit restores primary input focus
+The system SHALL restore focus to the German word input after a successful home add-word submit on desktop-style pointer devices.
+
+#### Scenario: Desktop repeated entry stays in the German input
+- **WHEN** a user successfully submits the home add-word form on a desktop-style pointer device
+- **THEN** the form is reset through the normal success flow
+- **AND** focus returns to the `#new-word-value` input
+
+### Requirement: Mobile submit does not force focus restoration
+The system SHALL avoid forcing focus restoration on touch-first/mobile devices after a successful home add-word submit.
+
+#### Scenario: Mobile success does not reopen the keyboard
+- **WHEN** a user successfully submits the home add-word form on a coarse-pointer or touch-first device
+- **THEN** the success flow completes without explicitly focusing the German input
+- **AND** the implementation does not intentionally reopen the soft keyboard
+

--- a/src/client/views/home.cljs
+++ b/src/client/views/home.cljs
@@ -10,6 +10,18 @@
   "home-add-form")
 
 
+(def home-add-panel-after-settle-script
+  (str
+   "if (event.target && event.target.id === 'home-add-form' && "
+   "matchMedia('(pointer:fine)').matches) { "
+   "var panel = this; "
+   "setTimeout(function() { "
+   "var input = htmx.find(panel, '#new-word-value'); "
+   "if (input) input.focus(); "
+   "}, 0); "
+   "}"))
+
+
 (defn- add-form
   [{:keys [oob?]}]
   [:form.home__add-form
@@ -111,6 +123,8 @@
 
    [:main.home__content
     [:section#home-add-panel.home__add
+     {"hx-on:htmx:after-settle"
+      home-add-panel-after-settle-script}
      [:header.home__add-header
       [:h2.home__panel-title
        "Быстрое добавление"]


### PR DESCRIPTION
## Summary
- restore desktop focus to the German input after successful add-word submit
- keep the handler inline via htmx on the stable home add panel
- archive the OpenSpec change and add the resulting main spec

Closes #110