### PR TITLE
GH-114 Clarify example fetch failures

### DIFF
--- a/openspec/changes/archive/2026-04-09-handle-invalid-example-fetch-warnings/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-09-handle-invalid-example-fetch-warnings/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-09

--- a/openspec/changes/archive/2026-04-09-handle-invalid-example-fetch-warnings/design.md
+++ b/openspec/changes/archive/2026-04-09-handle-invalid-example-fetch-warnings/design.md
@@ -1,0 +1,61 @@
+## Context
+
+After a new word is created, the client schedules an `example-fetch` background task. That task calls `/api/examples`, receives JSON, and then persists an `example` document locally. Right now the client validates only at save time, so malformed or incomplete backend responses produce a generic warning from `save-example!`.
+
+In development this is especially confusing because failures may come from:
+
+- missing `OPENAI_API_KEY`
+- invalid/malformed payloads from the backend example generator
+- transport/server errors
+
+The task runner itself is working as designed: it logs the warning and retries. The main issue is that the failure is classified too late and explained too poorly.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Fail earlier and more explicitly when `/api/examples` returns an invalid payload.
+- Return clearer backend status/error responses for unavailable example generation.
+- Keep the current background-task retry model intact.
+
+**Non-Goals:**
+- Redesigning example generation prompts.
+- Removing retries from `example-fetch`.
+- Building a full structured error taxonomy across the whole app.
+
+## Decisions
+
+### 1) Validate example payloads at the API boundary
+- Treat a successful example response as requiring at least `value` and `translation`.
+- Reject malformed success payloads in `fetch-one` before `save-example!` runs.
+
+### 2) Make backend failures explicit
+- If example generation is unavailable in development because `OPENAI_API_KEY` is missing, return a non-200 response with a clear error message.
+- If backend generation returns an invalid example payload, return a non-200 response instead of `200` with a malformed body.
+
+### 3) Keep local persistence validation as a final guard
+- `save-example!` should still defend against invalid data, but it should no longer be the primary place where backend contract failures are first discovered.
+
+### 4) Preserve task retry semantics
+- `example-fetch` should still return `false` on fetch/validation failures so retries continue to work.
+- The key change is clearer failure messages and cleaner separation between server-side and client-side validation failures.
+
+## Risks / Trade-offs
+
+- **Risk:** Returning non-200 for missing API key may cause more visible retries in development.  
+  **Mitigation:** That is acceptable because the message becomes actionable instead of misleading.
+
+- **Risk:** Some existing code may rely on permissive success parsing.  
+  **Mitigation:** Add tests for valid and invalid payloads at the client task boundary.
+
+## Migration Plan
+
+1. Tighten backend availability/payload checks for `/api/examples`.
+2. Tighten client parsing in `fetch-one`.
+3. Add tests for invalid payload rejection and task retry behavior.
+4. Verify logs now point to the real failure cause instead of late save-time validation.
+
+Rollback: revert backend response handling and client payload validation together.
+
+## Open Questions
+
+- Should missing `OPENAI_API_KEY` eventually disable example-fetch task creation in dev, or is clearer failure reporting enough for now?

--- a/openspec/changes/archive/2026-04-09-handle-invalid-example-fetch-warnings/proposal.md
+++ b/openspec/changes/archive/2026-04-09-handle-invalid-example-fetch-warnings/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Adding a word can trigger a background `example-fetch` task that currently logs a vague warning like `Invalid example: missing required fields`. The warning is technically true, but it hides the real failure mode:
+
+- the backend may be unavailable for example generation in development
+- the backend may return an invalid payload
+- the client only discovers the problem late, when trying to save the example locally
+
+This makes debugging noisy and slows down understanding of whether the problem is configuration, backend behavior, or client validation.
+
+## What Changes
+
+- Make example-fetch failures surface clearer error causes instead of collapsing into a late `missing required fields` warning.
+- Validate example payloads closer to the backend/client boundary.
+- Return clearer backend responses when example generation is unavailable or invalid.
+- Preserve retry behavior for background example-fetch tasks while improving observability.
+
+## Capabilities
+
+### New Capabilities
+- `example-fetch-error-clarity`: Defines how example-fetch failures are validated and surfaced across backend and client boundaries.
+
+### Modified Capabilities
+- `examples`: Tightens the contract for successful example payloads used by background fetch tasks.
+
+## Impact
+
+- Affected code: `src/backend/core.clj`, `src/backend/examples.clj`, `src/client/examples.cljs`, `test/client/examples_test.cljs`.
+- Affected behavior: background example generation after adding a word, especially in local development.
+- Validation focus: invalid payload handling, missing API key handling, and clearer client/task-level failure signaling.

