### PR TITLE
GH-137 Update project dependencies

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -15,18 +15,18 @@ jobs:
           distribution: temurin
           java-version: 21
 
-      - uses: actions/setup-node@v6.2.0
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: 20
           cache: npm
           cache-dependency-path: package-lock.json
 
-      - uses: DeLaGuardo/setup-clojure@13.5.2
+      - uses: DeLaGuardo/setup-clojure@13.6.0
         with:
           cli: latest
 
       - id: cache-clojure
-        uses: actions/cache/restore@v5.0.2
+        uses: actions/cache/restore@v5.0.5
         with:
           path: |
             ~/.m2/repository
@@ -40,7 +40,7 @@ jobs:
       - run: clojure -T:build uber
       - run: cp target/learning-app.jar target/learning-app.jar.tmp
 
-      - uses: actions/cache/save@v5.0.2
+      - uses: actions/cache/save@v5.0.5
         if: ${{ always() && steps.cache-clojure.outputs.cache-hit != 'true' }}
         with:
           path: |
@@ -59,7 +59,7 @@ jobs:
           target: '/opt/learning-app/'
           overwrite: true
 
-      - uses: appleboy/ssh-action@v1.2.4
+      - uses: appleboy/ssh-action@v1.2.5
         with:
           host: ${{ secrets.HOST }}
           username: ${{ secrets.USER }}

--- a/.github/workflows/deploy-dictionary.yml
+++ b/.github/workflows/deploy-dictionary.yml
@@ -15,12 +15,12 @@ jobs:
           distribution: temurin
           java-version: 21
 
-      - uses: DeLaGuardo/setup-clojure@13.5.2
+      - uses: DeLaGuardo/setup-clojure@13.6.0
         with:
           cli: latest
 
       - id: cache-clojure
-        uses: actions/cache/restore@v5.0.2
+        uses: actions/cache/restore@v5.0.5
         with:
           path: |
             ~/.m2/repository
@@ -30,7 +30,7 @@ jobs:
 
       - run: clojure -T:build dictionary-import
 
-      - uses: actions/cache/save@v5.0.2
+      - uses: actions/cache/save@v5.0.5
         if: ${{ always() && steps.cache-clojure.outputs.cache-hit != 'true' }}
         with:
           path: |
@@ -40,7 +40,7 @@ jobs:
           key: clojure-${{ hashFiles('deps.edn') }}
 
       - name: Verify dictionary directories access
-        uses: appleboy/ssh-action@v1.2.4
+        uses: appleboy/ssh-action@v1.2.5
         with:
           host: ${{ secrets.HOST }}
           username: ${{ secrets.USER }}
@@ -98,7 +98,7 @@ jobs:
           overwrite: true
 
       - name: Run dictionary import service and smoke checks
-        uses: appleboy/ssh-action@v1.2.4
+        uses: appleboy/ssh-action@v1.2.5
         with:
           host: ${{ secrets.HOST }}
           username: ${{ secrets.USER }}

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -25,7 +25,7 @@ jobs:
           overwrite: true
 
       - name: Install infra deb and restart app
