### PR TITLE
GH-133 Add lesson example token annotations

### DIFF
--- a/openspec/changes/annotate-lesson-example-answers/.openspec.yaml
+++ b/openspec/changes/annotate-lesson-example-answers/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-20

--- a/openspec/changes/annotate-lesson-example-answers/proposal.md
+++ b/openspec/changes/annotate-lesson-example-answers/proposal.md
@@ -1,0 +1,16 @@
+## Why
+
+Lesson examples already carry structure data from example generation, but the lesson UI drops that structure before showing the correct answer. That blocks inline annotation of the answer text and prevents later hover/tap actions for translation lookup and add-to-vocabulary.
+
+## What Changes
+
+- Keep example `structure` in lesson example trials.
+- Build deterministic answer annotation segments from `answer` plus `structure.wordIndex`.
+- Render the correct example answer as segmented tokens in the lesson footer instead of plain text.
+- Keep the first slice read-only: no add-to-vocabulary action yet, only structured rendering needed for later UI work.
+
+## Impact
+
+- Affected specs: `specs/lesson/spec.md`, `specs/data-model/spec.md`
+- Affected code: lesson domain/presenter/view code and lesson tests
+- Validation: client lesson tests plus presenter/domain checks for segment generation

--- a/openspec/changes/annotate-lesson-example-answers/tasks.md
+++ b/openspec/changes/annotate-lesson-example-answers/tasks.md
@@ -1,0 +1,14 @@
+## 1. Specs
+
+- [x] 1.1 Describe lesson answer annotation segments and structure-carrying example trials.
+
+## 2. Implementation
+
+- [x] 2.1 Keep `structure` on lesson example trials.
+- [x] 2.2 Build deterministic answer segments from `answer` and `wordIndex`.
+- [x] 2.3 Render segmented correct answers in lesson footer for example trials.
+- [x] 2.4 Add token info card and lesson-side add-to-vocabulary action for annotated answer words.
+
+## 3. Verify
+
+- [x] 3.1 Run focused lesson domain/presenter/client tests.

--- a/openspec/specs/data-model/spec.md
+++ b/openspec/specs/data-model/spec.md
@@ -53,7 +53,7 @@ Example:
   "value": "Der Hund schlaeft unter dem Tisch.",
   "translation": "The dog sleeps under the table.",
   "structure": [
-    {"usedForm": "Hund", "dictionaryForm": "der Hund", "translation": "dog"}
+    {"usedForm": "Hund", "dictionaryForm": "der Hund", "translation": "dog", "wordIndex": 1}
   ],
   "created-at": "2026-01-20T10:02:00.000Z"
 }

--- a/openspec/specs/lesson/spec.md
+++ b/openspec/specs/lesson/spec.md
@@ -89,3 +89,15 @@ The system SHALL keep example trials hidden from lesson selection until the matc
 - **THEN** example trials with the same `word-id` become unlocked
 - **AND** those unlocked example trials join the normal selectable pool
 - **AND** the next selected trial is still chosen by the lesson trial-selector rather than forced to that example
+
+### Requirement: Example answer rendering keeps structure annotations
+The system SHALL keep example structure data on lesson example trials so the correct answer can be rendered with deterministic word annotations.
+
+#### Scenario: Example trial stores answer structure
+- **WHEN** an example trial is generated for a lesson
+- **THEN** it keeps the example `structure` items alongside the denormalized prompt and answer
+
+#### Scenario: Correct example answer is segmented by structure
+- **WHEN** lesson UI renders the correct answer for an example trial
+- **THEN** it builds answer segments from the German answer text plus each structure item `wordIndex`
+- **AND** annotated segments keep the matching `dictionaryForm` and `translation`

--- a/resources/public/css/blocks/lesson.css
+++ b/resources/public/css/blocks/lesson.css
@@ -205,6 +205,42 @@
 .lesson__answer-body {
   font-size: 15px;
   font-weight: 500;
+  line-height: 1.75;
+  margin: 0;
+  overflow: visible;
+}
+
+.lesson__answer-token {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  cursor: pointer;
+  display: inline;
+  font: inherit;
+  line-height: inherit;
+  margin: 0;
+  padding: 0 1px;
+  text-decoration-color: currentcolor;
+  text-decoration-line: underline;
+  text-decoration-style: dotted;
+  text-decoration-thickness: 2px;
+  text-underline-offset: 4px;
+}
+
+.lesson__answer-token:hover,
+.lesson__answer-token:focus-visible {
+  background: color-mix(in srgb, currentColor 12%, transparent);
+  border-radius: 6px;
+  outline: none;
+  text-decoration-style: solid;
+}
+
+.lesson__answer-token[aria-expanded="true"] {
+  background: color-mix(in srgb, currentColor 14%, transparent);
+  border-radius: 6px;
+  box-shadow: inset 0 -2px 0 currentColor;
+  text-decoration-color: transparent;
 }
 
 .lesson__footer--success {

--- a/resources/public/css/blocks/popover.css
+++ b/resources/public/css/blocks/popover.css
@@ -1,0 +1,44 @@
+/*
+ * Generic popover shell. Singleton element mounted once in app-shell;
+ * callers render arbitrary content into #popover-content.
+ *
+ * Uses HTML popover API — browser handles light-dismiss (click outside, Esc)
+ * and top-layer rendering (escapes ancestor overflow:hidden).
+ * Positioning is JS-driven (resources/public/js/popover.js).
+ */
+
+.popover {
+  background: transparent;
+  border: 0;
+  inset: auto;
+  margin: 0;
+  max-width: min(280px, calc(100vw - 16px));
+  overflow: visible;
+  padding: 0;
+  position: fixed;
+  width: max-content;
+}
+
+.popover::backdrop {
+  background: transparent;
+}
+
+.popover__arrow {
+  background: rgb(var(--color-snow));
+  border-right: 1px solid rgb(var(--color-swan));
+  border-bottom: 1px solid rgb(var(--color-swan));
+  height: 10px;
+  pointer-events: none;
+  position: absolute;
+  width: 10px;
+}
+
+.popover[data-side="top"] .popover__arrow {
+  bottom: -6px;
+  transform: translateX(-5px) rotate(45deg);
+}
+
+.popover[data-side="bottom"] .popover__arrow {
+  top: -6px;
+  transform: translateX(-5px) rotate(225deg);
+}

--- a/resources/public/css/blocks/token-card.css
+++ b/resources/public/css/blocks/token-card.css
@@ -1,0 +1,68 @@
+/*
+ * Token card: dictionary-form entry rendered into the popover shell
+ * when a user taps an annotated word in a lesson answer.
+ */
+
+.token-card {
+  background: rgb(var(--color-snow));
+  border: 1px solid rgb(var(--color-swan));
+  border-radius: 14px;
+  box-shadow: 0 2px 0 rgba(var(--color-swan), 0.8), 0 10px 20px rgba(0, 0, 0, 0.12);
+  color: rgb(var(--color-eel));
+  display: grid;
+  gap: 4px;
+  padding: 12px 14px;
+  text-align: left;
+}
+
+.token-card__word {
+  color: rgb(var(--color-eel));
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  line-height: 1.2;
+  margin: 0;
+}
+
+.token-card__translation {
+  color: rgb(var(--color-wolf));
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.3;
+  margin: 0 0 6px;
+}
+
+.token-card__state {
+  color: rgb(var(--color-owl));
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  margin: 2px 0 0;
+  text-transform: uppercase;
+}
+
+.token-card__form {
+  margin: 2px 0 0;
+}
+
+.token-card__button {
+  background: rgb(var(--color-macaw));
+  border: 0;
+  border-bottom: 3px solid rgb(var(--color-whale));
+  border-radius: 10px;
+  color: rgb(var(--color-snow));
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  min-height: 36px;
+  padding: 0 12px;
+  text-transform: uppercase;
+  width: 100%;
+}
+
+.token-card__button:active {
+  border-bottom-width: 0;
+  transform: translateY(2px);
+}

--- a/resources/public/css/styles.css
+++ b/resources/public/css/styles.css
@@ -16,6 +16,8 @@
 @import url("./blocks/word-list.css") layer(blocks);
 @import url("./blocks/word-item.css") layer(blocks);
 @import url("./blocks/modal.css") layer(blocks);
+@import url("./blocks/popover.css") layer(blocks);
+@import url("./blocks/token-card.css") layer(blocks);
 @import url("./blocks/word-edit-dialog.css") layer(blocks);
 @import url("./blocks/vocabulary.css") layer(blocks);
 @import url("./blocks/pwa-install.css") layer(blocks);

--- a/resources/public/js/popover.js
+++ b/resources/public/js/popover.js
@@ -1,0 +1,122 @@
+/*
+ * Generic popover shell. Uses HTML popover API; browser gives us light-dismiss
+ * (click outside, Escape) and top-layer rendering.
+ *
+ * Expects in the DOM: #popover (popover="auto") containing #popover-content
+ * and #popover-arrow. Content is rendered in by the caller.
+ *
+ * API:
+ *   openPopover(anchor)     open at anchor rect; sets aria-expanded on anchor
+ *   repositionPopover()     recompute position after content swap
+ *
+ * Auto-close:
+ *   - On open, arm timer (IDLE_OPEN_MS, or data-dismiss on content root if set).
+ *   - Pointer/focus inside popover cancels the timer.
+ *   - Pointer leave or focus out arms a short timer (IDLE_LEAVE_MS).
+ *   - On touch devices (hover:none) no idle timer arms; data-dismiss still does.
+ */
+
+(function () {
+  var POPOVER_ID = "popover";
+  var CONTENT_ID = "popover-content";
+  var ARROW_ID = "popover-arrow";
+  var PAD = 8;
+  var OFFSET = 10;
+  var IDLE_OPEN_MS = 3000;
+  var IDLE_LEAVE_MS = 600;
+
+  var currentAnchor = null;
+  var autoTimer = null;
+
+  function el(id) { return document.getElementById(id); }
+
+  function position() {
+    var pop = el(POPOVER_ID);
+    var arrow = el(ARROW_ID);
+    if (!pop || !currentAnchor || !pop.matches(":popover-open")) return;
+    var a = currentAnchor.getBoundingClientRect();
+    var pw = pop.offsetWidth;
+    var ph = pop.offsetHeight;
+
+    var centerX = a.left + a.width / 2;
+    var left = Math.max(PAD, Math.min(window.innerWidth - pw - PAD, centerX - pw / 2));
+    var above = a.top - ph - OFFSET;
+    var flip = above < PAD && a.bottom + ph + OFFSET + PAD <= window.innerHeight;
+    var top = flip ? a.bottom + OFFSET : above;
+
+    pop.style.left = left + "px";
+    pop.style.top = top + "px";
+    pop.dataset.side = flip ? "bottom" : "top";
+    arrow.style.left = Math.max(12, Math.min(pw - 12, centerX - left)) + "px";
+  }
+
+  function isActive() {
+    var pop = el(POPOVER_ID);
+    return !!pop && (pop.matches(":hover") || pop.contains(document.activeElement));
+  }
+
+  function clearAutoTimer() {
+    if (autoTimer) { clearTimeout(autoTimer); autoTimer = null; }
+  }
+
+  function scheduleAutoClose(ms) {
+    clearAutoTimer();
+    if (!ms) return;
+    var pop = el(POPOVER_ID);
+    if (!pop) return;
+    autoTimer = setTimeout(function () {
+      if (pop.matches(":popover-open") && !isActive()) pop.hidePopover();
+    }, ms);
+  }
+
+  function initialCloseMs() {
+    var first = el(CONTENT_ID) && el(CONTENT_ID).firstElementChild;
+    var forced = first && parseInt(first.getAttribute("data-dismiss") || "0", 10);
+    if (forced > 0) return forced;
+    var hoverCapable = window.matchMedia && window.matchMedia("(hover: hover)").matches;
+    return hoverCapable ? IDLE_OPEN_MS : 0;
+  }
+
+  window.openPopover = function (anchor) {
+    var pop = el(POPOVER_ID);
+    if (!pop) return;
+    if (currentAnchor) currentAnchor.setAttribute("aria-expanded", "false");
+    currentAnchor = anchor;
+    if (anchor) anchor.setAttribute("aria-expanded", "true");
+    if (!pop.matches(":popover-open")) pop.showPopover();
+    requestAnimationFrame(function () {
+      position();
+      scheduleAutoClose(isActive() ? 0 : initialCloseMs());
+    });
+  };
+
+  window.repositionPopover = function () {
+    requestAnimationFrame(function () {
+      position();
+      scheduleAutoClose(isActive() ? 0 : initialCloseMs());
+    });
+  };
+
+  // Always-on; position() bails when popover is closed, so this is a cheap no-op.
+  window.addEventListener("resize", position, { passive: true });
+  window.addEventListener("scroll", position, { passive: true, capture: true });
+
+  document.addEventListener("DOMContentLoaded", function () {
+    var pop = el(POPOVER_ID);
+    if (!pop) return;
+    pop.addEventListener("toggle", function (e) {
+      if (e.newState !== "closed") return;
+      clearAutoTimer();
+      if (currentAnchor) currentAnchor.setAttribute("aria-expanded", "false");
+      currentAnchor = null;
+      var content = el(CONTENT_ID);
+      if (content) content.innerHTML = "";
+    });
+    pop.addEventListener("pointerenter", clearAutoTimer);
+    pop.addEventListener("pointerleave", function () { scheduleAutoClose(IDLE_LEAVE_MS); });
+    pop.addEventListener("focusin", clearAutoTimer);
+    pop.addEventListener("focusout", function () {
+      setTimeout(function () { if (!isActive()) scheduleAutoClose(IDLE_LEAVE_MS); }, 0);
+    });
+  });
+})();

--- a/src/backend/examples.clj
+++ b/src/backend/examples.clj
@@ -90,9 +90,6 @@
    [:translation
     {:description "Russian translation of the sentence."}
     [:string {:min 1}]]
-   [:glossMismatch
-    {:description "Whether the supplied Russian gloss appears mismatched to the German word."}
-    :boolean]
    [:structure
     {:description "A list of JSON objects containing the used word form, its dictionary form, and its translation, ordered left to right as they appear in the German sentence."}
     [:vector {:min 1}
@@ -215,8 +212,7 @@
   {:malformed-example            "The generated example did not match the required JSON shape or text constraints. See `details` for the specific field errors."
    :structure-mismatch           "Items in `structure` must appear in strict left-to-right order as they occur in the German sentence, each `usedForm` must match the word at its position, and a `{usedForm, dictionaryForm}` pair must not repeat (each separable-verb prefix appears once, not twice)."
    :sentence-length-out-of-range "The German sentence must contain between 3 and 12 words."
-   :target-lemma-missing         "The target lemma must appear as a `dictionaryForm` entry in `structure`."
-   :target-gloss-mismatch        "The target lemma's structure `translation` contradicts the supplied Russian gloss."})
+   :target-lemma-missing         "The target lemma must appear as a `dictionaryForm` entry in `structure`."})
 
 
 (defn- example-issue
@@ -240,10 +236,7 @@
       {:issue :sentence-length-out-of-range}
 
       (not (dictionary/lemma-in-structure? word (:structure indexed)))
-      {:issue :target-lemma-missing}
-
-      (not (dictionary/word-gloss-valid? word translations (:structure indexed)))
-      {:issue :target-gloss-mismatch})))
+      {:issue :target-lemma-missing})))
 
 
 
