### PR TITLE
GH-127 Lock lesson examples until word success

### DIFF
--- a/openspec/changes/lock-example-trials-until-word-success/.openspec.yaml
+++ b/openspec/changes/lock-example-trials-until-word-success/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-19

--- a/openspec/changes/lock-example-trials-until-word-success/proposal.md
+++ b/openspec/changes/lock-example-trials-until-word-success/proposal.md
@@ -1,0 +1,15 @@
+# Change: Lock example trials until successful word answers
+
+## Why
+Lesson examples can currently appear before the learner has correctly recalled the underlying word. That makes the lesson flow leak the target word too early and weakens recall practice.
+
+## What Changes
+- Store lesson trials with an explicit `locked?` flag.
+- Start lessons with word trials unlocked and example trials locked.
+- Unlock example trials only after a correct answer on the matching word trial.
+- Keep progress based on all generated trials, including locked examples that already exist in the lesson state.
+- Preserve random trial selection across the currently unlocked pool instead of forcing an example immediately after its word.
+
+## Impact
+- Affected specs: `specs/lesson/spec.md`, `specs/data-model/spec.md`
+- Affected code: `src/client/domain/lesson.cljs`, `src/client/lesson.cljs`, client lesson tests

--- a/openspec/changes/lock-example-trials-until-word-success/tasks.md
+++ b/openspec/changes/lock-example-trials-until-word-success/tasks.md
@@ -1,0 +1,16 @@
+## 1. Specs
+
+- [x] 1.1 Update lesson spec for locked example trials and unlock-on-success behavior.
+- [x] 1.2 Update data-model spec for lesson-trial `locked?` field.
+
+## 2. Implementation
+
+- [x] 2.1 Add `locked?` to generated lesson trials.
+- [x] 2.2 Unlock example trials after successful matching word answers.
+- [x] 2.3 Keep trial selection random across unlocked remaining trials only.
+- [x] 2.4 Preserve progress semantics across all generated trials.
+
+## 3. Verify
+
+- [x] 3.1 Run focused lesson domain/client tests.
+- [x] 3.2 Run app compile and fix regressions if any.

--- a/openspec/specs/data-model/spec.md
+++ b/openspec/specs/data-model/spec.md
@@ -81,7 +81,8 @@ Example:
       "type": "word",
       "word-id": "<vocab-id>",
       "prompt": "dog",
-      "answer": "der Hund"
+      "answer": "der Hund",
+      "locked?": false
     }
   ],
   "remaining-trials": [
@@ -89,25 +90,29 @@ Example:
       "type": "word",
       "word-id": "<vocab-id>",
       "prompt": "dog",
-      "answer": "der Hund"
+      "answer": "der Hund",
+      "locked?": false
     }
   ],
   "current-trial": {
     "type": "word",
     "word-id": "<vocab-id>",
     "prompt": "dog",
-    "answer": "der Hund"
+    "answer": "der Hund",
+    "locked?": false
   },
   "last-result": null
 }
 ```
 
-### Requirement: Lesson trials include prompt and answer
-The system SHALL store lesson trials with prompt and answer strings.
+### Requirement: Lesson trials include prompt, answer, and lock state
+The system SHALL store lesson trials with prompt and answer strings plus a lock flag used for lesson selection.
 
 #### Scenario: Lesson trial shape
 - **WHEN** a lesson trial is stored
-- **THEN** it includes `type`, `word-id`, `prompt`, and `answer`
+- **THEN** it includes `type`, `word-id`, `prompt`, `answer`, and `locked?`
+- **AND** word trials are stored with `locked?` false
+- **AND** example trials may be stored with `locked?` true until unlocked by lesson progress
 
 Example:
 ```json
@@ -115,7 +120,8 @@ Example:
   "type": "word",
   "word-id": "<vocab-id>",
   "prompt": "dog",