-        uses: appleboy/ssh-action@v1.2.4
+        uses: appleboy/ssh-action@v1.2.5
         with:
           host: ${{ secrets.HOST }}
           username: ${{ secrets.USER }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -45,18 +45,18 @@ jobs:
           distribution: temurin
           java-version: 21
 
-      - uses: actions/setup-node@v6.2.0
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: 20
           cache: npm
           cache-dependency-path: package-lock.json
 
-      - uses: DeLaGuardo/setup-clojure@13.5.2
+      - uses: DeLaGuardo/setup-clojure@13.6.0
         with:
           cli: latest
 
       - id: cache-clojure
-        uses: actions/cache/restore@v5.0.2
+        uses: actions/cache/restore@v5.0.5
         with:
           path: |
             ~/.m2/repository
@@ -72,7 +72,7 @@ jobs:
           npx shadow-cljs compile node-test
           node target/node-tests.js
 
-      - uses: actions/cache/save@v5.0.2
+      - uses: actions/cache/save@v5.0.5
         if: ${{ always() && steps.cache-clojure.outputs.cache-hit != 'true' }}
         with:
           path: |

--- a/deps.edn
+++ b/deps.edn
@@ -1,19 +1,19 @@
 {:paths   ["src/backend" "src/shared" "resources"]
 
  :deps    {buddy/buddy-hashers               {:mvn/version "2.0.167"}
-           cheshire/cheshire                 {:mvn/version "6.1.0"}
+           cheshire/cheshire                 {:mvn/version "6.2.0"}
            com.github.seancorfield/honeysql  {:mvn/version "2.7.1368"}
-           com.github.seancorfield/next.jdbc {:mvn/version "1.3.1086"}
+           com.github.seancorfield/next.jdbc {:mvn/version "1.3.1093"}
            com.lambdaisland/hiccup           {:mvn/version "0.14.67"}
            com.taoensso/telemere             {:mvn/version "1.2.1"}
            funcool/promesa                   {:mvn/version "11.0.678"}
            http-kit/http-kit                 {:mvn/version "2.8.1"}
            metosin/malli                     {:mvn/version "0.20.1"}
-           metosin/reitit                    {:mvn/version "0.10.0"}
+           metosin/reitit                    {:mvn/version "0.10.1"}
            org.clojure/clojure               {:mvn/version "1.12.4"}
-           org.xerial/sqlite-jdbc            {:mvn/version "3.51.1.0"}
+           org.xerial/sqlite-jdbc            {:mvn/version "3.53.0.0"}
            philoskim/debux-stubs             {:mvn/version "0.9.1"}
-           ring/ring                         {:mvn/version "1.15.3"}}
+           ring/ring                         {:mvn/version "1.15.4"}}
 
  :aliases {:dev   {:jvm-opts    ["-Djdk.attach.allowAttachSelf"] ; https://docs.cider.mx/cider/basics/up_and_running.html#enabling-nrepl-jvmti-agent
                    :extra-deps  {philoskim/debux {:mvn/version "0.9.1"}}
@@ -22,18 +22,18 @@
            :test  {:extra-paths ["test"]}
 
            :build {:deps       {org.clojure/clojure           {:mvn/version "1.12.4"}
-                                io.github.clojure/tools.build {:git/tag "v0.10.12" :git/sha "216ff79"}}
+                                io.github.clojure/tools.build {:git/tag "v0.10.13" :git/sha "3a3c177"}}
                    :ns-default build}
 
            :dictionary {:extra-paths ["tools/dictionary"]
-                        :extra-deps  {org.clojure/data.csv  {:mvn/version "1.1.0"}
-                                      org.clojure/tools.cli {:mvn/version "1.3.250"}}
+                        :extra-deps  {org.clojure/data.csv  {:mvn/version "1.1.1"}
+                                      org.clojure/tools.cli {:mvn/version "1.4.256"}}
                         :jvm-opts    ["-Dclojure.compiler.direct-linking=true" "-Xmx4g"]
                         :main-opts   ["-m" "dictionary.core"]}
 
            :test-dictionary {:extra-paths ["test/dictionary" "tools/dictionary"]
-                             :extra-deps  {org.clojure/data.csv  {:mvn/version "1.1.0"}
-                                           org.clojure/tools.cli {:mvn/version "1.3.250"}
+                             :extra-deps  {org.clojure/data.csv  {:mvn/version "1.1.1"}
+                                           org.clojure/tools.cli {:mvn/version "1.4.256"}
                                            io.github.cognitect-labs/test-runner
                                            {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
                              :main-opts   ["-m" "cognitect.test-runner"

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -1,10 +1,10 @@
 {:dependencies
  [[binaryage/devtools "1.0.7"]
-  [cheshire/cheshire "6.1.0"]
-  [cider/cider-nrepl "0.58.0"]
+  [cheshire/cheshire "6.2.0"]
+  [cider/cider-nrepl "0.59.0"]
   [com.lambdaisland/glogi "1.3.169"]
   [funcool/promesa "11.0.678"]
-  [metosin/reitit "0.10.0"]
+  [metosin/reitit "0.10.1"]
   [metosin/sieppari "0.0.0-alpha13"]
   [philoskim/debux "0.9.1"]
   [refactor-nrepl/refactor-nrepl "3.11.0"]

--- a/tools/dictionary/dictionary/transform.clj
+++ b/tools/dictionary/dictionary/transform.clj
@@ -24,6 +24,7 @@
     "postp"
     "prep"
     "pron"
+    "unknown"
     "verb"})
 
 


### PR DESCRIPTION
Summary:
- update dependencies reported by clj -M:outdated
- update GitHub Actions pins reported by clj -M:outdated
- allow dictionary entries with unknown POS, fixing existing dictionary test failure exposed during verification

Verification:
- clj -M:outdated
- clojure -M:test -e "(require 'backend.core-test 'backend.examples-test)(clojure.test/run-tests 'backend.core-test 'backend.examples-test)"
- npx shadow-cljs compile node-test
- npx shadow-cljs compile app
- clojure -T:build uber
- clojure -M:test-dictionary

Notes:
- final clj -M:outdated still reports timeouts for already-updated org.clojure/data.csv, org.clojure/tools.cli, org.xerial/sqlite-jdbc and failed fetch for metosin/sieppari alpha; no newer confirmed version was available from successful output.

Closes #137