@@ -270,7 +263,6 @@
     "- Produce one natural standard German sentence, 6-12 words, using the target lemma or a correct inflected form."
     "- German sentence only: no labels, notes, markdown, or meta commentary."
     "- `translation` must be one natural Russian sentence, not a calque."
-    "- Set `glossMismatch` to true only if the supplied gloss clearly mismatches the target lemma; otherwise false."
     "- `structure` must include every noun, verb (including auxiliaries and modals), adjective, and adverb in the sentence."
     "- Each item in `structure` must be a JSON object with keys `usedForm`, `dictionaryForm`, and `translation`."
     "- Never use arrays like `[\"Fenster\", \"das Fenster\", \"окно\"]` inside `structure`."
@@ -287,19 +279,19 @@
     "- Ambiguous noun articles and ambiguous prefixes (`um-`, `über-`, `unter-`, `durch-`, `wieder-`) must follow the supplied Russian gloss."
     "- Example structure item: `{\"usedForm\":\"Fenster\",\"dictionaryForm\":\"das Fenster\",\"translation\":\"окно\"}`."
     "Example word=aufstehen gloss=вставать:"
-    "{\"value\":\"Ich stehe jeden Morgen um sieben Uhr auf.\",\"translation\":\"Я встаю каждое утро в семь часов.\",\"glossMismatch\":false,\"structure\":[{\"usedForm\":\"stehe\",\"dictionaryForm\":\"aufstehen\",\"translation\":\"вставать\"},{\"usedForm\":\"Morgen\",\"dictionaryForm\":\"der Morgen\",\"translation\":\"утро\"},{\"usedForm\":\"auf\",\"dictionaryForm\":\"aufstehen\",\"translation\":\"вставать\"}]}"
+    "{\"value\":\"Ich stehe jeden Morgen um sieben Uhr auf.\",\"translation\":\"Я встаю каждое утро в семь часов.\",\"structure\":[{\"usedForm\":\"stehe\",\"dictionaryForm\":\"aufstehen\",\"translation\":\"вставать\"},{\"usedForm\":\"Morgen\",\"dictionaryForm\":\"der Morgen\",\"translation\":\"утро\"},{\"usedForm\":\"auf\",\"dictionaryForm\":\"aufstehen\",\"translation\":\"вставать\"}]}"
     "Example word=aufpassen gloss=следить:"
-    "{\"value\":\"Er passt auf die Kinder auf.\",\"translation\":\"Он следит за детьми.\",\"glossMismatch\":false,\"structure\":[{\"usedForm\":\"passt\",\"dictionaryForm\":\"aufpassen\",\"translation\":\"следить\"},{\"usedForm\":\"Kinder\",\"dictionaryForm\":\"das Kind\",\"translation\":\"дети\"},{\"usedForm\":\"auf\",\"dictionaryForm\":\"aufpassen\",\"translation\":\"следить\"}]}"
+    "{\"value\":\"Er passt auf die Kinder auf.\",\"translation\":\"Он следит за детьми.\",\"structure\":[{\"usedForm\":\"passt\",\"dictionaryForm\":\"aufpassen\",\"translation\":\"следить\"},{\"usedForm\":\"Kinder\",\"dictionaryForm\":\"das Kind\",\"translation\":\"дети\"},{\"usedForm\":\"auf\",\"dictionaryForm\":\"aufpassen\",\"translation\":\"следить\"}]}"
     "Note: the first `auf` is a preposition and is excluded; only the sentence-final `auf` is the detached separable prefix."
     "Example word=das Verstehen gloss=понимание:"
-    "{\"value\":\"Das Verstehen dieser Regel dauert lange.\",\"translation\":\"Понимание этого правила требует времени.\",\"glossMismatch\":false,\"structure\":[{\"usedForm\":\"Verstehen\",\"dictionaryForm\":\"das Verstehen\",\"translation\":\"понимание\"},{\"usedForm\":\"Regel\",\"dictionaryForm\":\"die Regel\",\"translation\":\"правило\"},{\"usedForm\":\"dauert\",\"dictionaryForm\":\"dauern\",\"translation\":\"длиться\"},{\"usedForm\":\"lange\",\"dictionaryForm\":\"lang\",\"translation\":\"долго\"}]}"
+    "{\"value\":\"Das Verstehen dieser Regel dauert lange.\",\"translation\":\"Понимание этого правила требует времени.\",\"structure\":[{\"usedForm\":\"Verstehen\",\"dictionaryForm\":\"das Verstehen\",\"translation\":\"понимание\"},{\"usedForm\":\"Regel\",\"dictionaryForm\":\"die Regel\",\"translation\":\"правило\"},{\"usedForm\":\"dauert\",\"dictionaryForm\":\"dauern\",\"translation\":\"длиться\"},{\"usedForm\":\"lange\",\"dictionaryForm\":\"lang\",\"translation\":\"долго\"}]}"
     "Example word=die Bank gloss=скамейка:"
-    "{\"value\":\"Wir sitzen auf einer Bank im Park.\",\"translation\":\"Мы сидим на скамейке в парке.\",\"glossMismatch\":false,\"structure\":[{\"usedForm\":\"sitzen\",\"dictionaryForm\":\"sitzen\",\"translation\":\"сидеть\"},{\"usedForm\":\"Bank\",\"dictionaryForm\":\"die Bank\",\"translation\":\"скамейка\"},{\"usedForm\":\"Park\",\"dictionaryForm\":\"der Park\",\"translation\":\"парк\"}]}"
+    "{\"value\":\"Wir sitzen auf einer Bank im Park.\",\"translation\":\"Мы сидим на скамейке в парке.\",\"structure\":[{\"usedForm\":\"sitzen\",\"dictionaryForm\":\"sitzen\",\"translation\":\"сидеть\"},{\"usedForm\":\"Bank\",\"dictionaryForm\":\"die Bank\",\"translation\":\"скамейка\"},{\"usedForm\":\"Park\",\"dictionaryForm\":\"der Park\",\"translation\":\"парк\"}]}"
     "Example word=Leiter gloss=лестница:"
-    "{\"value\":\"Die Leiter steht neben der Wand.\",\"translation\":\"Лестница стоит у стены.\",\"glossMismatch\":false,\"structure\":[{\"usedForm\":\"Leiter\",\"dictionaryForm\":\"die Leiter\",\"translation\":\"лестница\"},{\"usedForm\":\"steht\",\"dictionaryForm\":\"stehen\",\"translation\":\"стоять\"},{\"usedForm\":\"Wand\",\"dictionaryForm\":\"die Wand\",\"translation\":\"стена\"}]}"
+    "{\"value\":\"Die Leiter steht neben der Wand.\",\"translation\":\"Лестница стоит у стены.\",\"structure\":[{\"usedForm\":\"Leiter\",\"dictionaryForm\":\"die Leiter\",\"translation\":\"лестница\"},{\"usedForm\":\"steht\",\"dictionaryForm\":\"stehen\",\"translation\":\"стоять\"},{\"usedForm\":\"Wand\",\"dictionaryForm\":\"die Wand\",\"translation\":\"стена\"}]}"
     "Do not use `der Leiter` for this meaning."
     "Example word=sich vorstellen gloss=представляться:"
-    "{\"value\":\"Er stellt sich bei den neuen Kollegen vor.\",\"translation\":\"Он представляется новым коллегам.\",\"glossMismatch\":false,\"structure\":[{\"usedForm\":\"stellt\",\"dictionaryForm\":\"sich vorstellen\",\"translation\":\"представляться\"},{\"usedForm\":\"neu\",\"dictionaryForm\":\"neu\",\"translation\":\"новый\"},{\"usedForm\":\"Kollegen\",\"dictionaryForm\":\"der Kollege\",\"translation\":\"коллега\"},{\"usedForm\":\"vor\",\"dictionaryForm\":\"sich vorstellen\",\"translation\":\"представляться\"}]}"]))
+    "{\"value\":\"Er stellt sich bei den neuen Kollegen vor.\",\"translation\":\"Он представляется новым коллегам.\",\"structure\":[{\"usedForm\":\"stellt\",\"dictionaryForm\":\"sich vorstellen\",\"translation\":\"представляться\"},{\"usedForm\":\"neu\",\"dictionaryForm\":\"neu\",\"translation\":\"новый\"},{\"usedForm\":\"Kollegen\",\"dictionaryForm\":\"der Kollege\",\"translation\":\"коллега\"},{\"usedForm\":\"vor\",\"dictionaryForm\":\"sich vorstellen\",\"translation\":\"представляться\"}]}"]))
 
 
 
@@ -394,8 +386,8 @@
   `translation` may be a single string or a collection of strings; all are
   passed through to the prompt and validation so any can be the chosen sense.
   Returns one of:
-  * success — map with keys :value, :translation, :glossMismatch,
-    :structure (a vector of maps with :usedForm, :dictionaryForm, :translation);
+  * success — map with keys :value, :translation, :structure
+    (a vector of maps with :usedForm, :dictionaryForm, :translation);
   * generation-failure map on a hard error (e.g. 429);
   * nil when all attempts are exhausted."
   ([input]
@@ -411,11 +403,6 @@
          (cond
            (and failure? (not (:retryable? example)))
            example
-
-           (and (not failure?) (= :target-gloss-mismatch issue))
-           (-> example
-               add-word-indexes
-               (assoc :glossMismatch true))
 
            (and (not failure?) (nil? issue))
            (add-word-indexes example)

--- a/src/backend/examples.clj
+++ b/src/backend/examples.clj
@@ -199,6 +199,18 @@
    "Examples generation failed"))
 
 
+(defn- normalize-translations
+  "Accepts a string, a collection of strings, or nil. Returns a vector of
+   non-blank strings, preserving order and deduping."
+  [translation]
+  (let [raw (cond
+              (nil? translation)         []
+              (string? translation)      [translation]
+              (sequential? translation)  translation
+              :else                      [])]
+    (->> raw (remove str/blank?) distinct vec)))
+
+
 (def ^:private issue-messages
   {:malformed-example            "The generated example did not match the required JSON shape or text constraints. See `details` for the specific field errors."
    :structure-mismatch           "Items in `structure` must appear in strict left-to-right order as they occur in the German sentence, each `usedForm` must match the word at its position, and a `{usedForm, dictionaryForm}` pair must not repeat (each separable-verb prefix appears once, not twice)."
@@ -208,7 +220,7 @@
 
 
 (defn- example-issue
-  [word translation example]
+  [word translations example]
   (let [raw     (strip-word-indexes example)
         valid?  (m/validate valid-generated-example-schema raw)
         indexed (when valid? (add-word-indexes raw))]
@@ -230,7 +242,7 @@
       (not (dictionary/lemma-in-structure? word (:structure indexed)))
       {:issue :target-lemma-missing}
 
-      (not (dictionary/word-gloss-valid? word translation (:structure indexed)))
+      (not (dictionary/word-gloss-valid? word translations (:structure indexed)))
       {:issue :target-gloss-mismatch})))
 
 
@@ -246,16 +258,6 @@
   (= ::generation-failure (::type result)))
 
 