--- a/openspec/changes/archive/2026-04-09-handle-invalid-example-fetch-warnings/specs/example-fetch-error-clarity/spec.md
+++ b/openspec/changes/archive/2026-04-09-handle-invalid-example-fetch-warnings/specs/example-fetch-error-clarity/spec.md
@@ -1,0 +1,20 @@
+## Purpose
+Define clearer backend/client failure handling for background example-fetch so invalid or unavailable example generation does not collapse into misleading late warnings.
+
+## ADDED Requirements
+
+### Requirement: Example fetch rejects malformed success payloads before local save
+The system SHALL reject malformed example payloads before attempting to save them as local example documents.
+
+#### Scenario: Backend success body misses required fields
+- **WHEN** `/api/examples` returns a success response that lacks required example fields
+- **THEN** the client rejects the payload before `save-example!`
+- **AND** the example-fetch task is treated as failed and retryable
+
+### Requirement: Example generation unavailability is surfaced explicitly
+The system SHALL return an explicit non-success response when backend example generation is unavailable.
+
+#### Scenario: Development backend has no API key
+- **WHEN** example generation is unavailable because required backend configuration is missing
+- **THEN** `/api/examples` returns a non-200 response with a clear error message
+- **AND** the resulting client/task warning points to the real availability problem rather than `missing required fields`

--- a/openspec/changes/archive/2026-04-09-handle-invalid-example-fetch-warnings/tasks.md
+++ b/openspec/changes/archive/2026-04-09-handle-invalid-example-fetch-warnings/tasks.md
@@ -1,0 +1,15 @@
+## 1. Clarify the Failure Contract
+
+- [x] 1.1 Document the desired backend/client behavior for unavailable or malformed example generation.
+
+## 2. Tighten Backend and Client Validation
+
+- [x] 2.1 Return clearer non-success responses from `/api/examples` when example generation is unavailable.
+- [x] 2.2 Reject malformed success payloads in `fetch-one` before local persistence.
+- [x] 2.3 Keep `save-example!` as a final guard without relying on it as the primary error classifier.
+
+## 3. Verify
+
+- [x] 3.1 Add or update tests for invalid example payload handling.
+- [x] 3.2 Add or update tests for task retry behavior on invalid example payloads.
+- [x] 3.3 Run relevant automated checks and confirm the warning now points to the real failure cause.

--- a/openspec/specs/example-fetch-error-clarity/spec.md
+++ b/openspec/specs/example-fetch-error-clarity/spec.md
@@ -1,0 +1,21 @@
+# example-fetch-error-clarity Specification
+
+## Purpose
+TBD - created by archiving change handle-invalid-example-fetch-warnings. Update Purpose after archive.
+## Requirements
+### Requirement: Example fetch rejects malformed success payloads before local save
+The system SHALL reject malformed example payloads before attempting to save them as local example documents.
+
+#### Scenario: Backend success body misses required fields
+- **WHEN** `/api/examples` returns a success response that lacks required example fields
+- **THEN** the client rejects the payload before `save-example!`
+- **AND** the example-fetch task is treated as failed and retryable
+
+### Requirement: Example generation unavailability is surfaced explicitly
+The system SHALL return an explicit non-success response when backend example generation is unavailable.
+
+#### Scenario: Development backend has no API key
+- **WHEN** example generation is unavailable because required backend configuration is missing
+- **THEN** `/api/examples` returns a non-200 response with a clear error message
+- **AND** the resulting client/task warning points to the real availability problem rather than `missing required fields`
+

--- a/src/backend/core.clj
+++ b/src/backend/core.clj
@@ -239,18 +239,26 @@
        (fn [{:keys [session] :as _request}]
          (auth-proxy-response session))}]
 