-  "answer": "der Hund"
+  "answer": "der Hund",
+  "locked?": false
 }
 ```
 
@@ -167,4 +173,3 @@ The system SHALL use the trial-selector from lesson options to determine trial s
 - **WHEN** selecting trials for a lesson
 - **THEN** the selection uses the `trial-selector` value from `options`
 - **AND** defaults to `"random"` if options or trial-selector is missing
-

--- a/openspec/specs/lesson/spec.md
+++ b/openspec/specs/lesson/spec.md
@@ -46,6 +46,7 @@ The system SHALL generate trials for each word and each example, using denormali
 #### Scenario: Trial generation
 - **WHEN** a lesson starts
 - **THEN** each word produces a word trial and each example produces an example trial
+- **AND** example trials start in a locked state until the matching word trial is answered correctly
 
 ### Requirement: Lesson state is denormalized
 The system SHALL store lesson state without a separate `:words` collection.
@@ -75,3 +76,16 @@ The system SHALL record review data for word-trial answers so retention-based pr
 - **WHEN** a user submits an answer for an example trial
 - **THEN** the system does not create a vocabulary review document for that answer
 
+### Requirement: Lesson trial unlocking controls example visibility
+The system SHALL keep example trials hidden from lesson selection until the matching word trial has been answered correctly.
+
+#### Scenario: Lesson start selectable pool
+- **WHEN** a lesson starts
+- **THEN** the selectable trial pool contains only unlocked word trials
+- **AND** locked example trials still count as lesson trials for progress tracking
+
+#### Scenario: Successful word answer unlocks examples
+- **WHEN** a user answers a word trial correctly
+- **THEN** example trials with the same `word-id` become unlocked
+- **AND** those unlocked example trials join the normal selectable pool
+- **AND** the next selected trial is still chosen by the lesson trial-selector rather than forced to that example

--- a/src/client/domain/lesson.cljs
+++ b/src/client/domain/lesson.cljs
@@ -42,7 +42,8 @@
                  (filter #(= "ru" (:lang %)))
                  (map :value)
                  (str/join ", "))
-   :answer  (:value word)})
+   :answer  (:value word)
+   :locked? false})
 
 
 (defn- example->trial
@@ -53,7 +54,8 @@
    :word-id        (:word-id example)
    :prompt         (:translation example)
    :answer         (:value example)
-   :gloss-mismatch (:gloss-mismatch example)})
+   :gloss-mismatch (:gloss-mismatch example)
+   :locked?        true})
 
 
 (defn generate-trials
@@ -69,6 +71,23 @@
   "Return a stable identifier for a trial (composite of type + word-id)."
   [trial]
   (str (:type trial) ":" (:word-id trial)))
+
+
+(defn- locked-trial?
+  [trial]
+  (true? (:locked? trial)))
+
+
+(defn- unlock-example-trial
+  [word-id trial]
+  (cond-> trial
+    (and (example-trial? trial) (-> trial :word-id (= word-id)))
+    (assoc :locked? false)))
+
+
+(defn- unlock-example-trials
+  [trials word-id]
+  (mapv #(unlock-example-trial word-id %) trials))
 
 
 (defn- select-trial
@@ -93,7 +112,7 @@
      :options       {:trial-selector trial-selector}
      :trials        trials
      :remaining-trials trials
-     :current-trial (select-trial trials trial-selector)
+     :current-trial (select-trial (remove locked-trial? trials) trial-selector)
      :last-result   nil}))
 
 
@@ -127,9 +146,16 @@
                           (normalized-answer correct-answer))
         remaining      (cond-> (:remaining-trials state)
                          correct? (remove-trial current-trial))
+        remaining      (if (and correct? (word-trial? current-trial))
+                         (unlock-example-trials remaining (:word-id current-trial))
+                         remaining)
+        trials         (if (and correct? (word-trial? current-trial))
+                         (unlock-example-trials (:trials state) (:word-id current-trial))
+                         (:trials state))
         last-result    {:correct? correct?
                         :answer   answer}]
     (-> state
+        (assoc :trials trials)
         (assoc :remaining-trials remaining)
         (assoc :last-result last-result))))
 
@@ -138,9 +164,10 @@
   "Returns trials available for next selection.
    Excludes current trial to avoid immediate repetition (unless only one remains)."
   [remaining-trials current-trial]
-  (if (> (count remaining-trials) 1)
-    (remove-trial remaining-trials current-trial)
-    remaining-trials))
+  (let [unlocked-trials (filterv (complement locked-trial?) remaining-trials)]
+    (if (> (count unlocked-trials) 1)
+      (remove-trial unlocked-trials current-trial)
+      unlocked-trials)))
 
 
 (defn advance

--- a/test/client/domain/lesson_test.cljs
+++ b/test/client/domain/lesson_test.cljs
@@ -110,6 +110,18 @@
       (is (= (first (:trials state)) (:current-trial state))))))
 
 
+(deftest initial-state-keeps-example-trials-locked
+  (testing "example trials are present but locked at lesson start"
+    (let [state          (sut/initial-state
+                          fixtures/lesson-words
+                          fixtures/lesson-examples
+                          :first
+                          "2024-08-20T10:00:00.000Z")
+          example-trials (filter sut/example-trial? (:remaining-trials state))]
+      (is (= 1 (count example-trials)))
+      (is (every? :locked? example-trials)))))
+
+
 ;; =============================================================================
 ;; expected-answer
 ;; =============================================================================
@@ -162,6 +174,19 @@
       (is (= 1 (count (:remaining-trials state)))))))
 
 
+(deftest check-answer-correct-word-unlocks-examples
+  (testing "correct word answer unlocks example trials for that word"
+    (let [state         (sut/initial-state
+                         fixtures/lesson-words
+                         fixtures/lesson-examples
+                         :first
+                         "2024-08-20T10:00:00.000Z")
+          updated-state (sut/check-answer state "der Hund")
+          example-trial (first (filter sut/example-trial? (:remaining-trials updated-state)))]
+      (is (some? example-trial))
+      (is (false? (:locked? example-trial))))))
+
+
 (deftest check-answer-correct-case-insensitive
   (testing "answer comparison ignores case"
     (let [state (sut/initial-state
@@ -188,6 +213,19 @@
           state (sut/check-answer state "wrong answer")]
       (is (false? (:correct? (sut/last-result state))))
       (is (= 2 (count (:remaining-trials state)))))))
+
+
+(deftest check-answer-wrong-word-keeps-examples-locked
+  (testing "wrong word answer does not unlock example trials"
+    (let [state         (sut/initial-state
+                         fixtures/lesson-words
+                         fixtures/lesson-examples
+                         :first
+                         "2024-08-20T10:00:00.000Z")
+          updated-state (sut/check-answer state "wrong answer")
+          example-trial (first (filter sut/example-trial? (:remaining-trials updated-state)))]
+      (is (some? example-trial))
+      (is (true? (:locked? example-trial))))))
 
 
 ;; =============================================================================
@@ -275,6 +313,31 @@
           next-state (sut/advance state)]
       (is (some? (sut/last-result state)))
       (is (nil? (sut/last-result next-state))))))
+
+
+(deftest advance-skips-locked-example-trials
+  (testing "advance selects only unlocked trials"
+    (let [state      (sut/initial-state
+                      fixtures/lesson-words
+                      fixtures/lesson-examples
+                      :first
+                      "2024-08-20T10:00:00.000Z")
+          next-state (sut/advance state)]
+      (is (sut/word-trial? (:current-trial next-state)))
+      (is (not (:locked? (:current-trial next-state)))))))
+
+
+(deftest advance-keeps-random-pool-after-unlock
+  (testing "unlocked examples join normal selectable pool instead of forcing next trial"
+    (let [state      (sut/initial-state
+                      fixtures/lesson-words
+                      fixtures/lesson-examples
+                      :first
+                      "2024-08-20T10:00:00.000Z")
+          state      (sut/check-answer state "der Hund")
+          next-state (sut/advance state)]
+      (is (= "word-2" (:word-id (:current-trial next-state))))
+      (is (sut/word-trial? (:current-trial next-state))))))
 
 
 (deftest advance-returns-nil-when-no-remaining

--- a/test/client/lesson_test.cljs
+++ b/test/client/lesson_test.cljs
@@ -103,7 +103,12 @@
                  trials (:trials lesson)]
              (is (= 2 (count trials)))
              (is (= 1 (count (filter #(= "word" (:type %)) trials))))
-             (is (= 1 (count (filter #(= "example" (:type %)) trials)))))))))))
+             (is (= 1 (count (filter #(= "example" (:type %)) trials))))
+             (is (= [true]
+                    (->> trials
+                         (filter #(= "example" (:type %)))
+                         (map :locked?)
+                         vec))))))))))
 
 
 ;; =============================================================================
@@ -225,6 +230,27 @@
                  final-reviews   (db-queries/fetch-by-type (:user/db dbs) "review")]
            ;; No new review should be created for example trials
            (is (= (count initial-reviews) (count final-reviews)))))))))
+
+
+(deftest check-answer-correct-word-unlocks-example-trial
+  (async-testing "`check-answer!` unlocks examples after successful word answer"
+    (with-test-dbs
+     (fn [dbs]
+       (p/do
+         (db-seed/seed-vocabulary! (:user/db dbs) [{:_id "word-1" :value "der Hund" :translation "пёс"}])
+         (db-seed/seed-examples! (:device/db dbs)
+                                 [{:_id         "example-1"
+                                   :word-id     "word-1"
+                                   :word        "der Hund"
+                                   :value       "Der Hund schlaeft."
+                                   :translation "Пёс спит."}])
+         (p/let [_      (sut/start! dbs {:trial-selector :first})
+                 result (sut/check-answer! dbs "der Hund")
+                 trial  (->> (:remaining-trials (:lesson-state result))
+                             (filter domain/example-trial?)
+                             first)]
+           (is (some? trial))
+           (is (false? (:locked? trial)))))))))
 
 
 (deftest check-answer-returns-error-when-no-lesson

--- a/test/client/presenter/lesson_test.cljs
+++ b/test/client/presenter/lesson_test.cljs
@@ -17,16 +17,23 @@
 
 (deftest footer-props-includes-user-answer-for-example-trial
   (testing "wrong example answer includes both user and correct sentences"
-    (let [state (domain/initial-state
-                 []
-                 [{:_id         "example-1"
-                   :word-id     "word-1"
-                   :word        "der Hund"
-                   :value       "Der Hund schlaeft."
-                   :translation "Пёс спит"}]
-                 :first
-                 "2024-08-20T10:00:00.000Z")
-          state (domain/check-answer state "Mein Hund schlaeft")
+    (let [state {:trials            [{:type    "example"
+                                      :word-id "word-1"
+                                      :prompt  "Пёс спит"
+                                      :answer  "Der Hund schlaeft."
+                                      :locked? false}]
+                 :remaining-trials  [{:type    "example"
+                                      :word-id "word-1"
+                                      :prompt  "Пёс спит"
+                                      :answer  "Der Hund schlaeft."
+                                      :locked? false}]
+                 :current-trial     {:type    "example"
+                                     :word-id "word-1"
+                                     :prompt  "Пёс спит"
+                                     :answer  "Der Hund schlaeft."
+                                     :locked? false}
+                 :last-result       {:correct? false
+                                     :answer   "Mein Hund schlaeft"}}
           props (sut/footer-props state)]
       (is (= :error (:variant props)))
       (is (= "Mein Hund schlaeft" (:user-answer props)))

--- a/test/client/support/fixtures.cljs
+++ b/test/client/support/fixtures.cljs
@@ -70,11 +70,13 @@
   [{:type    "word"
     :word-id "word-1"
     :prompt  "пёс"
-    :answer  "der Hund"}
+    :answer  "der Hund"
+    :locked? false}
    {:type    "word"
     :word-id "word-2"
     :prompt  "кошка"
-    :answer  "die Katze"}])
+    :answer  "die Katze"
+    :locked? false}])
 
 
 (def expected-example-trials
@@ -83,7 +85,8 @@
     :word-id "word-1"
     :prompt  "Пёс спит"
     :answer  "Der Hund schlaeft."
-    :gloss-mismatch nil}])
+    :gloss-mismatch nil
+    :locked? true}])
 
 
 (def all-expected-trials


### PR DESCRIPTION
## Summary
- add locked lesson trials so examples stay unavailable until the matching word is answered correctly
- keep lesson progress based on all generated trials while selecting only from unlocked remaining trials
- update lesson/data-model specs and add regression tests for the unlock flow

Closes #127

## Verification
- npx shadow-cljs compile node-test
- npx shadow-cljs compile app