-(defn- gloss-mismatch-issue?
-  [issue]
-  (= :target-gloss-mismatch issue))
-
-
-(defn- mark-gloss-mismatch
-  [example]
-  (assoc example :glossMismatch true))
-
-
 (def system-prompt
   (str/join
    "\n"
@@ -263,7 +265,8 @@
     "Return only JSON that matches the supplied schema."
     "Input fields: word, translation, part of speech, cefrLevel, previousAttempt, previousIssue."
     "Missing cefrLevel => B2."
-    "- Match the intended Russian gloss sence."
+    "- `translation` is one or more Russian glosses the learner has confirmed; any of them is an acceptable sense for the sentence."
+    "- Pick one sense that fits naturally; the structure `translation` of the target lemma must match the gloss you chose."
     "- Produce one natural standard German sentence, 6-12 words, using the target lemma or a correct inflected form."
     "- German sentence only: no labels, notes, markdown, or meta commentary."
     "- `translation` must be one natural Russian sentence, not a calque."
@@ -309,7 +312,7 @@
 
 
 (defn- user-prompt
-  [word translation word-meta retry-context]
+  [word translations word-meta retry-context]
   (str/join
    "\n"
    ["Generate one example."
@@ -319,17 +322,17 @@
      (cond-> {:word         word
               :partOfSpeech (:partOfSpeech word-meta)
               :cefrLevel    (:cefrLevel word-meta "C2")
-              :translation  translation}
+              :translation  translations}
        retry-context (assoc :previousAttempt (:example retry-context)
                             :previousIssue   (previous-issue-payload retry-context))))]))
 
 
 (defn- request-body
-  [word translation word-meta retry-context]
+  [word translations word-meta retry-context]
   {:messages        [{:role    "system"
                       :content system-prompt}
                      {:role    "user"
-                      :content (user-prompt word translation word-meta retry-context)}]
+                      :content (user-prompt word translations word-meta retry-context)}]
    :temperature     0.1
    :max_tokens      (example-max-tokens)
    :response_format {:type        "json_schema"
@@ -340,9 +343,9 @@
 
 
 (defn example-api-request
-  [word translation word-meta retry-context]
+  [word translations word-meta retry-context]
   (provider/request
-   (request-body word translation word-meta retry-context)
+   (request-body word translations word-meta retry-context)
    (example-generation-timeout-ms)))
 
 
@@ -371,9 +374,9 @@
 
 
 (defn- generate-attempt!
-  [word translation word-meta retry-context]
+  [word translations word-meta retry-context]
   (try
-    (-> @(example-api-request word translation word-meta retry-context)
+    (-> @(example-api-request word translations word-meta retry-context)
         (parse-generated-example word))
     (catch Exception error
       (let [failure {::type      ::generation-failure
@@ -388,29 +391,31 @@
 
 (defn generate-one!
   "Generates a German example sentence for word/translation.
-  Returns a map with keyword keys:
-  * :value — German text;
-  * :translation — Russian translation;
-  * :glossMismatch — true if the supplied gloss appears mismatched to the word;
-  * :structure — list of maps with keyword keys :usedForm, :dictionaryForm, :translation.
-  Returns a generation-failure map on a hard error (e.g. 429), nil when all attempts are exhausted."
+  `translation` may be a single string or a collection of strings; all are
+  passed through to the prompt and validation so any can be the chosen sense.
+  Returns one of:
+  * success — map with keys :value, :translation, :glossMismatch,
+    :structure (a vector of maps with :usedForm, :dictionaryForm, :translation);
+  * generation-failure map on a hard error (e.g. 429);
+  * nil when all attempts are exhausted."
   ([input]
    (generate-one! input 3))
   ([{:keys [word translation]} max-attempts]
-   (let [word-meta (dictionary/lookup-word-meta word translation)]
+   (let [translations (normalize-translations translation)
+         word-meta    (dictionary/lookup-word-meta word translations)]
      (loop [attempt 1 retry-context nil]
-       (let [example  (generate-attempt! word translation word-meta retry-context)
+       (let [example  (generate-attempt! word translations word-meta retry-context)
              failure? (generation-failure? example)
-             result   (when-not failure? (example-issue word translation example))
+             result   (when-not failure? (example-issue word translations example))
              issue    (:issue result)]
          (cond
            (and failure? (not (:retryable? example)))
            example
 
-           (and (not failure?) (gloss-mismatch-issue? issue))
+           (and (not failure?) (= :target-gloss-mismatch issue))
            (-> example
                add-word-indexes
-               mark-gloss-mismatch)
+               (assoc :glossMismatch true))
 
            (and (not failure?) (nil? issue))
            (add-word-indexes example)
@@ -442,4 +447,4 @@
 
 
 (comment
-  (generate-one! {:word "das Entsetzen"}))
+  (generate-one! {:word "das Entsetzen" :translation ["ужас" "испуг"]}))

--- a/src/backend/examples.clj
+++ b/src/backend/examples.clj
@@ -18,6 +18,12 @@
           parse-long))
 
 
+(defn- example-max-tokens
+  []
+  (-> (or (System/getenv "EXAMPLE_MAX_TOKENS") "300")
+      parse-long))
+
+
 (defn valid-example?
   [example]
   (and (map? example)
@@ -76,7 +82,7 @@
   [:and schema [:fn {:error/message message} pred]])
 
 
-(def ^:private example-structure-schema
+(def ^:private generated-example-schema
   [:map {:closed true}
    [:value
     {:description "A natural German sentence using the requested word."}
@@ -88,7 +94,7 @@
     {:description "Whether the supplied Russian gloss appears mismatched to the German word."}
     :boolean]
    [:structure
-    {:description "A list of JSON objects containing the used word form, its dictionary form and its translation."}
+    {:description "A list of JSON objects containing the used word form, its dictionary form, and its translation, ordered left to right as they appear in the German sentence."}
     [:vector {:min 1}
      [:map {:closed true}
       [:usedForm
@@ -102,8 +108,8 @@
        [:string {:min 1}]]]]]])
 
 
-(def ^:private generated-example-schema
-  (-> example-structure-schema
+(def ^:private valid-generated-example-schema
+  (-> generated-example-schema
       (mu/update :value       with-constraint german-sentence-text?  "German sentence required")
       (mu/update :translation with-constraint russian-sentence-text? "Russian translation required")
       (mu/update-in [:structure 0 :translation] with-constraint russian-text? "Structure translation must be Cyrillic")))
@@ -112,20 +118,6 @@
 (defn- normalize-text
   [text]
   (some-> text utils/sanitize-text str/lower-case))
-
-
-(defn- sentence-contains-word?
-  [sentence word]
-  (let [sentence (normalize-text sentence)
-        word     (normalize-text word)]
-    (when (and sentence word)
-      (boolean
-       (re-find
-        (re-pattern
-         (str "(?iu)(^|\\P{L})"
-              (java.util.regex.Pattern/quote word)
-              "($|\\P{L})"))
-        sentence)))))
 
 
 (defn- sentence-word-count
@@ -138,9 +130,64 @@
   (<= 3 (sentence-word-count sentence) 12))
 
 
-(defn- structure-matches-sentence?
+(defn- split-sentence-words
+  [sentence]
+  (if (str/blank? sentence)
+    []
+    (str/split (str/trim sentence) #"\s+")))
+
+
+(defn- strip-word-edges
+  [word]
+  (some-> word
+          (str/replace #"(?u)^\P{L}+" "")
+          (str/replace #"(?u)\P{L}+$" "")))
+
+
+(defn- strip-word-indexes
+  [example]
+  (update example :structure
+          (fn [structure]
+            (mapv #(dissoc % :wordIndex) (or structure [])))))
+
+
+(defn- find-word-index
+  [words next-word-index used-form]
+  (loop [word-index next-word-index]
+    (when (< word-index (count words))
+      (if (= (normalize-text used-form)
+             (normalize-text (strip-word-edges (nth words word-index))))
+        word-index
+        (recur (inc word-index))))))
+
+
+(defn- add-word-indexes-to-structure
   [sentence structure]
-  (every? #(sentence-contains-word? sentence (:usedForm %)) structure))
+  (let [words (split-sentence-words sentence)]
+    (loop [items           (seq structure)
+           next-word-index 0
+           indexed         []]
+      (if-let [item (first items)]
+        (if-let [word-index (find-word-index words next-word-index (:usedForm item))]
+          (recur (next items)
+                 (inc word-index)
+                 (conj indexed (assoc item :wordIndex word-index)))
+          nil)
+        indexed))))
+
+
+(defn- structure-has-duplicate-items?
+  [structure]
+  (not= (count structure)
+        (count (distinct (map (juxt :usedForm :dictionaryForm) structure)))))
+
+
+(defn- add-word-indexes
+  [example]
+  (let [example (strip-word-indexes example)]
+    (when-not (structure-has-duplicate-items? (:structure example))
+      (when-let [structure (add-word-indexes-to-structure (:value example) (:structure example))]
+        (assoc example :structure structure)))))
 
 
 (defn- log-generation-failure!
@@ -152,28 +199,39 @@
    "Examples generation failed"))
 
 
+(def ^:private issue-messages
+  {:malformed-example            "The generated example did not match the required JSON shape or text constraints. See `details` for the specific field errors."
+   :structure-mismatch           "Items in `structure` must appear in strict left-to-right order as they occur in the German sentence, each `usedForm` must match the word at its position, and a `{usedForm, dictionaryForm}` pair must not repeat (each separable-verb prefix appears once, not twice)."
+   :sentence-length-out-of-range "The German sentence must contain between 3 and 12 words."
+   :target-lemma-missing         "The target lemma must appear as a `dictionaryForm` entry in `structure`."
+   :target-gloss-mismatch        "The target lemma's structure `translation` contradicts the supplied Russian gloss."})
+
+
 (defn- example-issue
   [word translation example]
-  (if-not (m/validate generated-example-schema example)
-    (do
-      (log-generation-failure!
-       {:word    word
-        :error   "Invalid generated example shape"
-        :explain (me/humanize (m/explain generated-example-schema example))})
-      :invalid-generated-example)
-    (let [{:keys [value structure]} example]
-      (cond
-        (not (structure-matches-sentence? value structure))
-        :structure-value-mismatch
+  (let [raw     (strip-word-indexes example)
+        valid?  (m/validate valid-generated-example-schema raw)
+        indexed (when valid? (add-word-indexes raw))]
+    (cond
+      (not valid?)
+      (let [explain (me/humanize (m/explain valid-generated-example-schema raw))]
+        (log-generation-failure!
+         {:word    word
+          :error   "Invalid generated example shape"
+          :explain explain})
+        {:issue :malformed-example :details explain})
 
-        (not (sentence-length-ok? value))
-        :sentence-length-out-of-range
+      (nil? indexed)
+      {:issue :structure-mismatch}
 
-        (not (dictionary/lemma-in-structure? word structure))
-        :target-dictionary-form-missing
+      (not (sentence-length-ok? (:value indexed)))
+      {:issue :sentence-length-out-of-range}
 
-        (not (dictionary/word-gloss-valid? word translation structure))
-        :target-dictionary-form-gloss-mismatch))))
+      (not (dictionary/lemma-in-structure? word (:structure indexed)))
+      {:issue :target-lemma-missing}
+
+      (not (dictionary/word-gloss-valid? word translation (:structure indexed)))
+      {:issue :target-gloss-mismatch})))
 
 
 
@@ -188,15 +246,25 @@
   (= ::generation-failure (::type result)))
 
 
+(defn- gloss-mismatch-issue?
+  [issue]
+  (= :target-gloss-mismatch issue))
+
+
+(defn- mark-gloss-mismatch
+  [example]
+  (assoc example :glossMismatch true))
+
+
 (def system-prompt
   (str/join
    "\n"
    ["You generate learner-facing German example sentences for a vocabulary app."
     "Return only JSON that matches the supplied schema."
-    "Input fields: word, translation, part of speech, cefrLevel, previousAttempt, previousIssues."
-    "Missing cefrLevel => B1."
-    "- Match the intended Russian gloss exactly. Do not switch senses."
-    "- Produce one natural standard German sentence, 3-12 words, using the target lemma or a correct inflected form."
+    "Input fields: word, translation, part of speech, cefrLevel, previousAttempt, previousIssue."
+    "Missing cefrLevel => B2."
+    "- Match the intended Russian gloss sence."
+    "- Produce one natural standard German sentence, 6-12 words, using the target lemma or a correct inflected form."
     "- German sentence only: no labels, notes, markdown, or meta commentary."
     "- `translation` must be one natural Russian sentence, not a calque."
     "- Set `glossMismatch` to true only if the supplied gloss clearly mismatches the target lemma; otherwise false."
@@ -205,15 +273,23 @@
     "- Never use arrays like `[\"Fenster\", \"das Fenster\", \"окно\"]` inside `structure`."
     "- Exclude articles, pronouns, prepositions, conjunctions, and pure particles like `zu` or `nicht`."
     "- Detached prefixes of separable verbs are not particles: include them."
+    "- Order `structure` items strictly left to right as they appear in the German sentence."
+    "- The backend assigns `wordIndex`; do not return `wordIndex`."
+    "- Keep `dictionaryForm` lemma-only unless the lemma inherently includes an article or `sich`."
     "- For nouns, `dictionaryForm` includes the article."
     "- For separable verbs with detached prefixes, include one item for the verb part and one for the prefix; both use the full infinitive as `dictionaryForm` and the same Russian gloss."
+    "- Separable verbs emit the prefix exactly once. If a preposition shares spelling with the prefix (for example `auf` in `Pass auf deine Sachen auf!`), exclude the preposition — only the detached prefix in the verb frame belongs in `structure`."
+    "- Never emit two `structure` items with the same `usedForm` and `dictionaryForm` pair."
     "- Reflexive verb `dictionaryForm` keeps `sich`."
     "- Ambiguous noun articles and ambiguous prefixes (`um-`, `über-`, `unter-`, `durch-`, `wieder-`) must follow the supplied Russian gloss."
     "- Example structure item: `{\"usedForm\":\"Fenster\",\"dictionaryForm\":\"das Fenster\",\"translation\":\"окно\"}`."
     "Example word=aufstehen gloss=вставать:"
     "{\"value\":\"Ich stehe jeden Morgen um sieben Uhr auf.\",\"translation\":\"Я встаю каждое утро в семь часов.\",\"glossMismatch\":false,\"structure\":[{\"usedForm\":\"stehe\",\"dictionaryForm\":\"aufstehen\",\"translation\":\"вставать\"},{\"usedForm\":\"Morgen\",\"dictionaryForm\":\"der Morgen\",\"translation\":\"утро\"},{\"usedForm\":\"auf\",\"dictionaryForm\":\"aufstehen\",\"translation\":\"вставать\"}]}"
+    "Example word=aufpassen gloss=следить:"
+    "{\"value\":\"Er passt auf die Kinder auf.\",\"translation\":\"Он следит за детьми.\",\"glossMismatch\":false,\"structure\":[{\"usedForm\":\"passt\",\"dictionaryForm\":\"aufpassen\",\"translation\":\"следить\"},{\"usedForm\":\"Kinder\",\"dictionaryForm\":\"das Kind\",\"translation\":\"дети\"},{\"usedForm\":\"auf\",\"dictionaryForm\":\"aufpassen\",\"translation\":\"следить\"}]}"
+    "Note: the first `auf` is a preposition and is excluded; only the sentence-final `auf` is the detached separable prefix."
     "Example word=das Verstehen gloss=понимание:"
-    "{\"value\":\"Das Verstehen dieser Regel dauert lange.\",\"translation\":\"Понимание этого правила требует времени.\",\"glossMismatch\":false,\"structure\":[{\"usedForm\":\"Verstehen\",\"dictionaryForm\":\"das Verstehen\",\"translation\":\"понимание\"},{\"usedForm\":\"Regel\",\"dictionaryForm\":\"die Regel\",\"translation\":\"правило\"},{\"usedForm\":\"dauert\",\"dictionaryForm\":\"dauern\",\"translation\":\"длиться\"}]}"
+    "{\"value\":\"Das Verstehen dieser Regel dauert lange.\",\"translation\":\"Понимание этого правила требует времени.\",\"glossMismatch\":false,\"structure\":[{\"usedForm\":\"Verstehen\",\"dictionaryForm\":\"das Verstehen\",\"translation\":\"понимание\"},{\"usedForm\":\"Regel\",\"dictionaryForm\":\"die Regel\",\"translation\":\"правило\"},{\"usedForm\":\"dauert\",\"dictionaryForm\":\"dauern\",\"translation\":\"длиться\"},{\"usedForm\":\"lange\",\"dictionaryForm\":\"lang\",\"translation\":\"долго\"}]}"
     "Example word=die Bank gloss=скамейка:"
     "{\"value\":\"Wir sitzen auf einer Bank im Park.\",\"translation\":\"Мы сидим на скамейке в парке.\",\"glossMismatch\":false,\"structure\":[{\"usedForm\":\"sitzen\",\"dictionaryForm\":\"sitzen\",\"translation\":\"сидеть\"},{\"usedForm\":\"Bank\",\"dictionaryForm\":\"die Bank\",\"translation\":\"скамейка\"},{\"usedForm\":\"Park\",\"dictionaryForm\":\"der Park\",\"translation\":\"парк\"}]}"
     "Example word=Leiter gloss=лестница:"
@@ -224,22 +300,28 @@
 
 
 
+(defn- previous-issue-payload
+  [{:keys [issue details]}]
+  (cond-> {:issue   (name issue)
+           :message (get issue-messages issue
+                         "Unknown issue; regenerate the example from scratch.")}
+    (seq details) (assoc :details details)))
+
+
 (defn- user-prompt
   [word translation word-meta retry-context]
   (str/join
    "\n"
    ["Generate one example."
     "Return one JSON object matching the supplied schema."
-    "If `previousAttempt` and `previousIssues` are present, fix those problems without changing the intended sense."
+    "If `previousAttempt` and `previousIssue` are present, fix the described problem without changing the intended sense."
     (cheshire/generate-string
-     (merge
-      {:word         word
-       :partOfSpeech (:partOfSpeech word-meta)
-       :cefrLevel    (:cefrLevel word-meta)
-       :translation  translation}
-      (when retry-context
-        {:previousAttempt (:example retry-context)
-         :previousIssues  [(name (:issue retry-context))]})))]))
+     (cond-> {:word         word
+              :partOfSpeech (:partOfSpeech word-meta)
+              :cefrLevel    (:cefrLevel word-meta "C2")
+              :translation  translation}
+       retry-context (assoc :previousAttempt (:example retry-context)
+                            :previousIssue   (previous-issue-payload retry-context))))]))
 
 
 (defn- request-body
@@ -248,9 +330,11 @@
                       :content system-prompt}
                      {:role    "user"
                       :content (user-prompt word translation word-meta retry-context)}]
+   :temperature     0.1
+   :max_tokens      (example-max-tokens)
    :response_format {:type        "json_schema"
                      :json_schema {:name   "sentence_example"
-                                   :schema (mjs/transform example-structure-schema)
+                                   :schema (mjs/transform generated-example-schema)
                                    :strict true}}})
 
 
@@ -317,17 +401,25 @@
      (loop [attempt 1 retry-context nil]
        (let [example  (generate-attempt! word translation word-meta retry-context)
              failure? (generation-failure? example)
-             issue    (when-not failure?
-                        (example-issue word translation example))]
+             result   (when-not failure? (example-issue word translation example))
+             issue    (:issue result)]
          (cond
            (and failure? (not (:retryable? example)))
            example
 
+           (and (not failure?) (gloss-mismatch-issue? issue))
+           (-> example
+               add-word-indexes
+               mark-gloss-mismatch)
+
            (and (not failure?) (nil? issue))
-           example
+           (add-word-indexes example)
 
            (< attempt max-attempts)
-           (let [retry-ctx (when-not failure? {:example example :issue issue})]
+           (let [retry-ctx (when (and (not failure?) issue)
+                             (cond-> {:example (strip-word-indexes example)
+                                      :issue   issue}
+                               (seq (:details result)) (assoc :details (:details result))))]
              (when retry-ctx
                (log-generation-failure!
                 {:words   [word]
@@ -339,7 +431,7 @@
 
            :else
            (do
-             (when-not failure?
+             (when (and (not failure?) issue)
                (log-generation-failure!
                 {:words   [word]
                  :attempt attempt

--- a/src/backend/examples/dictionary.clj
+++ b/src/backend/examples/dictionary.clj
@@ -157,15 +157,6 @@
            (canonical-dictionary-form target))))))
 
 
-(defn lemma-forms
-  "Returns the distinct dictionaryForm values from structure whose lemma matches word."
-  [word structure]
-  (->> structure
-       (keep :dictionaryForm)
-       (filter #(same-lemma? word %))
-       distinct))
-
-
 ;; =============================================================================
 ;; Translation matching
 ;; =============================================================================
@@ -224,17 +215,6 @@
         (:translation entry)))
 
 
-(defn- form-has-gloss?
-  [dictionary-form translation]
-  (let [entries (lookup-dictionary-entries dictionary-form)]
-    ;; If dictionary lookup itself is unavailable, do not turn that outage into a
-    ;; hard example-generation failure. Only reject when the lookup succeeds and
-    ;; the returned entries disagree with the intended gloss.
-    (or (nil? entries)
-        (some #(dictionary-entry-matches-gloss? % translation)
-              entries))))
-
-
 ;; =============================================================================
 ;; Public API
 ;; =============================================================================
@@ -254,17 +234,6 @@
                      (first entries))]
         {:partOfSpeech (:pos best)
          :cefrLevel    (get-in best [:meta :cefr_level])}))))
-
-
-(defn word-gloss-valid?
-  "Returns true if at least one dictionaryForm for word in structure has a
-   dictionary entry whose Russian gloss matches any of `translations`.
-   Returns true when translations is empty or DB is unavailable."
-  [word translations structure]
-  (let [form-matches-any? (fn [form]
-                            (some #(form-has-gloss? form %) translations))]
-    (or (empty? (remove str/blank? translations))
-        (some form-matches-any? (lemma-forms word structure)))))
 
 
 (defn lemma-in-structure?

--- a/src/backend/examples/dictionary.clj
+++ b/src/backend/examples/dictionary.clj
@@ -242,26 +242,29 @@
 
 (defn lookup-word-meta
   "Look up partOfSpeech and cefrLevel for a word from dictionary entries.
-   Prefers the entry whose Russian gloss matches `translation`.
+   Prefers entries whose Russian gloss matches any of `translations`.
    Returns nil if the lookup fails or produces no results."
-  [word translation]
-  (let [entries (lookup-dictionary-entries (normalize-dictionary-form word))]
+  [word translations]
+  (let [entries (lookup-dictionary-entries (normalize-dictionary-form word))
+        matches-any-gloss? (fn [entry]
+                             (some #(dictionary-entry-matches-gloss? entry %)
+                                   translations))]
     (when (seq entries)
-      (let [best (or (some #(when (dictionary-entry-matches-gloss? % translation) %) entries)
+      (let [best (or (first (filter matches-any-gloss? entries))
                      (first entries))]
-        (when best
-          {:partOfSpeech (:pos best)
-           :cefrLevel    (get-in best [:meta :cefr_level])})))))
+        {:partOfSpeech (:pos best)
+         :cefrLevel    (get-in best [:meta :cefr_level])}))))
 
 
 (defn word-gloss-valid?
   "Returns true if at least one dictionaryForm for word in structure has a
-   dictionary entry whose Russian gloss matches translation.
-   Returns true when translation is blank or DB is unavailable."
-  [word translation structure]
-  (or (str/blank? translation)
-      (some #(form-has-gloss? % translation)
-            (lemma-forms word structure))))
+   dictionary entry whose Russian gloss matches any of `translations`.
+   Returns true when translations is empty or DB is unavailable."
+  [word translations structure]
+  (let [form-matches-any? (fn [form]
+                            (some #(form-has-gloss? form %) translations))]
+    (or (empty? (remove str/blank? translations))
+        (some form-matches-any? (lemma-forms word structure)))))
 
 
 (defn lemma-in-structure?

--- a/src/client/application.cljs
+++ b/src/client/application.cljs
@@ -275,7 +275,7 @@
               (p/let [_ (lesson/add-word-from-structure! dbs (:dictionary-form params) (:translation params))]
                 {:html/body (views.lesson/token-card {:dictionary-form (:dictionary-form params)
                                                       :translation     (:translation params)
-                                                      :known?          true})
+                                                      :state           :known-with-translation})
                  :status    200}))}]]])
 
 

--- a/src/client/application.cljs
+++ b/src/client/application.cljs
@@ -46,6 +46,7 @@
      [:script {:src "/js/word-autocomplete.js" :defer true}]
      [:script {:src "/js/virtual-keyboard.js" :defer true}]
      [:script {:src "/js/pwa-install.js" :defer true}]
+     [:script {:src "/js/popover.js" :defer true}]
      head]
     [:body
      [:div#loader.app-shell__loader
@@ -67,6 +68,11 @@
      [:dialog#modal.modal
       {:hx-on:htmx:after-swap "if(!this.open) this.showModal()"
        :hx-on:click           "if(event.target===this) this.close()"}]
+     [:div#popover.popover
+      {:popover "auto"}
+      [:div#popover-content.popover__content
+       {:hx-on:htmx:after-swap "repositionPopover()"}]
+      [:div#popover-arrow.popover__arrow]]
      [:div#app body]]]))
 
 
@@ -256,7 +262,21 @@
                                (views.lesson/challenge lesson-state {:hx-swap-oob "true"})
                                (views.lesson/progress lesson-state {:hx-swap-oob "innerHTML"}))
                    :status    200}
-                  {:status 404})))}]]])
+                  {:status 404})))}]
+
+    ["/lesson/token-info"
+     {:get (fn [{:keys [dbs params]}]
+             (p/let [info (lesson/token-info dbs (:dictionary-form params) (:translation params))]
+               {:html/body (views.lesson/token-card info)
+                :status    200}))}]
+
+    ["/lesson/token-add"
+     {:post (fn [{:keys [dbs params]}]
+              (p/let [_ (lesson/add-word-from-structure! dbs (:dictionary-form params) (:translation params))]
+                {:html/body (views.lesson/token-card {:dictionary-form (:dictionary-form params)
+                                                      :translation     (:translation params)
+                                                      :known?          true})
+                 :status    200}))}]]])
 
 
 (def ring-handler

--- a/src/client/domain/lesson.cljs
+++ b/src/client/domain/lesson.cljs
@@ -50,13 +50,12 @@
   "Convert an example document to an example trial.
    Example doc has :word-id, :value, :translation."
   [example]
-  {:type           trial-type-example
-   :word-id        (:word-id example)
-   :prompt         (:translation example)
-   :answer         (:value example)
-   :structure      (:structure example)
-   :gloss-mismatch (:gloss-mismatch example)
-   :locked?        true})
+  {:type      trial-type-example
+   :word-id   (:word-id example)
+   :prompt    (:translation example)
+   :answer    (:value example)
+   :structure (:structure example)
+   :locked?   true})
 
 
 (defn generate-trials

--- a/src/client/domain/lesson.cljs
+++ b/src/client/domain/lesson.cljs
@@ -54,6 +54,7 @@
    :word-id        (:word-id example)
    :prompt         (:translation example)
    :answer         (:value example)
+   :structure      (:structure example)
    :gloss-mismatch (:gloss-mismatch example)
    :locked?        true})
 
@@ -211,3 +212,30 @@
   "Get the last answer result from lesson state."
   [state]
   (:last-result state))
+
+
+(defn- split-answer-words
+  [answer]
+  (str/split (str/trim (or answer "")) #"\s+"))
+
+
+(defn answer-segments
+  "Build segmented answer tokens using example structure wordIndex data."
+  [trial]
+  (let [structure-by-index (into {}
+                                 (map (juxt :wordIndex identity))
+                                 (:structure trial))]
+    (->> (split-answer-words (:answer trial))
+         (map-indexed
+          (fn [word-index word]
+            (if-let [item (get structure-by-index word-index)]
+              {:type            :annotated-word
+               :text            word
+               :used-form       (:usedForm item)
+               :dictionary-form (:dictionaryForm item)
+               :translation     (:translation item)
+               :word-index      word-index}
+              {:type       :plain-word
+               :text       word
+               :word-index word-index})))
+         vec)))

--- a/src/client/examples.cljs
+++ b/src/client/examples.cljs
@@ -13,13 +13,14 @@
   "Invalid example response from backend")
 
 
-(defn- primary-translation
+(defn- russian-translations
+  "Collect user-confirmed Russian translations as a vector of strings."
   [word-doc]
-  (or (->> (:translation word-doc)
-           (filter #(= "ru" (:lang %)))
-           first
-           :value)
-      (some-> (:translation word-doc) first :value)))
+  (->> (:translation word-doc)
+       (filter #(= "ru" (:lang %)))
+       (map :value)
+       (filter utils/non-blank)
+       vec))
 
 
 (defn- retry-after-ms
@@ -35,14 +36,17 @@
 
 (defn fetch-one
   "Fetches an example sentence for the given German word from the backend.
-   Returns a promise that resolves to the example map.
+   `translations` is a vector of Russian glosses the user has confirmed; all
+   are sent as repeated `translation` query params so the backend prompt can
+   weigh every sense. Returns a promise resolving to the example map.
    Rejects on network or server errors."
   ([word]
-   (fetch-one word nil))
-  ([word translation]
-   (let [url (str "/api/examples?word=" (js/encodeURIComponent word)
-                  (when (utils/non-blank translation)
-                    (str "&translation=" (js/encodeURIComponent translation))))]
+   (fetch-one word []))
+  ([word translations]
+   (let [url (->> translations
+                  (filter utils/non-blank)
+                  (map #(str "&translation=" (js/encodeURIComponent %)))
+                  (reduce str (str "/api/examples?word=" (js/encodeURIComponent word))))]
      (p/let [response (js/fetch url)]
        (if (.-ok response)
          ;; Successful HTTP still needs validation: the body may be invalid JSON
@@ -142,7 +146,7 @@
 
         (p/catch
           (p/let [example (fetch-one (:value word-doc)
-                                     (primary-translation word-doc))]
+                                     (russian-translations word-doc))]
             (save-example! dbs word-id (:value word-doc) example)
             true)
 

--- a/src/client/examples.cljs
+++ b/src/client/examples.cljs
@@ -101,7 +101,6 @@
                      :value         (:value example)
                      :translation   (:translation example)
                      :structure     (:structure example)
-                     :gloss-mismatch (:glossMismatch example)
                      :created-at    (utils/now-iso)}]
     (dbs/insert dbs example-doc)))
 

--- a/src/client/lesson.cljs
+++ b/src/client/lesson.cljs
@@ -120,3 +120,20 @@
             (log/error :advance-lesson/save-failed {:error (ex-message err)})
             {:error :lesson-save-failed}))))))
 
+
+(defn token-info
+  "Return token info for lesson answer annotation card."
+  [dbs dictionary-form translation]
+  (p/let [existing (vocabulary/find-duplicate-by-value dbs dictionary-form)]
+    {:dictionary-form dictionary-form
+     :translation     translation
+     :known?          (some? existing)}))
+
+
+(defn add-word-from-structure!
+  "Add dictionary form from lesson example structure into vocabulary."
+  [dbs dictionary-form translation]
+  (p/let [result (vocabulary/add! dbs dictionary-form translation)]
+    (when (:created? result)
+      (examples/create-fetch-task! (:word-id result)))
+    result))

--- a/src/client/lesson.cljs
+++ b/src/client/lesson.cljs
@@ -121,17 +121,35 @@
             {:error :lesson-save-failed}))))))
 
 