-     ["/api/examples"
-      {:get
-       (fn [request]
-         (let [word (-> request :params :word)]
-           (if (utils/non-blank word)
-             (let [example (examples/generate-one! word)]
-               {:status 200
-                :headers {"Content-Type" "application/json"}
-                :body (cheshire/generate-string example)})
-             {:status 400
-              :headers {"Content-Type" "application/json"}
-              :body (cheshire/generate-string {:error "Missing 'word' parameter"})})))}]]
+    ["/api/examples"
+     {:get
+      (fn [request]
+        (let [word (-> request :params :word)]
+          (cond
+            (not (utils/non-blank word))
+            {:status 400
+             :headers {"Content-Type" "application/json"}
+             :body (cheshire/generate-string {:error "Missing 'word' parameter"})}
+
+            :else
+            (let [example (examples/generate-one! word)]
+              (if (examples/valid-example? example)
+                {:status 200
+                 :headers {"Content-Type" "application/json"}
+                 :body (cheshire/generate-string example)}
+                {:status 502
+                 :headers {"Content-Type" "application/json"}
+                 :body (cheshire/generate-string
+                        {:error "Examples are temporarily unavailable"})})))))}]]
 
     {:data {:interceptors [session-interceptor
                            (parameters/parameters-interceptor)

--- a/src/backend/examples.clj
+++ b/src/backend/examples.clj
@@ -1,12 +1,36 @@
 (ns examples
   (:require
    [cheshire.core :as cheshire]
-   [org.httpkit.client :as client]))
+   [clojure.string :as str]
+   [org.httpkit.client :as client]
+   [taoensso.telemere :as t]))
 
 
 (defn open-ai-service-account-api-key
   []
   (System/getenv "OPENAI_API_KEY"))
+
+
+(defn valid-example?
+  [example]
+  (and (map? example)
+       (not (str/blank? (some-> example (get "value"))))
+       (not (str/blank? (some-> example (get "translation"))))))
+
+
+(defn- valid-generated-examples?
+  [examples]
+  (and (map? examples)
+       (every? valid-example? (vals examples))))
+
+
+(defn- log-generation-failure!
+  [data]
+  (t/log!
+   {:level :warn
+    :id    ::generation-failed
+    :data  data}
+   "Examples generation failed"))
 
 
 (def system-prompt
@@ -101,8 +125,34 @@ Return only the JSON object without additional text.")
     * `:usedForm` — the form of the word used in the sentence."
   [words]
   (let [response @(gen-words-api-request words)]
-    ;; I am not converting keys of :message :content to keywords, as the upper level keys may contain spaces, e.g 'der Hund'.
-    (-> response :body (cheshire/parse-string true) :choices first :message :content cheshire/parse-string)))
+    (if (= 200 (:status response))
+      (try
+        ;; I am not converting keys of :message :content to keywords, as the upper level keys may contain spaces, e.g 'der Hund'.
+        (let [examples (-> response :body (cheshire/parse-string true) :choices first :message :content cheshire/parse-string)]
+          (if (valid-generated-examples? examples)
+            examples
+            (do
+              (log-generation-failure!
+               {:words words
+                :status (:status response)
+                :error "Invalid generated examples payload"
+                :examples examples
+                :body (:body response)})
+              nil)))
+        (catch Exception error
+          (log-generation-failure!
+           {:words words
+            :status (:status response)
+            :error (.getMessage error)
+            :body (:body response)})
+          nil))
+      (do
+        (log-generation-failure!
+         {:words words
+          :status (:status response)
+          :error (:error response)
+          :body (:body response)})
+        nil))))
 
 
 (defn generate-one!

--- a/src/client/examples.cljs
+++ b/src/client/examples.cljs
@@ -9,6 +9,10 @@
    [utils :as utils]))
 
 