+(defn- token-state
+  "Classify a (word, translation) pair against the user's vocabulary:
+     :unknown-word               — no matching word doc
+     :known-with-translation     — word exists and this translation is in its set
+     :known-missing-translation  — word exists but translation is new for it."
+  [existing translation]
+  (cond
+    (nil? existing)
+    :unknown-word
+
+    (some #(= translation (:value %)) (:translation existing))
+    :known-with-translation
+
+    :else
+    :known-missing-translation))
+
+
 (defn token-info
   "Return token info for lesson answer annotation card."
   [dbs dictionary-form translation]
   (p/let [existing (vocabulary/find-duplicate-by-value dbs dictionary-form)]
     {:dictionary-form dictionary-form
      :translation     translation
-     :known?          (some? existing)}))
+     :state           (token-state existing translation)}))
 
 
 (defn add-word-from-structure!
-  "Add dictionary form from lesson example structure into vocabulary."
+  "Add dictionary form + translation from lesson example structure into vocabulary.
+   If the word already exists, `vocabulary/add!` merges the new translation."
   [dbs dictionary-form translation]
   (p/let [result (vocabulary/add! dbs dictionary-form translation)]
     (when (:created? result)

--- a/src/client/presenter/lesson.cljs
+++ b/src/client/presenter/lesson.cljs
@@ -26,7 +26,10 @@
    Returns map with :variant (:success/:error) and display data."
   [state]
   (when-let [result (domain/last-result state)]
-    {:variant        (if (:correct? result) :success :error)
-     :correct-answer (domain/expected-answer state)
-     :user-answer    (:answer result)
-     :finished?      (domain/finished? state)}))
+    (let [trial (domain/current-trial state)]
+      {:variant                 (if (:correct? result) :success :error)
+       :correct-answer          (domain/expected-answer state)
+       :correct-answer-segments (when (domain/example-trial? trial)
+                                  (domain/answer-segments trial))
+       :user-answer             (:answer result)
+       :finished?               (domain/finished? state)})))

--- a/src/client/presenter/lesson.cljs
+++ b/src/client/presenter/lesson.cljs
@@ -9,9 +9,8 @@
   "Props for the challenge display (prompt + instruction)."
   [state]
   (let [trial (domain/current-trial state)]
-    {:prompt          (:prompt trial)
-     :is-example?     (domain/example-trial? trial)
-     :gloss-mismatch? (:gloss-mismatch trial)}))
+    {:prompt      (:prompt trial)
+     :is-example? (domain/example-trial? trial)}))
 
 
 (defn progress-props

--- a/src/client/views/lesson.cljs
+++ b/src/client/views/lesson.cljs
@@ -39,23 +39,29 @@
     [:p.lesson__answer-body {:lang "de"} correct-answer]))
 
 
+(defn- token-add-form
+  [dictionary-form translation label]
+  [:form.token-card__form
+   {:hx-post   "/lesson/token-add"
+    :hx-target "#popover-content"
+    :hx-swap   "innerHTML"}
+   [:input {:type "hidden" :name "dictionary-form" :value dictionary-form}]
+   [:input {:type "hidden" :name "translation" :value translation}]
+   [:button.token-card__button
+    {:type "submit"}
+    label]])
+
+
 (defn token-card
-  [{:keys [dictionary-form translation known?]}]
+  [{:keys [dictionary-form translation state]}]
   [:div.token-card
-   (when known? {:data-dismiss "900"})
+   (when (= state :known-with-translation) {:data-dismiss "900"})
    [:p.token-card__word {:lang "de"} dictionary-form]
    [:p.token-card__translation {:lang "ru"} translation]
-   (if known?
-     [:p.token-card__state "✓ В словаре"]
-     [:form.token-card__form
-      {:hx-post   "/lesson/token-add"
-       :hx-target "#popover-content"
-       :hx-swap   "innerHTML"}
-      [:input {:type "hidden" :name "dictionary-form" :value dictionary-form}]
-      [:input {:type "hidden" :name "translation" :value translation}]
-      [:button.token-card__button
-       {:type "submit"}
-       "+ В МОЙ СЛОВАРЬ"]])])
+   (case state
+     :known-with-translation    [:p.token-card__state "✓ В словаре"]
+     :known-missing-translation (token-add-form dictionary-form translation "+ ДОБАВИТЬ ПЕРЕВОД")
+     :unknown-word              (token-add-form dictionary-form translation "+ В МОЙ СЛОВАРЬ"))])
 
 
 (defn progress

--- a/src/client/views/lesson.cljs
+++ b/src/client/views/lesson.cljs
@@ -61,7 +61,7 @@
    (case state
      :known-with-translation    [:p.token-card__state "✓ В словаре"]
      :known-missing-translation (token-add-form dictionary-form translation "+ ДОБАВИТЬ ПЕРЕВОД")
-     :unknown-word              (token-add-form dictionary-form translation "+ В МОЙ СЛОВАРЬ"))])
+     :unknown-word              (token-add-form dictionary-form translation "+ В СЛОВАРЬ"))])
 
 
 (defn progress

--- a/src/client/views/lesson.cljs
+++ b/src/client/views/lesson.cljs
@@ -1,7 +1,8 @@
 (ns views.lesson
   "Lesson page views."
   (:require
-   [presenter.lesson :as presenter.lesson]))
+   [presenter.lesson :as presenter.lesson]
+   [utils :as utils]))
 
 
 (def result-action-keydown
@@ -9,6 +10,52 @@
 
 (def input-focus-after-settle
   "if(matchMedia('(pointer:fine)').matches){var input=this.querySelector('#lesson-answer'); if(input){input.focus();}}")
+
+
+(defn- answer-body
+  [{:keys [correct-answer correct-answer-segments]}]
+  (if (seq correct-answer-segments)
+    (into
+     [:p.lesson__answer-body {:lang "de"}]
+     (interpose " ")
+     (for [{:keys [type text dictionary-form translation word-index]} correct-answer-segments]
+       (if (= :annotated-word type)
+         [:button.lesson__answer-token
+          {:type                     "button"
+           :data-word-index          word-index
+           :data-dictionary-form     dictionary-form
+           :data-translation         translation
+           :aria-haspopup            "dialog"
+           :aria-expanded            "false"
+           :aria-controls            "popover"
+           :hx-get                   (utils/build-url "/lesson/token-info"
+                                                     {:dictionary-form dictionary-form
+                                                      :translation     translation})
+           :hx-target                "#popover-content"
+           :hx-swap                  "innerHTML"
+           :hx-on:htmx:after-request "if(event.detail.successful) openPopover(this)"}
+          text]
+         text)))
+    [:p.lesson__answer-body {:lang "de"} correct-answer]))
+
+
+(defn token-card
+  [{:keys [dictionary-form translation known?]}]
+  [:div.token-card
+   (when known? {:data-dismiss "900"})
+   [:p.token-card__word {:lang "de"} dictionary-form]
+   [:p.token-card__translation {:lang "ru"} translation]
+   (if known?
+     [:p.token-card__state "✓ В словаре"]
+     [:form.token-card__form
+      {:hx-post   "/lesson/token-add"
+       :hx-target "#popover-content"
+       :hx-swap   "innerHTML"}
+      [:input {:type "hidden" :name "dictionary-form" :value dictionary-form}]
+      [:input {:type "hidden" :name "translation" :value translation}]
+      [:button.token-card__button
+       {:type "submit"}
+       "+ В МОЙ СЛОВАРЬ"]])])
 
 
 (defn progress
@@ -70,16 +117,16 @@
 
 
 (defn- success
-  [{:keys [correct-answer finished?]}]
+  [{:keys [finished?] :as props}]
   [:footer#lesson-footer
    {:tabindex "-1"
     :hx-on:htmx:afterSettle
     "var btn = this.querySelector('#lesson-next') || this.querySelector('#lesson-finish'); if(btn){btn.focus();}"
    }
-   [:div.lesson__footer.lesson__footer--success.page-footer
+    [:div.lesson__footer.lesson__footer--success.page-footer
     [:div.lesson__answer
      [:h3.lesson__answer-header "Правильно!"]
-     [:p.lesson__answer-body {:lang "de"} correct-answer]]
+     (answer-body props)]
     [:form
      (if finished?
        {:hx-delete "/lesson" :hx-target "#app" :hx-swap "innerHTML"}
@@ -94,16 +141,16 @@
 
 
 (defn- error
-  [{:keys [correct-answer user-answer]}]
+  [{:keys [user-answer] :as props}]
   [:footer#lesson-footer
    {:tabindex "-1"
     :hx-on:htmx:afterSettle "var btn = this.querySelector('#lesson-next'); if(btn){btn.focus();}"}
-   [:div.lesson__footer.lesson__footer--error.page-footer
+    [:div.lesson__footer.lesson__footer--error.page-footer
     [:div.lesson__answer
      [:h3.lesson__answer-header "Ваш ответ:"]
      [:p.lesson__answer-body {:lang "de"} (or user-answer "")]
      [:h3.lesson__answer-header "Правильный ответ:"]
-     [:p.lesson__answer-body {:lang "de"} correct-answer]]
+     (answer-body props)]
     [:form {:hx-post "/lesson/next" :hx-target "#lesson-footer" :hx-swap "outerHTML"}
      [:div.lesson__action.page-footer__action
       [:button.big-button

--- a/src/client/views/lesson.cljs
+++ b/src/client/views/lesson.cljs
@@ -83,14 +83,12 @@
 (defn challenge
   "Renders a challenge - prompt text and instruction."
   [state & {:as attrs}]
-  (let [{:keys [prompt is-example? gloss-mismatch?]} (presenter.lesson/challenge-props state)]
+  (let [{:keys [prompt is-example?]} (presenter.lesson/challenge-props state)]
     [:div#lesson-challenge.lesson__challenge
      attrs
      [:h2.lesson__prompt
       {:lang "ru"}
       prompt]
-     (when gloss-mismatch?
-       [:p.lesson__gloss-warning "Перевод слова может быть неточным"])
      [:p.lesson__instruction
       (if is-example?
         "Переведите предложение на немецкий"

--- a/src/client/vocabulary.cljs
+++ b/src/client/vocabulary.cljs
@@ -49,6 +49,12 @@
             {:word-id id :created? true})))))))
 
 
+(defn find-duplicate-by-value
+  "Return existing vocab doc whose normalized value matches value."
+  [dbs value]
+  (find-duplicate dbs (domain/normalize-value value)))
+
+
 (defn get
   "Returns a word row by id, or nil if not found."
   [dbs word-id]

--- a/test/backend/examples_test.clj
+++ b/test/backend/examples_test.clj
@@ -18,7 +18,7 @@
                     provider/config (constantly {:api-url "https://api.groq.com/openai/v1/chat/completions"
                                                           :api-key "groq-test-key"
                                                           :model "openai/gpt-oss-20b"})]
-        (is (= ::request (sut/example-api-request "Hund" nil nil nil)))
+        (is (= ::request (sut/example-api-request "Hund" [] nil nil)))
         (let [{:keys [url method headers body]} @captured
               payload (cheshire/parse-string body true)]
           (is (= "https://api.groq.com/openai/v1/chat/completions" url))
@@ -80,7 +80,7 @@
                     provider/config (constantly {:api-url "https://example.test/openai/v1/chat/completions"
                                                           :api-key "openai-override-key"
                                                           :model "openai/gpt-oss-120b"})]
-        (is (= ::request (sut/example-api-request "Hund" "собака" nil nil)))
+        (is (= ::request (sut/example-api-request "Hund" ["собака"] nil nil)))
         (let [{:keys [url headers body]} @captured
               payload (cheshire/parse-string body true)]
           (is (= "https://example.test/openai/v1/chat/completions" url))
@@ -105,9 +105,27 @@
                                                  :api-key "openai-override-key"
                                                  :model "openai/gpt-oss-120b"})]
         (with-redefs [sut/example-max-tokens (constantly 180)]
-          (is (= ::request (sut/example-api-request "Hund" "собака" nil nil)))
+          (is (= ::request (sut/example-api-request "Hund" ["собака"] nil nil)))
           (let [payload (cheshire/parse-string (:body @captured) true)]
             (is (= 180 (:max_tokens payload)))))))))
+
+
+(deftest example-api-request-serializes-translations-as-array
+  (testing "user prompt sends every confirmed translation so the model can pick the fitting sense"
+    (let [captured (atom nil)]
+      (with-redefs [client/request (fn [request]
+                                     (reset! captured request)
+                                     ::request)
+                    provider/config (constantly {:api-url "https://api.groq.com/openai/v1/chat/completions"
+                                                 :api-key "groq-test-key"
+                                                 :model "openai/gpt-oss-20b"})]
+        (is (= ::request (sut/example-api-request "Bank" ["банк" "скамейка"] nil nil)))
+        (let [payload      (cheshire/parse-string (:body @captured) true)
+              user-message (get-in payload [:messages 1 :content])
+              payload-line (re-find #"(?m)^\{.*\}$" user-message)
+              user-payload (cheshire/parse-string payload-line true)]
+          (is (= ["банк" "скамейка"] (:translation user-payload)))
+          (is (= "Bank" (:word user-payload))))))))
 
 
 (deftest example-api-request-includes-retry-feedback
@@ -129,7 +147,7 @@
         (is (= ::request
                (sut/example-api-request
                 "Leiter"
-                "лестница"
+                ["лестница"]
                 nil
                 {:example rejected-example
                  :issue   :target-gloss-mismatch})))
@@ -172,7 +190,7 @@
                      :dictionaryForm "aufstehen"
                      :translation "to stand up"}]}]
       (is (= :malformed-example
-             (:issue (#'sut/example-issue "aufstehen" "вставать" example)))))))
+             (:issue (#'sut/example-issue "aufstehen" ["вставать"] example)))))))
 
 
 (deftest deterministic-example-issues-reject-target-present-only-in-structure
@@ -195,7 +213,7 @@
                      :translation "парк"}]}]
       (with-redefs [dictionary/lookup-dictionary-entries (constantly nil)]
         (is (= :structure-mismatch
-               (:issue (#'sut/example-issue "Leiter" "лестница" example))))))))
+               (:issue (#'sut/example-issue "Leiter" ["лестница"] example))))))))
 
 
 (deftest deterministic-example-issues-reject-used-form-at-wrong-word-index
@@ -215,7 +233,7 @@
                      :translation "душа"}]}]
       (with-redefs [dictionary/lookup-dictionary-entries (constantly nil)]
         (is (= :structure-mismatch
-               (:issue (#'sut/example-issue "aufpassen" "беречь" example))))))))
+               (:issue (#'sut/example-issue "aufpassen" ["беречь"] example))))))))
 
 
 (deftest deterministic-example-issues-reject-duplicate-structure-items
@@ -238,7 +256,7 @@
                      :translation "беречь"}]}]
       (with-redefs [dictionary/lookup-dictionary-entries (constantly nil)]
         (is (= :structure-mismatch
-               (:issue (#'sut/example-issue "aufpassen" "беречь" example))))))))
+               (:issue (#'sut/example-issue "aufpassen" ["беречь"] example))))))))
 
 
 (deftest add-word-indexes-handles-last-separable-prefix
@@ -282,7 +300,7 @@
                      :dictionaryForm "der Park"
                      :translation "парк"}]}]
       (is (= :malformed-example
-             (:issue (#'sut/example-issue "Hund" "собака" example)))))))
+             (:issue (#'sut/example-issue "Hund" ["собака"] example)))))))
 
 
 (deftest valid-generated-example-rejects-small-latin-tail-in-translation
@@ -304,7 +322,7 @@
                      :dictionaryForm "der Park"
                      :translation "парк"}]}]
       (is (= :malformed-example
-             (:issue (#'sut/example-issue "Hund" "собака" example)))))))
+             (:issue (#'sut/example-issue "Hund" ["собака"] example)))))))
 
 
 (deftest valid-generated-example-rejects-latin-in-structure-translation
@@ -326,7 +344,7 @@
                      :dictionaryForm "der Park"
                      :translation "парк"}]}]
       (is (= :malformed-example
-             (:issue (#'sut/example-issue "Hund" "собака" example)))))))
+             (:issue (#'sut/example-issue "Hund" ["собака"] example)))))))
 
 
 (deftest valid-generated-example-rejects-cyrillic-in-german-sentence
@@ -342,7 +360,7 @@
                      :dictionaryForm "der Park"
                      :translation "парк"}]}]
       (is (= :malformed-example
-             (:issue (#'sut/example-issue "Hund" "собака" example)))))))
+             (:issue (#'sut/example-issue "Hund" ["собака"] example)))))))
 
 
 (deftest valid-generated-example-rejects-multiple-sentences
@@ -361,7 +379,7 @@
                      :dictionaryForm "schnell"
                      :translation "быстрый"}]}]
       (is (= :malformed-example
-             (:issue (#'sut/example-issue "Hund" "собака" example)))))))
+             (:issue (#'sut/example-issue "Hund" ["собака"] example)))))))
 
 
 (deftest valid-generated-example-rejects-colon-prefixed-german-meta
@@ -380,7 +398,7 @@
                      :dictionaryForm "der Park"
                      :translation "парк"}]}]
       (is (= :malformed-example
-             (:issue (#'sut/example-issue "Hund" "собака" example)))))))
+             (:issue (#'sut/example-issue "Hund" ["собака"] example)))))))
 
 
 (deftest valid-generated-example-rejects-colon-prefixed-russian-meta
@@ -399,7 +417,7 @@
                      :dictionaryForm "der Park"
                      :translation "парк"}]}]
       (is (= :malformed-example
-             (:issue (#'sut/example-issue "Hund" "собака" example)))))))
+             (:issue (#'sut/example-issue "Hund" ["собака"] example)))))))
 
 
 (deftest deterministic-example-issues-allow-three-word-sentence
@@ -418,7 +436,7 @@
         (is (= nil
                (#'sut/example-issue
                 "Hund"
-                "собака"
+                ["собака"]
                 example)))))))
 
 
@@ -441,7 +459,7 @@
         (is (= nil
                (#'sut/example-issue
                 "Leiter"
-                "лестница"
+                ["лестница"]
                 example)))))))
 
 
@@ -467,7 +485,7 @@
         (is (= nil
                (#'sut/example-issue
                 "vorstellen"
-                "представляться"
+                ["представляться"]
                 example)))))))
 
 
@@ -544,7 +562,7 @@
 
 
 (deftest dictionary-gloss-validation-allows-overlapping-translation-variants
-  (testing "expected and dictionary glosses may match through shared translation variants"
+  (testing "validation accepts when any supplied gloss matches the dictionary entry"
     (with-redefs [dictionary/lookup-dictionary-entries
                   (fn [_dictionary-form]
                     [{:_id "lemma:die leiter:noun"
@@ -552,7 +570,7 @@
                       :translation [{:lang "ru" :value "лестница"}]}])]
       (is (true? (dictionary/word-gloss-valid?
                   "Leiter"
-                  "лестница, стремянка"
+                  ["лестница" "стремянка"]
                   [{:usedForm "Leiter"
                     :dictionaryForm "die Leiter"
                     :translation "лестница"}]))))))

--- a/test/backend/examples_test.clj
+++ b/test/backend/examples_test.clj
@@ -28,7 +28,7 @@
           (is (= "openai/gpt-oss-20b" (:model payload)))
           (is (= 300 (:max_tokens payload)))
           (is (= "json_schema" (get-in payload [:response_format :type])))
-          (is (= ["value" "translation" "glossMismatch" "structure"]
+          (is (= ["value" "translation" "structure"]
                  (get-in payload [:response_format :json_schema :schema :required])))
           (is (= "array"
                  (get-in payload [:response_format :json_schema :schema :properties :structure :type])))
@@ -87,7 +87,7 @@
           (is (= "Bearer openai-override-key" (get headers "Authorization")))
           (is (= "openai/gpt-oss-120b" (:model payload)))
           (is (= 300 (:max_tokens payload)))
-          (is (= ["value" "translation" "glossMismatch" "structure"]
+          (is (= ["value" "translation" "structure"]
                  (get-in payload [:response_format :json_schema :schema :required])))
           (is (= ["usedForm" "dictionaryForm" "translation"]
                  (get-in payload [:response_format :json_schema :schema :properties :structure :items :required])))
@@ -133,7 +133,6 @@
     (let [captured (atom nil)
           rejected-example {:value "Der Leiter steht neben der Wand."
                             :translation "Лестница стоит рядом со стеной."
-                            :glossMismatch false
                             :structure
                             [{:usedForm "Leiter"
                               :dictionaryForm "der Leiter"
@@ -150,13 +149,13 @@
                 ["лестница"]
                 nil
                 {:example rejected-example
-                 :issue   :target-gloss-mismatch})))
+                 :issue   :structure-mismatch})))
         (let [payload      (cheshire/parse-string (:body @captured) true)
               user-message (get-in payload [:messages 1 :content])]
           (is (re-find #"previousAttempt" user-message))
           (is (re-find #"previousIssue" user-message))
-          (is (re-find #"target-gloss-mismatch" user-message))
-          (is (re-find #"structure `translation` contradicts" user-message))
+          (is (re-find #"structure-mismatch" user-message))
+          (is (re-find #"Items in `structure` must appear in strict left-to-right order" user-message))
           (is (re-find #"Der Leiter steht neben der Wand" user-message)))))))
 
 
@@ -169,7 +168,6 @@
                     (cheshire/generate-string
                      {:value "The example for 'aufstehen' is ..."
                       :translation "to stand up"
-                      :glossMismatch true
                       :structure
                       [{:usedForm "aufstehen"
                         :dictionaryForm "aufstehen"
@@ -184,7 +182,6 @@
   (testing "structurally invalid examples return only the structural issue"
     (let [example {:value "The example for 'aufstehen' is ..."
                    :translation "to stand up"
-                   :glossMismatch true
                    :structure
                    [{:usedForm "aufstehen"
                      :dictionaryForm "aufstehen"
@@ -197,7 +194,6 @@
   (testing "target forms mentioned only in structure do not count as present in the sentence"
     (let [example {:value "Der Hund läuft schnell im Park."
                    :translation "Собака быстро бежит по парку."
-                   :glossMismatch false
                    :structure
                    [{:usedForm "Leiter"
                      :dictionaryForm "die Leiter"
@@ -220,7 +216,6 @@
   (testing "structure items must stay in left-to-right sentence order"
     (let [example {:value "Pass auf deine Seele auf."
                    :translation "Береги свою душу."
-                   :glossMismatch false
                    :structure
                    [{:usedForm "auf"
                      :dictionaryForm "aufpassen"
@@ -240,7 +235,6 @@
   (testing "duplicate {usedForm, dictionaryForm} pairs reject the structure (e.g. a doubled separable-verb prefix mistaken for a preposition)"
     (let [example {:value "Pass auf deine Sachen auf!"
                    :translation "Береги свои вещи!"
-                   :glossMismatch false
                    :structure
                    [{:usedForm "Pass"
                      :dictionaryForm "aufpassen"
@@ -263,7 +257,6 @@
   (testing "backend assigns the final token index for a detached prefix near punctuation"
     (let [example {:value "Pass gut auf das kleine Kind auf!"
                    :translation "Присмотри внимательно за маленьким ребёнком!"
-                   :glossMismatch false
                    :structure
                    [{:usedForm "Pass"
                      :dictionaryForm "aufpassen"
@@ -285,7 +278,6 @@
   (testing "translation must be predominantly Cyrillic, not mixed with English"
     (let [example {:value "Der Hund läuft schnell im Park."
                    :translation "The dog runs quickly in the park, собака."
-                   :glossMismatch false
                    :structure
                    [{:usedForm "Hund"
                      :dictionaryForm "der Hund"
@@ -307,7 +299,6 @@
   (testing "translation must not keep even a small Latin fragment"
     (let [example {:value "Der Hund läuft schnell im Park."
                    :translation "Собака бежит fast."
-                   :glossMismatch false
                    :structure
                    [{:usedForm "Hund"
                      :dictionaryForm "der Hund"
@@ -329,7 +320,6 @@
   (testing "structure item translation must not keep Latin fragments either"
     (let [example {:value "Der Hund läuft schnell im Park."
                    :translation "Собака быстро бежит по парку."
-                   :glossMismatch false
                    :structure
                    [{:usedForm "Hund"
                      :dictionaryForm "der Hund"
@@ -351,7 +341,6 @@
   (testing "german sentence should not contain Cyrillic text"
     (let [example {:value "Der Hund бежит по парку."
                    :translation "Собака бежит по парку."
-                   :glossMismatch false
                    :structure
                    [{:usedForm "Hund"
                      :dictionaryForm "der Hund"
@@ -367,7 +356,6 @@
   (testing "german example must contain exactly one sentence"
     (let [example {:value "Der Hund läuft. Er ist schnell."
                    :translation "Собака бежит. Она быстрая."
-                   :glossMismatch false
                    :structure
                    [{:usedForm "Hund"
                      :dictionaryForm "der Hund"
@@ -386,7 +374,6 @@
   (testing "german value should look like a plain sentence, not a prefixed explanation"
     (let [example {:value "Sentence: Der Hund läuft im Park."
                    :translation "Собака бежит в парке."
-                   :glossMismatch false
                    :structure
                    [{:usedForm "Hund"
                      :dictionaryForm "der Hund"
@@ -405,7 +392,6 @@
   (testing "russian translation should look like a plain sentence, not a prefixed explanation"
     (let [example {:value "Der Hund läuft im Park."
                    :translation "Перевод: Собака бежит в парке."
-                   :glossMismatch false
                    :structure
                    [{:usedForm "Hund"
                      :dictionaryForm "der Hund"
@@ -424,7 +410,6 @@
   (testing "simple three-word sentence is acceptable"
     (let [example {:value "Der Hund schläft."
                    :translation "Собака спит."
-                   :glossMismatch false
                    :structure
                    [{:usedForm "Hund"
                      :dictionaryForm "der Hund"
@@ -440,34 +425,10 @@
                 example)))))))
 
 
-(deftest deterministic-example-issues-ignore-gloss-mismatch-flag
-  (testing "glossMismatch alone does not reject an otherwise valid example"
-    (let [example {:value "Die Leiter steht neben der Wand."
-                   :translation "Лестница стоит рядом со стеной."
-                   :glossMismatch true
-                   :structure
-                   [{:usedForm "Leiter"
-                     :dictionaryForm "die Leiter"
-                     :translation "лестница"}
-                    {:usedForm "steht"
-                     :dictionaryForm "stehen"
-                     :translation "стоять"}
-                    {:usedForm "Wand"
-                     :dictionaryForm "die Wand"
-                     :translation "стена"}]}]
-      (with-redefs [dictionary/lookup-dictionary-entries (constantly nil)]
-        (is (= nil
-               (#'sut/example-issue
-                "Leiter"
-                ["лестница"]
-                example)))))))
-
-
 (deftest target-dictionary-form-allows-reflexive-lemma-match
   (testing "non-article target can match reflexive dictionary form"
     (let [example {:value "Er stellt sich heute freundlich vor."
                    :translation "Он сегодня дружелюбно представляется."
-                   :glossMismatch false
                    :structure
                    [{:usedForm "stellt"
                      :dictionaryForm "sich vorstellen"
@@ -493,14 +454,12 @@
   (testing "best-of-N style retries can skip a bad candidate and keep a later valid one"
     (let [bad-example {:value "Die Leiter."
                        :translation "Лестница стоит рядом со стеной."
-                       :glossMismatch false
                        :structure
                        [{:usedForm "Leiter"
                          :dictionaryForm "die Leiter"
                          :translation "лестница"}]}
           good-example {:value "Die Leiter steht neben der Wand."
                         :translation "Лестница стоит рядом со стеной."
-                        :glossMismatch false
                         :structure
                         [{:usedForm "Leiter"
                           :dictionaryForm "die Leiter"
@@ -527,60 +486,10 @@
                @retry-contexts))))))
 
 
-(deftest generate-one-keeps-example-when-dictionary-gloss-disagrees
-  (testing "dictionary gloss mismatch keeps the example and marks glossMismatch for the client"
-    (let [example {:value "Pass auf deine Sachen auf!"
-                   :translation "Береги свои вещи!"
-                   :glossMismatch false
-                   :structure
-                   [{:usedForm "Pass"
-                     :dictionaryForm "aufpassen"
-                     :translation "беречь"}
-                    {:usedForm "Sachen"
-                     :dictionaryForm "die Sache"
-                     :translation "вещи"}
-                    {:usedForm "auf"
-                     :dictionaryForm "aufpassen"
-                     :translation "беречь"}]}
-          calls (atom 0)]
-      (with-redefs [sut/generate-attempt! (fn [_word _translation _word-meta _retry-context]
-                                            (swap! calls inc)
-                                            example)
-                    dictionary/lookup-dictionary-entries
-                    (fn [dictionary-form]
-                      (case dictionary-form
-                        "aufpassen" [{:_id "lemma:aufpassen:verb"
-                                      :value "aufpassen"
-                                      :translation [{:lang "ru" :value "присматривать"}]}]
-                        "die Sache" [{:_id "lemma:die sache:noun"
-                                      :value "die Sache"
-                                      :translation [{:lang "ru" :value "вещь"}]}]
-                        []))]
-        (is (= (assoc (#'sut/add-word-indexes example) :glossMismatch true)
-               (sut/generate-one! {:word "aufpassen" :translation "беречь"} 3)))
-        (is (= 1 @calls))))))
-
-
-(deftest dictionary-gloss-validation-allows-overlapping-translation-variants
-  (testing "validation accepts when any supplied gloss matches the dictionary entry"
-    (with-redefs [dictionary/lookup-dictionary-entries
-                  (fn [_dictionary-form]
-                    [{:_id "lemma:die leiter:noun"
-                      :value "die Leiter"
-                      :translation [{:lang "ru" :value "лестница"}]}])]
-      (is (true? (dictionary/word-gloss-valid?
-                  "Leiter"
-                  ["лестница" "стремянка"]
-                  [{:usedForm "Leiter"
-                    :dictionaryForm "die Leiter"
-                    :translation "лестница"}]))))))
-
-
 (deftest generate-one-accepts-map-input
   (testing "single-item API accepts {:word :translation} input"
     (let [example {:value "Die Leiter steht neben der Wand."
                    :translation "Лестница стоит рядом со стеной."
-                   :glossMismatch false
                    :structure
                    [{:usedForm "Leiter"
                      :dictionaryForm "die Leiter"

--- a/test/backend/examples_test.clj
+++ b/test/backend/examples_test.clj
@@ -26,6 +26,7 @@
           (is (= "Bearer groq-test-key" (get headers "Authorization")))
           (is (= "application/json" (get headers "Content-Type")))
           (is (= "openai/gpt-oss-20b" (:model payload)))
+          (is (= 300 (:max_tokens payload)))
           (is (= "json_schema" (get-in payload [:response_format :type])))
           (is (= ["value" "translation" "glossMismatch" "structure"]
                  (get-in payload [:response_format :json_schema :schema :required])))
@@ -35,6 +36,8 @@
                  (get-in payload [:response_format :json_schema :schema :properties :structure :items :type])))
           (is (= ["usedForm" "dictionaryForm" "translation"]
                  (get-in payload [:response_format :json_schema :schema :properties :structure :items :required])))
+          (is (nil?
+               (get-in payload [:response_format :json_schema :schema :properties :structure :items :properties :wordIndex])))
           (is (= "sentence_example" (get-in payload [:response_format :json_schema :name])))
           (is (string? (get-in payload [:messages 0 :content])))
           (is (re-find #"learner-facing German example sentences"
@@ -42,6 +45,12 @@
           (is (re-find #"part of speech"
                        (get-in payload [:messages 0 :content])))
           (is (re-find #"Ich stehe jeden Morgen um sieben Uhr auf"
+                       (get-in payload [:messages 0 :content])))
+          (is (re-find #"Er passt auf die Kinder auf"
+                       (get-in payload [:messages 0 :content])))
+          (is (re-find #"Separable verbs emit the prefix exactly once"
+                       (get-in payload [:messages 0 :content])))
+          (is (re-find #"Never emit two `structure` items with the same `usedForm` and `dictionaryForm` pair"
                        (get-in payload [:messages 0 :content])))
           (is (re-find #"sich vorstellen"
                        (get-in payload [:messages 0 :content])))
@@ -52,6 +61,10 @@
           (is (re-find #"die Leiter"
                        (get-in payload [:messages 0 :content])))
           (is (re-find #"Each item in `structure` must be a JSON object"
+                       (get-in payload [:messages 0 :content])))
+          (is (re-find #"Order `structure` items strictly left to right"
+                       (get-in payload [:messages 0 :content])))
+          (is (re-find #"The backend assigns `wordIndex`; do not return `wordIndex`"
                        (get-in payload [:messages 0 :content])))
           (is (re-find #"Never use arrays like"
                        (get-in payload [:messages 0 :content])))
@@ -73,10 +86,28 @@
           (is (= "https://example.test/openai/v1/chat/completions" url))
           (is (= "Bearer openai-override-key" (get headers "Authorization")))
           (is (= "openai/gpt-oss-120b" (:model payload)))
+          (is (= 300 (:max_tokens payload)))
           (is (= ["value" "translation" "glossMismatch" "structure"]
                  (get-in payload [:response_format :json_schema :schema :required])))
+          (is (= ["usedForm" "dictionaryForm" "translation"]
+                 (get-in payload [:response_format :json_schema :schema :properties :structure :items :required])))
           (is (re-find #"собака"
                        (get-in payload [:messages 1 :content]))))))))
+
+
+(deftest example-api-request-allows-max-tokens-env-override
+  (testing "max tokens can be overridden for example generation requests"
+    (let [captured (atom nil)]
+      (with-redefs [client/request (fn [request]
+                                     (reset! captured request)
+                                     ::request)
+                    provider/config (constantly {:api-url "https://example.test/openai/v1/chat/completions"
+                                                 :api-key "openai-override-key"
+                                                 :model "openai/gpt-oss-120b"})]
+        (with-redefs [sut/example-max-tokens (constantly 180)]
+          (is (= ::request (sut/example-api-request "Hund" "собака" nil nil)))
+          (let [payload (cheshire/parse-string (:body @captured) true)]
+            (is (= 180 (:max_tokens payload)))))))))
 
 
 (deftest example-api-request-includes-retry-feedback
@@ -101,12 +132,13 @@
                 "лестница"
                 nil
                 {:example rejected-example
-                 :issue   :target-dictionary-form-gloss-mismatch})))
+                 :issue   :target-gloss-mismatch})))
         (let [payload      (cheshire/parse-string (:body @captured) true)
               user-message (get-in payload [:messages 1 :content])]
           (is (re-find #"previousAttempt" user-message))
-          (is (re-find #"previousIssues" user-message))
-          (is (re-find #"target-dictionary-form-gloss-mismatch" user-message))
+          (is (re-find #"previousIssue" user-message))
+          (is (re-find #"target-gloss-mismatch" user-message))
+          (is (re-find #"structure `translation` contradicts" user-message))
           (is (re-find #"Der Leiter steht neben der Wand" user-message)))))))
 
 
@@ -139,11 +171,8 @@
                    [{:usedForm "aufstehen"
                      :dictionaryForm "aufstehen"
                      :translation "to stand up"}]}]
-      (is (= :invalid-generated-example
-             (#'sut/example-issue
-              "aufstehen"
-              "вставать"
-              example))))))
+      (is (= :malformed-example
+             (:issue (#'sut/example-issue "aufstehen" "вставать" example)))))))
 
 
 (deftest deterministic-example-issues-reject-target-present-only-in-structure
@@ -165,11 +194,73 @@
                      :dictionaryForm "der Park"
                      :translation "парк"}]}]
       (with-redefs [dictionary/lookup-dictionary-entries (constantly nil)]
-        (is (= :structure-value-mismatch
-               (#'sut/example-issue
-                "Leiter"
-                "лестница"
-                example)))))))
+        (is (= :structure-mismatch
+               (:issue (#'sut/example-issue "Leiter" "лестница" example))))))))
+
+
+(deftest deterministic-example-issues-reject-used-form-at-wrong-word-index
+  (testing "structure items must stay in left-to-right sentence order"
+    (let [example {:value "Pass auf deine Seele auf."
+                   :translation "Береги свою душу."
+                   :glossMismatch false
+                   :structure
+                   [{:usedForm "auf"
+                     :dictionaryForm "aufpassen"
+                     :translation "беречь"}
+                    {:usedForm "Pass"
+                     :dictionaryForm "aufpassen"
+                     :translation "беречь"}
+                    {:usedForm "Seele"
+                     :dictionaryForm "die Seele"
+                     :translation "душа"}]}]
+      (with-redefs [dictionary/lookup-dictionary-entries (constantly nil)]
+        (is (= :structure-mismatch
+               (:issue (#'sut/example-issue "aufpassen" "беречь" example))))))))
+
+
+(deftest deterministic-example-issues-reject-duplicate-structure-items
+  (testing "duplicate {usedForm, dictionaryForm} pairs reject the structure (e.g. a doubled separable-verb prefix mistaken for a preposition)"
+    (let [example {:value "Pass auf deine Sachen auf!"
+                   :translation "Береги свои вещи!"
+                   :glossMismatch false
+                   :structure
+                   [{:usedForm "Pass"
+                     :dictionaryForm "aufpassen"
+                     :translation "беречь"}
+                    {:usedForm "auf"
+                     :dictionaryForm "aufpassen"
+                     :translation "беречь"}
+                    {:usedForm "Sachen"
+                     :dictionaryForm "die Sache"
+                     :translation "вещи"}
+                    {:usedForm "auf"
+                     :dictionaryForm "aufpassen"
+                     :translation "беречь"}]}]
+      (with-redefs [dictionary/lookup-dictionary-entries (constantly nil)]
+        (is (= :structure-mismatch
+               (:issue (#'sut/example-issue "aufpassen" "беречь" example))))))))
+
+
+(deftest add-word-indexes-handles-last-separable-prefix
+  (testing "backend assigns the final token index for a detached prefix near punctuation"
+    (let [example {:value "Pass gut auf das kleine Kind auf!"
+                   :translation "Присмотри внимательно за маленьким ребёнком!"
+                   :glossMismatch false
+                   :structure
+                   [{:usedForm "Pass"
+                     :dictionaryForm "aufpassen"
+                     :translation "присматривать"}
+                    {:usedForm "gut"
+                     :dictionaryForm "gut"
+                     :translation "хорошо"}
+                    {:usedForm "Kind"
+                     :dictionaryForm "das Kind"
+                     :translation "ребёнок"}
+                    {:usedForm "auf"
+                     :dictionaryForm "aufpassen"
+                     :translation "присматривать"}]}]
+      (is (= [0 1 5 6]
+             (mapv :wordIndex (:structure (#'sut/add-word-indexes example))))))))
 
 
 (deftest valid-generated-example-rejects-mixed-language-translation
@@ -190,8 +281,8 @@
                     {:usedForm "Park"
                      :dictionaryForm "der Park"
                      :translation "парк"}]}]
-      (is (= :invalid-generated-example
-             (#'sut/example-issue "Hund" "собака" example))))))
+      (is (= :malformed-example
+             (:issue (#'sut/example-issue "Hund" "собака" example)))))))
 
 
 (deftest valid-generated-example-rejects-small-latin-tail-in-translation
@@ -212,8 +303,8 @@
                     {:usedForm "Park"
                      :dictionaryForm "der Park"
                      :translation "парк"}]}]
-      (is (= :invalid-generated-example
-             (#'sut/example-issue "Hund" "собака" example))))))
+      (is (= :malformed-example
+             (:issue (#'sut/example-issue "Hund" "собака" example)))))))
 
 
 (deftest valid-generated-example-rejects-latin-in-structure-translation
@@ -234,8 +325,8 @@
                     {:usedForm "Park"
                      :dictionaryForm "der Park"
                      :translation "парк"}]}]
-      (is (= :invalid-generated-example
-             (#'sut/example-issue "Hund" "собака" example))))))
+      (is (= :malformed-example
+             (:issue (#'sut/example-issue "Hund" "собака" example)))))))
 
 
 (deftest valid-generated-example-rejects-cyrillic-in-german-sentence
@@ -250,8 +341,8 @@
                     {:usedForm "Park"
                      :dictionaryForm "der Park"
                      :translation "парк"}]}]
-      (is (= :invalid-generated-example
-             (#'sut/example-issue "Hund" "собака" example))))))
+      (is (= :malformed-example
+             (:issue (#'sut/example-issue "Hund" "собака" example)))))))
 
 
 (deftest valid-generated-example-rejects-multiple-sentences
@@ -269,8 +360,8 @@
                     {:usedForm "schnell"
                      :dictionaryForm "schnell"
                      :translation "быстрый"}]}]
-      (is (= :invalid-generated-example
-             (#'sut/example-issue "Hund" "собака" example))))))
+      (is (= :malformed-example
+             (:issue (#'sut/example-issue "Hund" "собака" example)))))))
 
 
 (deftest valid-generated-example-rejects-colon-prefixed-german-meta
@@ -288,8 +379,8 @@
                     {:usedForm "Park"
                      :dictionaryForm "der Park"
                      :translation "парк"}]}]
-      (is (= :invalid-generated-example
-             (#'sut/example-issue "Hund" "собака" example))))))
+      (is (= :malformed-example
+             (:issue (#'sut/example-issue "Hund" "собака" example)))))))
 
 
 (deftest valid-generated-example-rejects-colon-prefixed-russian-meta
@@ -307,8 +398,8 @@
                     {:usedForm "Park"
                      :dictionaryForm "der Park"
                      :translation "парк"}]}]
-      (is (= :invalid-generated-example
-             (#'sut/example-issue "Hund" "собака" example))))))
+      (is (= :malformed-example
+             (:issue (#'sut/example-issue "Hund" "собака" example)))))))
 
 
 (deftest deterministic-example-issues-allow-three-word-sentence
@@ -410,7 +501,7 @@
                                                    (swap! responses subvec 1)
                                                    next-example))
                     dictionary/lookup-dictionary-entries (constantly nil)]
-        (is (= good-example
+        (is (= (#'sut/add-word-indexes good-example)
                (sut/generate-one! {:word "Leiter" :translation "лестница"} 2)))
         (is (= [nil
                 {:example bad-example
@@ -418,51 +509,38 @@
                @retry-contexts))))))
 
 
-(deftest generate-one-retries-when-dictionary-gloss-disagrees
-  (testing "backend dictionary validation rejects a wrong noun article for the intended gloss"
-    (let [bad-example {:value "Der Leiter steht neben der Wand."
-                       :translation "Лестница стоит рядом со стеной."
-                       :glossMismatch false
-                       :structure
-                       [{:usedForm "Leiter"
-                         :dictionaryForm "der Leiter"
-                         :translation "лестница"}
-                        {:usedForm "steht"
-                         :dictionaryForm "stehen"
-                         :translation "стоять"}
-                        {:usedForm "Wand"
-                          :dictionaryForm "die Wand"
-                          :translation "стена"}]}
-          good-example {:value "Die Leiter steht neben der Wand."
-                        :translation "Лестница стоит рядом со стеной."
-                        :glossMismatch false
-                        :structure
-                        [{:usedForm "Leiter"
-                          :dictionaryForm "die Leiter"
-                          :translation "лестница"}
-                         {:usedForm "steht"
-                          :dictionaryForm "stehen"
-                          :translation "стоять"}
-                         {:usedForm "Wand"
-                          :dictionaryForm "die Wand"
-                          :translation "стена"}]}
-          responses (atom [bad-example good-example])]
-      (with-redefs [sut/generate-attempt!      (fn [_word _translation _word-meta _retry-context]
-                                                 (let [next-example (first @responses)]
-                                                   (swap! responses subvec 1)
-                                                   next-example))
+(deftest generate-one-keeps-example-when-dictionary-gloss-disagrees
+  (testing "dictionary gloss mismatch keeps the example and marks glossMismatch for the client"
+    (let [example {:value "Pass auf deine Sachen auf!"
+                   :translation "Береги свои вещи!"
+                   :glossMismatch false
+                   :structure
+                   [{:usedForm "Pass"
+                     :dictionaryForm "aufpassen"
+                     :translation "беречь"}
+                    {:usedForm "Sachen"
+                     :dictionaryForm "die Sache"
+                     :translation "вещи"}
+                    {:usedForm "auf"
+                     :dictionaryForm "aufpassen"
+                     :translation "беречь"}]}
+          calls (atom 0)]
+      (with-redefs [sut/generate-attempt! (fn [_word _translation _word-meta _retry-context]
+                                            (swap! calls inc)
+                                            example)
                     dictionary/lookup-dictionary-entries
                     (fn [dictionary-form]
                       (case dictionary-form
-                        "der Leiter" [{:_id "lemma:der leiter:noun"
-                                       :value "der Leiter"
-                                       :translation [{:lang "ru" :value "руководитель"}]}]
-                        "die Leiter" [{:_id "lemma:die leiter:noun"
-                                       :value "die Leiter"
-                                       :translation [{:lang "ru" :value "лестница"}]}]
+                        "aufpassen" [{:_id "lemma:aufpassen:verb"
+                                      :value "aufpassen"
+                                      :translation [{:lang "ru" :value "присматривать"}]}]
+                        "die Sache" [{:_id "lemma:die sache:noun"
+                                      :value "die Sache"
+                                      :translation [{:lang "ru" :value "вещь"}]}]
                         []))]
-        (is (= good-example
-               (sut/generate-one! {:word "Leiter" :translation "лестница"} 2)))))))
+        (is (= (assoc (#'sut/add-word-indexes example) :glossMismatch true)
+               (sut/generate-one! {:word "aufpassen" :translation "беречь"} 3)))
+        (is (= 1 @calls))))))
 
 
 (deftest dictionary-gloss-validation-allows-overlapping-translation-variants
@@ -492,7 +570,7 @@
       (with-redefs [sut/generate-attempt! (fn [_word _translation _word-meta _retry-context]
                                             example)
                     dictionary/lookup-dictionary-entries (constantly nil)]
-        (is (= example
+        (is (= (#'sut/add-word-indexes example)
                (sut/generate-one! {:word "Leiter" :translation "лестница"} 1)))))))
 
 

--- a/test/client/domain/lesson_test.cljs
+++ b/test/client/domain/lesson_test.cljs
@@ -136,6 +136,26 @@
     (is (= "der Hund" (sut/expected-answer state)))))
 
 
+(deftest answer-segments-builds-annotated-and-plain-words
+  (testing "example answer segments use wordIndex to annotate matching words"
+    (let [trial {:type      "example"
+                 :word-id   "word-1"
+                 :answer    "Der Hund schlaeft."
+                 :structure [{:usedForm "Hund"
+                              :dictionaryForm "der Hund"
+                              :translation "пёс"
+                              :wordIndex 1}
+                             {:usedForm "schlaeft"
+                              :dictionaryForm "schlafen"
+                              :translation "спать"
+                              :wordIndex 2}]}
+          segments (sut/answer-segments trial)]
+      (is (= [{:type :plain-word :text "Der" :word-index 0}
+              {:type :annotated-word :text "Hund" :used-form "Hund" :dictionary-form "der Hund" :translation "пёс" :word-index 1}
+              {:type :annotated-word :text "schlaeft." :used-form "schlaeft" :dictionary-form "schlafen" :translation "спать" :word-index 2}]
+             segments)))))
+
+
 ;; =============================================================================
 ;; normalized-answer
 ;; =============================================================================

--- a/test/client/examples_test.cljs
+++ b/test/client/examples_test.cljs
@@ -280,6 +280,34 @@
           (set! js/fetch original-fetch))))))
 
 
+(deftest task-handler-sends-all-confirmed-translations
+  (async-testing "task handler sends every confirmed Russian translation as a repeated query param"
+    (let [example        {:value "Wir sitzen auf einer Bank im Park." :translation "Мы сидим на скамейке в парке."}
+          requested-url  (atom nil)
+          original-fetch js/fetch]
+      (set! js/fetch
+            (fn [url]
+              (reset! requested-url url)
+              ((fetch-mocks/mock-fetch-success example) url)))
+      (p/finally
+        (with-test-dbs
+         (fn [dbs]
+           (p/do
+             (db/insert (:user/db dbs) {:_id "word-bank"
+                                        :type "vocab"
+                                        :value "Bank"
+                                        :translation [{:lang "ru" :value "банк"}
+                                                      {:lang "ru" :value "скамейка"}]})
+             (p/let [_ (tasks/execute-task
+                        {:task-type "example-fetch"
+                         :data      {:word-id "word-bank"}}
+                        dbs)]
+               (is (= "/api/examples?word=Bank&translation=%D0%B1%D0%B0%D0%BD%D0%BA&translation=%D1%81%D0%BA%D0%B0%D0%BC%D0%B5%D0%B9%D0%BA%D0%B0"
+                      @requested-url))))))
+        (fn []
+          (set! js/fetch original-fetch))))))
+
+
 (deftest task-handler-returns-false-on-fetch-failure
   (async-testing "task handler returns false on fetch failure"
     (let [original-fetch js/fetch]

--- a/test/client/lesson_test.cljs
+++ b/test/client/lesson_test.cljs
@@ -253,6 +253,38 @@
            (is (false? (:locked? trial)))))))))
 
 
+(deftest add-word-from-structure-creates-vocab-and-fetch-task
+  (async-testing "`add-word-from-structure!` adds vocab and schedules fetch task"
+    (with-test-dbs
+     (fn [dbs]
+       (let [fetch-tasks (atom [])]
+         (p/with-redefs [examples/create-fetch-task! (fn [word-id]
+                                                       (swap! fetch-tasks conj word-id)
+                                                       (p/resolved nil))]
+           (p/let [result (sut/add-word-from-structure! dbs "die Seele" "душа")
+                   words  (db-queries/fetch-by-type (:user/db dbs) "vocab")]
+             (is (true? (:created? result)))
+             (is (= ["die Seele"] (mapv :value words)))
+             (is (= [(:word-id result)] @fetch-tasks)))))))))
+
+
+(deftest add-word-from-structure-skips-fetch-task-for-duplicate
+  (async-testing "`add-word-from-structure!` skips fetch task for duplicate"
+    (with-test-dbs
+     (fn [dbs]
+       (let [fetch-tasks (atom [])]
+         (p/do
+           (db-seed/seed-vocabulary! (:user/db dbs) [{:_id "word-1" :value "die Seele" :translation "душа"}])
+           (p/with-redefs [examples/create-fetch-task! (fn [word-id]
+                                                         (swap! fetch-tasks conj word-id)
+                                                         (p/resolved nil))]
+             (p/let [result (sut/add-word-from-structure! dbs "die Seele" "душа")
+                     words  (db-queries/fetch-by-type (:user/db dbs) "vocab")]
+               (is (false? (:created? result)))
+               (is (= 1 (count words)))
+               (is (empty? @fetch-tasks))))))))))
+
+
 (deftest check-answer-returns-error-when-no-lesson
   (async-testing "`check-answer!` errors when no lesson"
     (with-test-dbs

--- a/test/client/lesson_test.cljs
+++ b/test/client/lesson_test.cljs
@@ -7,6 +7,7 @@
    [client.support.time :as time]
    [db :as db]
    [domain.lesson :as domain]
+   [examples]
    [lesson :as sut]
    [promesa.core :as p]
    [utils :as utils])
@@ -251,6 +252,59 @@
                              first)]
            (is (some? trial))
            (is (false? (:locked? trial)))))))))
+
+
+;; =============================================================================
+;; token-info
+;; =============================================================================
+
+
+(deftest token-info-returns-unknown-for-missing-word
+  (async-testing "`token-info` reports unknown word when dictionary form not in vocabulary"
+    (with-test-dbs
+     (fn [dbs]
+       (p/let [info (sut/token-info dbs "die Seele" "душа")]
+         (is (= :unknown-word (:state info)))
+         (is (= "die Seele" (:dictionary-form info)))
+         (is (= "душа" (:translation info))))))))
+
+
+(deftest token-info-returns-known-when-translation-in-set
+  (async-testing "`token-info` reports known-with-translation when the gloss is already on the word"
+    (with-test-dbs
+     (fn [dbs]
+       (p/do
+         (db-seed/seed-vocabulary! (:user/db dbs) [{:_id "w" :value "die Seele" :translation "душа"}])
+         (p/let [info (sut/token-info dbs "die Seele" "душа")]
+           (is (= :known-with-translation (:state info)))))))))
+
+
+(deftest token-info-returns-missing-when-translation-not-in-set
+  (async-testing "`token-info` reports known-missing-translation when the gloss is new for an existing word"
+    (with-test-dbs
+     (fn [dbs]
+       (p/do
+         (db-seed/seed-vocabulary! (:user/db dbs) [{:_id "w" :value "die Bank" :translation "банк"}])
+         (p/let [info (sut/token-info dbs "die Bank" "скамейка")]
+           (is (= :known-missing-translation (:state info)))))))))
+
+
+(deftest add-word-from-structure-appends-translation-to-existing-word
+  (async-testing "`add-word-from-structure!` merges a new translation into an existing word's set"
+    (with-test-dbs
+     (fn [dbs]
+       (p/do
+         (db-seed/seed-vocabulary! (:user/db dbs) [{:_id "w" :value "die Bank" :translation "банк"}])
+         (let [fetch-tasks (atom [])]
+           (p/with-redefs [examples/create-fetch-task! (fn [word-id]
+                                                          (swap! fetch-tasks conj word-id)
+                                                          (p/resolved nil))]
+             (p/let [result (sut/add-word-from-structure! dbs "die Bank" "скамейка")
+                     word   (db/get (:user/db dbs) "w")]
+               (is (false? (:created? result)))
+               (is (empty? @fetch-tasks))
+               (is (= ["банк" "скамейка"]
+                      (mapv :value (:translation word))))))))))))
 
 
 (deftest add-word-from-structure-creates-vocab-and-fetch-task

--- a/test/client/presenter/lesson_test.cljs
+++ b/test/client/presenter/lesson_test.cljs
@@ -21,23 +21,39 @@
                                       :word-id "word-1"
                                       :prompt  "Пёс спит"
                                       :answer  "Der Hund schlaeft."
+                                      :structure [{:usedForm "Hund"
+                                                   :dictionaryForm "der Hund"
+                                                   :translation "пёс"
+                                                   :wordIndex 1}]
                                       :locked? false}]
                  :remaining-trials  [{:type    "example"
                                       :word-id "word-1"
                                       :prompt  "Пёс спит"
                                       :answer  "Der Hund schlaeft."
+                                      :structure [{:usedForm "Hund"
+                                                   :dictionaryForm "der Hund"
+                                                   :translation "пёс"
+                                                   :wordIndex 1}]
                                       :locked? false}]
                  :current-trial     {:type    "example"
                                      :word-id "word-1"
                                      :prompt  "Пёс спит"
                                      :answer  "Der Hund schlaeft."
+                                     :structure [{:usedForm "Hund"
+                                                  :dictionaryForm "der Hund"
+                                                  :translation "пёс"
+                                                  :wordIndex 1}]
                                      :locked? false}
                  :last-result       {:correct? false
                                      :answer   "Mein Hund schlaeft"}}
           props (sut/footer-props state)]
       (is (= :error (:variant props)))
       (is (= "Mein Hund schlaeft" (:user-answer props)))
-      (is (= "Der Hund schlaeft." (:correct-answer props))))))
+      (is (= "Der Hund schlaeft." (:correct-answer props)))
+      (is (= [{:type :plain-word :text "Der" :word-index 0}
+              {:type :annotated-word :text "Hund" :used-form "Hund" :dictionary-form "der Hund" :translation "пёс" :word-index 1}
+              {:type :plain-word :text "schlaeft." :word-index 2}]
+             (:correct-answer-segments props))))))
 
 
 (deftest footer-props-includes-user-answer-for-word-trial

--- a/test/client/support/fixtures.cljs
+++ b/test/client/support/fixtures.cljs
@@ -61,7 +61,14 @@
     :word        "der Hund"
     :value       "Der Hund schlaeft."
     :translation "Пёс спит"
-    :structure   []
+    :structure   [{:usedForm "Hund"
+                   :dictionaryForm "der Hund"
+                   :translation "пёс"
+                   :wordIndex 1}
+                  {:usedForm "schlaeft"
+                   :dictionaryForm "schlafen"
+                   :translation "спать"
+                   :wordIndex 2}]
     :created-at  "2024-08-20T10:00:00.000Z"}])
 
 
@@ -85,6 +92,14 @@
     :word-id "word-1"
     :prompt  "Пёс спит"
     :answer  "Der Hund schlaeft."
+    :structure [{:usedForm "Hund"
+                 :dictionaryForm "der Hund"
+                 :translation "пёс"
+                 :wordIndex 1}
+                {:usedForm "schlaeft"
+                 :dictionaryForm "schlafen"
+                 :translation "спать"
+                 :wordIndex 2}]
     :gloss-mismatch nil
     :locked? true}])
 

--- a/test/client/support/fixtures.cljs
+++ b/test/client/support/fixtures.cljs
@@ -100,7 +100,6 @@
                  :dictionaryForm "schlafen"
                  :translation "спать"
                  :wordIndex 2}]
-    :gloss-mismatch nil
     :locked? true}])
 
 


### PR DESCRIPTION
Summary:
- add word indexes to generated example structure
- show answer-token popovers with add-to-vocabulary actions
- remove stale gloss-mismatch warning from lesson flow

Verification:
- clojure -M:test -e "(require 'backend.examples-test)(clojure.test/run-tests 'backend.examples-test)"
- npx shadow-cljs compile node-test
- npx shadow-cljs compile app

Closes #133