+(def invalid-response-message
+  "Invalid example response from backend")
+
+
 (defn fetch-one
   "Fetches an example sentence for the given German word from the backend.
    Returns a promise that resolves to the example map.
@@ -17,10 +21,35 @@
   (let [url (str "/api/examples?word=" (js/encodeURIComponent word))]
     (p/let [response (js/fetch url)]
       (if (.-ok response)
-        (p/let [json (.json response)]
-          (js->clj json :keywordize-keys true))
-        (p/rejected (ex-info "Server error fetching example"
-                             {:word word :status (.-status response)}))))))
+        ;; Successful HTTP still needs validation: the body may be invalid JSON
+        ;; or a malformed example payload.
+        (p/let [json (-> (.json response)
+                         (p/catch (fn [_error] ::invalid-json)))]
+          (if (= ::invalid-json json)
+            (p/rejected
+             (ex-info invalid-response-message
+                      {:word word
+                       :status 502
+                       :error-kind :invalid-json}))
+            (let [example (js->clj json :keywordize-keys true)]
+              (if (and (:value example) (:translation example))
+                example
+                (p/rejected
+                 (ex-info invalid-response-message
+                          {:word word
+                           :status 502
+                           :error-kind :invalid-response
+                           :example example}))))))
+        ;; On non-OK responses, prefer the backend-provided error message when available.
+        (p/let [error-body (-> (.json response)
+                               (p/catch (constantly nil)))
+                error-body (some-> error-body (js->clj :keywordize-keys true))
+                status     (.-status response)
+                message    (or (:error error-body) "Server error fetching example")]
+          (p/rejected (ex-info message
+                               {:word word
+                                :status status
+                                :error-body error-body})))))))
 
 
 (defn save-example!

--- a/test/client/examples_test.cljs
+++ b/test/client/examples_test.cljs
@@ -62,14 +62,52 @@
 (deftest fetch-one-rejects-on-server-error
   (async-testing "`fetch-one` rejects on server error"
     (let [original-fetch js/fetch]
-      (set! js/fetch (fetch-mocks/mock-fetch-error 500))
+      (set! js/fetch
+            (fetch-mocks/mock-fetch-error-with-body
+             500
+             {:error "Examples are temporarily unavailable"}))
       (p/finally
         (p/catch
           (p/do
             (sut/fetch-one "Hund")
             (is false "Should have rejected"))
           (fn [error]
+            (is (= "Examples are temporarily unavailable" (ex-message error)))
             (is (= 500 (:status (ex-data error))))))
+        (fn []
+          (set! js/fetch original-fetch))))))
+
+
+(deftest fetch-one-rejects-on-invalid-example-payload
+  (async-testing "`fetch-one` rejects on invalid example payload"
+    (let [original-fetch js/fetch]
+      (set! js/fetch (fetch-mocks/mock-fetch-success {:value "Der Hund läuft"}))
+      (p/finally
+        (p/catch
+          (p/do
+            (sut/fetch-one "Hund")
+            (is false "Should have rejected"))
+          (fn [error]
+            (is (= sut/invalid-response-message (ex-message error)))
+            (is (= "Hund" (:word (ex-data error))))
+            (is (= :invalid-response (:error-kind (ex-data error))))))
+        (fn []
+          (set! js/fetch original-fetch))))))
+
+
+(deftest fetch-one-rejects-on-invalid-json-success-response
+  (async-testing "`fetch-one` rejects on invalid JSON in a success response"
+    (let [original-fetch js/fetch]
+      (set! js/fetch (fetch-mocks/mock-fetch-success-invalid-json))
+      (p/finally
+        (p/catch
+          (p/do
+            (sut/fetch-one "Hund")
+            (is false "Should have rejected"))
+          (fn [error]
+            (is (= sut/invalid-response-message (ex-message error)))
+            (is (= 502 (:status (ex-data error))))
+            (is (= :invalid-json (:error-kind (ex-data error))))))
         (fn []
           (set! js/fetch original-fetch))))))
 
@@ -227,5 +265,25 @@
                               :data      {:word-id "word-123"}}
                              dbs)]
                (is (false? result))))))
+        (fn []
+          (set! js/fetch original-fetch))))))
+
+
+(deftest task-handler-returns-false-on-invalid-example-payload
+  (async-testing "task handler returns false on invalid example payload"
+    (let [original-fetch js/fetch]
+      (set! js/fetch (fetch-mocks/mock-fetch-success {:translation "Собака бежит"}))
+      (p/finally
+        (with-test-dbs
+         (fn [dbs]
+           (p/do
+             (db/insert (:user/db dbs) {:_id "word-123" :type "vocab" :value "Hund"})
+             (p/let [result (tasks/execute-task
+                             {:task-type "example-fetch"
+                              :data      {:word-id "word-123"}}
+                             dbs)]
+               (is (false? result))
+               (p/let [examples (db-queries/fetch-examples (:device/db dbs))]
+                 (is (empty? examples)))))))
         (fn []
           (set! js/fetch original-fetch))))))

--- a/test/client/support/fetch_mocks.cljs
+++ b/test/client/support/fetch_mocks.cljs
@@ -12,11 +12,30 @@
           :json (fn [] (p/resolved (clj->js data)))})))
 
 
+(defn mock-fetch-success-invalid-json
+  "Returns a mock fetch that resolves with ok=true but rejects while parsing JSON."
+  []
+  (fn [_url]
+    (p/resolved
+     #js {:ok   true
+          :json (fn [] (p/rejected (js/Error. "Invalid JSON response")))})))
+
+
 (defn mock-fetch-error
   "Returns a mock fetch that resolves with error status."
   [status]
   (fn [_url]
     (p/resolved #js {:ok false :status status})))
+
+
+(defn mock-fetch-error-with-body
+  "Returns a mock fetch that resolves with error status and JSON body."
+  [status data]
+  (fn [_url]
+    (p/resolved
+     #js {:ok   false
+          :status status
+          :json (fn [] (p/resolved (clj->js data)))})))
 
 
 (defn mock-fetch-network-error


### PR DESCRIPTION
## Summary
- clarify backend and client handling for unavailable or malformed example generation
- keep client-facing errors neutral while preserving backend-side failure logging
- archive the completed OpenSpec change and sync the resulting main spec

## Verification
- clj -M:dev -e "(require 'examples 'core) (println :ok)"
- npx shadow-cljs compile node-test

Closes #114