### PR TITLE
GH-139 Fix GitHub project workflow management

### DIFF
--- a/.codex/skills/gh-project-workflow/SKILL.md
+++ b/.codex/skills/gh-project-workflow/SKILL.md
@@ -27,12 +27,15 @@ gh auth refresh -s project
 - Set these environment variables before running scripts:
   - `GHWF_OWNER` (project owner login)
   - `GHWF_REPO` (`owner/repo`)
-  - `GHWF_PROJECT_NUMBER` (Project V2 number)
+  - `GHWF_PROJECT_NUMBER` (Project V2 number; this repo uses `2` for the `Learning app` project)
 - Optionally set:
   - `GHWF_AREA_FIELD` (default: `Area`, optional if your project does not expose it)
+  - `GHWF_PRIORITY_FIELD` (default: `Priority`)
+  - `GHWF_SIZE_FIELD` (default: `Size`)
   - `GHWF_STATUS_FIELD` (default: `Status`)
   - `GHWF_DEFAULT_ASSIGNEES` (default: `@me`)
-  - `GHWF_DEFAULT_STATUS` (default: `Todo`)
+  - `GHWF_DEFAULT_STATUS` (default: `Backlog` in this repo)
+  - `GHWF_REVIEW_STATUS` (default: `In review` in this repo)
   - `GHWF_DONE_STATUS` (default: `Done`)
   - `GHWF_DEFAULT_BASE` (default: `master`)
   - `GHWF_DEPLOY_CMD` (deploy command used by `scripts/deploy.sh`)
@@ -46,18 +49,25 @@ Run this when the user wants to create a new item and begin implementation.
   --title "Add offline start screen" \
   --body "Allow basic lesson entry without network" \
   --area "Backend" \
-  --status "Todo" \
+  --priority "Major" \
+  --status "In progress" \
   --assignees "@me" \
   --labels "enhancement,offline" \
   --base master
 ```
 
 Important behavior:
-- Default mode (`--mode issue`) creates an issue first, adds it to project, sets fields, and creates/checks out a dev branch.
-- Draft mode (`--mode draft-convert`) creates a draft item, sets fields, converts it to an issue, then creates/checks out branch.
+- Before creating anything, the script searches the configured project for an exact-title item and reuses it when found.
+- Existing issue project items are reused as-is; existing draft items are converted to issues.
+- If `--issue <number>` is passed, that issue is reused and added to the project when needed.
+- If no project item exists, the script searches repo issues by exact title before creating a new issue.
+- Default mode (`--mode issue`) creates an issue only when no reusable project item or issue exists, adds it to project, sets fields, and creates/checks out a dev branch.
+- Draft mode (`--mode draft-convert`) creates a draft item only when no reusable item exists, sets fields, converts it to an issue, then creates/checks out branch.
 - Branch creation uses `gh issue develop <number> --checkout`.
-- Requested optional fields like `Area` are skipped with a warning when the target project does not expose them.
-- If no assignee or status is provided, the workflow defaults to `@me` and `Todo`.
+- Requested optional fields like `Area`, `Priority`, and `Size` are skipped with a warning when the target project does not expose them.
+- Missing labels are skipped with a warning instead of aborting issue creation.
+- If no assignee or status is provided, the workflow defaults to `@me` and `Backlog`.
+- For active work, pass `--status "In progress"` explicitly.
 - After the current task is merged or closed, do not keep reusing its branch/issue for the next non-trivial repo scope; start a fresh issue/branch unless the user is clearly asking only for final closeout steps.
 
 ## Finish Work
@@ -76,6 +86,8 @@ Important behavior:
 - Creates PR if needed.
 - Merges PR (or falls back to enabling auto-merge when direct merge is blocked).
 - After a successful merge, attempts to set the GitHub Project `Status` field to `Done`.
+- When a PR is created and merge is not skipped, attempts to set project `Status` to `In review` before merging.
+- After a successful merge, attempts to set project `Status` to `Done`.
 - Successful finish changes the task boundary: later repo work should be treated as a new issue/branch by default unless it is obviously just archive/deploy/closeout cleanup for the just-finished task.
 
 If the worktree contains unrelated local changes, prefer manual Git/PR steps instead of staging everything through the wrapper script.

--- a/.codex/skills/gh-project-workflow/references/config.env.example
+++ b/.codex/skills/gh-project-workflow/references/config.env.example
@@ -1,13 +1,16 @@
 # Required
 export GHWF_OWNER="@me"
 export GHWF_REPO="u473t8/learning-app"
-export GHWF_PROJECT_NUMBER="1"
+export GHWF_PROJECT_NUMBER="2"
 
 # Optional
 export GHWF_AREA_FIELD="Area"
+export GHWF_PRIORITY_FIELD="Priority"
+export GHWF_SIZE_FIELD="Size"
 export GHWF_STATUS_FIELD="Status"
 export GHWF_DEFAULT_ASSIGNEES="@me"
-export GHWF_DEFAULT_STATUS="Todo"
+export GHWF_DEFAULT_STATUS="Backlog"
+export GHWF_REVIEW_STATUS="In review"
 export GHWF_DONE_STATUS="Done"
 export GHWF_DEFAULT_BASE="master"
 export GHWF_DEPLOY_CMD="./infra/deploy.sh production"

--- a/.codex/skills/gh-project-workflow/scripts/finish_issue_flow.sh
+++ b/.codex/skills/gh-project-workflow/scripts/finish_issue_flow.sh
@@ -20,6 +20,7 @@ Options:
   --owner <login>               Project owner (default: GHWF_OWNER)
   --project-number <number>     Project number (default: GHWF_PROJECT_NUMBER)
   --status-field <name>         Field name (default: GHWF_STATUS_FIELD or Status)
+  --review-status <option>      Status option to set after PR creation (default: GHWF_REVIEW_STATUS or In review)
   --done-status <option>        Status option to set after merge (default: GHWF_DONE_STATUS or Done)
   --no-push                     Skip push
   --no-pr                       Skip PR creation
@@ -91,14 +92,14 @@ apply_single_select_field() {
     --single-select-option-id "$option_id" >/dev/null
 }
 
-mark_issue_done_in_project() {
+mark_issue_status_in_project() {
   local owner="$1"
   local project_number="$2"
   local issue_number="$3"
   local status_field="$4"
-  local done_status="$5"
+  local status="$5"
 
-  [[ -n "$owner" && -n "$project_number" && -n "$issue_number" ]] || return 0
+  [[ -n "$owner" && -n "$project_number" && -n "$issue_number" && -n "$status" ]] || return 0
 
   local project_id
   project_id="$(gh project view "$project_number" --owner "$owner" --format json --jq '.id' 2>/dev/null || true)"
@@ -111,7 +112,7 @@ mark_issue_done_in_project() {
   fields_json="$(normalize_fields_json "$(gh project field-list "$project_number" --owner "$owner" --format json)")"
 
   local item_json item_id
-  item_json="$(gh project item-list "$project_number" --owner "$owner" --limit 100 --format json)"
+  item_json="$(gh project item-list "$project_number" --owner "$owner" --limit "${GHWF_ITEM_LIMIT:-200}" --format json)"
   item_id="$(jq -r --argjson issue_number "$issue_number" '.items[] | select(.content.number? == $issue_number) | .id' <<<"$item_json" | head -n1)"
 
   [[ -n "$item_id" ]] || {
@@ -119,7 +120,7 @@ mark_issue_done_in_project() {
     return 0
   }
 
-  apply_single_select_field "$item_id" "$project_id" "$fields_json" "$status_field" "$done_status" true
+  apply_single_select_field "$item_id" "$project_id" "$fields_json" "$status_field" "$status" true
 }
 
 infer_repo_from_origin() {
@@ -138,6 +139,7 @@ repo="${GHWF_REPO:-}"
 owner="${GHWF_OWNER:-}"
 project_number="${GHWF_PROJECT_NUMBER:-}"
 status_field="${GHWF_STATUS_FIELD:-Status}"
+review_status="${GHWF_REVIEW_STATUS:-In review}"
 done_status="${GHWF_DONE_STATUS:-Done}"
 base_branch="${GHWF_DEFAULT_BASE:-master}"
 issue_number=""
@@ -200,6 +202,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --status-field)
       status_field="$2"
+      shift 2
+      ;;
+    --review-status)
+      review_status="$2"
       shift 2
       ;;
     --done-status)
@@ -328,6 +334,8 @@ if [[ "$skip_merge" -eq 1 ]]; then
   exit 0
 fi
 
+mark_issue_status_in_project "$owner" "$project_number" "$issue_number" "$status_field" "$review_status"
+
 merge_flag="--squash"
 if [[ "$merge_method" == "merge" ]]; then
   merge_flag="--merge"
@@ -346,7 +354,7 @@ fi
 
 pr_state="$(gh pr view "$pr_url" -R "$repo" --json state --jq '.state' 2>/dev/null || true)"
 if [[ "$pr_state" == "MERGED" ]]; then
-  mark_issue_done_in_project "$owner" "$project_number" "$issue_number" "$status_field" "$done_status"
+  mark_issue_status_in_project "$owner" "$project_number" "$issue_number" "$status_field" "$done_status"
 fi
 
 echo "Commit Message: $commit_message"

--- a/.codex/skills/gh-project-workflow/scripts/start_issue_flow.sh
+++ b/.codex/skills/gh-project-workflow/scripts/start_issue_flow.sh
@@ -13,8 +13,11 @@ Options:
   --body-file <path>            Body file path
   --labels <csv>                Comma-separated labels
   --assignees <csv>             Comma-separated assignees (supports @me)
+  --issue <number>              Reuse existing issue number instead of creating one
   --area <option>               Area field option to set
   --category <option>           Deprecated alias for --area
+  --priority <option>           Priority field option to set
+  --size <option>               Size field option to set
   --status <option>             Status field option to set
   --mode <issue|draft-convert>  Default: issue
   --owner <login>               Project owner (default: GHWF_OWNER)
@@ -22,9 +25,12 @@ Options:
   --project-number <number>     Project number (default: GHWF_PROJECT_NUMBER)
   --area-field <name>           Field name (default: GHWF_AREA_FIELD or Area)
   --category-field <name>       Deprecated alias for --area-field
+  --priority-field <name>       Field name (default: GHWF_PRIORITY_FIELD or Priority)
+  --size-field <name>           Field name (default: GHWF_SIZE_FIELD or Size)
   --status-field <name>         Field name (default: GHWF_STATUS_FIELD or Status)
   --base <branch>               Base branch for dev branch (default: GHWF_DEFAULT_BASE or master)
   --branch-name <name>          Override branch name
+  --no-reuse-existing           Do not reuse exact-title project item or issue
   --skip-branch                 Do not create/checkout development branch
   --help                        Show this help
 USAGE
@@ -92,10 +98,119 @@ apply_single_select_field() {
     --single-select-option-id "$option_id" >/dev/null
 }
 
+project_items_json() {
+  gh project item-list "$project_number" --owner "$owner" --limit "${GHWF_ITEM_LIMIT:-200}" --format json
+}
+
+find_project_item_by_title() {
+  local items_json="$1"
+  local item_title="$2"
+  jq -c --arg item_title "$item_title" '.items[] | select(.title == $item_title)' <<<"$items_json" | head -n1
+}
+
+find_project_item_by_issue_number() {
+  local items_json="$1"
+  local number="$2"
+  jq -c --argjson number "$number" '.items[] | select(.content.number? == $number)' <<<"$items_json" | head -n1
+}
+
+find_issue_by_title() {
+  local issue_title="$1"
+  gh issue list -R "$repo" --state all --search "$issue_title in:title" --limit 20 --json number,title,url \
+    | jq -c --arg issue_title "$issue_title" '.[] | select(.title == $issue_title)' \
+    | head -n1
+}
+
+label_exists() {
+  local label="$1"
+
+  if [[ -z "${labels_json:-}" ]]; then
+    labels_json="$(gh label list -R "$repo" --limit 200 --json name 2>/dev/null || true)"
+  fi
+
+  [[ -n "$labels_json" ]] || return 1
+  jq -e --arg label "$label" '.[] | select(.name == $label)' <<<"$labels_json" >/dev/null
+}
+
+append_existing_labels() {
+  local -n args_ref=$1
+  local csv="$2"
+  local flag="${3:---label}"
+
+  [[ -n "$csv" ]] || return 0
+
+  IFS=',' read -r -a labels <<<"$csv"
+  for label in "${labels[@]}"; do
+    label="$(trim "$label")"
+    [[ -n "$label" ]] || continue
+    if label_exists "$label"; then
+      args_ref+=("$flag" "$label")
+    else
+      echo "Warning: Label '$label' not found in repo '$repo', skipping" >&2
+    fi
+  done
+}
+
+append_assignees() {
+  local -n args_ref=$1
+  local csv="$2"
+  local flag="${3:---assignee}"
+
+  [[ -n "$csv" ]] || return 0
+
+  IFS=',' read -r -a assignees <<<"$csv"
+  for assignee in "${assignees[@]}"; do
+    assignee="$(trim "$assignee")"
+    [[ -n "$assignee" ]] && args_ref+=("$flag" "$assignee")
+  done
+}
+
+convert_project_draft_to_issue() {
+  local draft_item_id="$1"
+
+  local repo_id
+  repo_id="$(gh repo view "$repo" --json id --jq '.id')"
+  [[ -n "$repo_id" ]] || die "Failed to resolve repository id"
+
+  local convert_query convert_json
+  convert_query='mutation($projectItemId:ID!,$repositoryId:ID!){ convertProjectV2DraftIssueItemToIssue(input:{projectItemId:$projectItemId,repositoryId:$repositoryId}) { issue { number url } } }'
+  convert_json="$(gh api graphql -f query="$convert_query" -F projectItemId="$draft_item_id" -F repositoryId="$repo_id")"
+
+  issue_number="$(jq -r '.data.convertProjectV2DraftIssueItemToIssue.issue.number // empty' <<<"$convert_json")"
+  issue_url="$(jq -r '.data.convertProjectV2DraftIssueItemToIssue.issue.url // empty' <<<"$convert_json")"
+  [[ -n "$issue_number" && -n "$issue_url" ]] || die "Draft item conversion to issue failed"
+}
+
+use_project_item() {
+  local item="$1"
+
+  item_id="$(jq -r '.id // empty' <<<"$item")"
+  [[ -n "$item_id" ]] || die "Existing project item has no id"
+
+  local content_type
+  content_type="$(jq -r '.content.type // empty' <<<"$item")"
+
+  case "$content_type" in
+    Issue)
+      issue_number="$(jq -r '.content.number // empty' <<<"$item")"
+      issue_url="$(jq -r '.content.url // empty' <<<"$item")"
+      [[ -n "$issue_number" && -n "$issue_url" ]] || die "Existing issue item is missing issue data"
+      ;;
+    DraftIssue)
+      convert_project_draft_to_issue "$item_id"
+      ;;
+    *)
+      die "Existing project item '$title' is not an issue or draft issue"
+      ;;
+  esac
+}
+
 owner="${GHWF_OWNER:-}"
 repo="${GHWF_REPO:-}"
 project_number="${GHWF_PROJECT_NUMBER:-}"
 area_field="${GHWF_AREA_FIELD:-${GHWF_CATEGORY_FIELD:-Area}}"
+priority_field="${GHWF_PRIORITY_FIELD:-Priority}"
+size_field="${GHWF_SIZE_FIELD:-Size}"
 status_field="${GHWF_STATUS_FIELD:-Status}"
 base_branch="${GHWF_DEFAULT_BASE:-master}"
 
@@ -104,11 +219,16 @@ body=""
 body_file=""
 labels_csv=""
 assignees_csv="${GHWF_DEFAULT_ASSIGNEES:-@me}"
+issue_number_override=""
 area_option="${GHWF_DEFAULT_AREA:-}"
-status_option="${GHWF_DEFAULT_STATUS:-Todo}"
+priority_option="${GHWF_DEFAULT_PRIORITY:-}"
+size_option="${GHWF_DEFAULT_SIZE:-}"
+status_option="${GHWF_DEFAULT_STATUS:-Backlog}"
 mode="issue"
 branch_name=""
+reuse_existing=1
 skip_branch=0
+labels_json=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -132,12 +252,24 @@ while [[ $# -gt 0 ]]; do
       assignees_csv="$2"
       shift 2
       ;;
+    --issue)
+      issue_number_override="$2"
+      shift 2
+      ;;
     --area)
       area_option="$2"
       shift 2
       ;;
     --category)
       area_option="$2"
+      shift 2
+      ;;
+    --priority)
+      priority_option="$2"
+      shift 2
+      ;;
+    --size)
+      size_option="$2"
       shift 2
       ;;
     --status)
@@ -168,6 +300,14 @@ while [[ $# -gt 0 ]]; do
       area_field="$2"
       shift 2
       ;;
+    --priority-field)
+      priority_field="$2"
+      shift 2
+      ;;
+    --size-field)
+      size_field="$2"
+      shift 2
+      ;;
     --status-field)
       status_field="$2"
       shift 2
@@ -179,6 +319,10 @@ while [[ $# -gt 0 ]]; do
     --branch-name)
       branch_name="$2"
       shift 2
+      ;;
+    --no-reuse-existing)
+      reuse_existing=0
+      shift
       ;;
     --skip-branch)
       skip_branch=1
@@ -208,7 +352,43 @@ issue_url=""
 issue_number=""
 item_id=""
 
-if [[ "$mode" == "issue" ]]; then
+if [[ "$reuse_existing" -eq 1 ]]; then
+  items_json="$(project_items_json)"
+  existing_item=""
+
+  if [[ -n "$issue_number_override" ]]; then
+    existing_item="$(find_project_item_by_issue_number "$items_json" "$issue_number_override")"
+  fi
+
+  if [[ -z "$existing_item" ]]; then
+    existing_item="$(find_project_item_by_title "$items_json" "$title")"
+  fi
+
+  if [[ -n "$existing_item" ]]; then
+    use_project_item "$existing_item"
+  elif [[ -n "$issue_number_override" ]]; then
+    issue_number="$issue_number_override"
+    issue_url="$(gh issue view "$issue_number" -R "$repo" --json url --jq '.url')"
+    [[ -n "$issue_url" ]] || die "Issue #$issue_number not found"
+
+    item_json="$(gh project item-add "$project_number" --owner "$owner" --url "$issue_url" --format json)"
+    item_id="$(jq -r '.id // empty' <<<"$item_json")"
+    [[ -n "$item_id" ]] || die "Failed to add issue to project"
+  else
+    existing_issue="$(find_issue_by_title "$title")"
+    if [[ -n "$existing_issue" ]]; then
+      issue_number="$(jq -r '.number // empty' <<<"$existing_issue")"
+      issue_url="$(jq -r '.url // empty' <<<"$existing_issue")"
+      [[ -n "$issue_number" && -n "$issue_url" ]] || die "Existing issue is missing issue data"
+
+      item_json="$(gh project item-add "$project_number" --owner "$owner" --url "$issue_url" --format json)"
+      item_id="$(jq -r '.id // empty' <<<"$item_json")"
+      [[ -n "$item_id" ]] || die "Failed to add existing issue to project"
+    fi
+  fi
+fi
+
+if [[ -z "$issue_number" && "$mode" == "issue" ]]; then
   issue_args=(issue create -R "$repo" --title "$title")
 
   if [[ -n "$body_file" ]]; then
@@ -217,21 +397,8 @@ if [[ "$mode" == "issue" ]]; then
     issue_args+=(--body "$body")
   fi
 
-  if [[ -n "$labels_csv" ]]; then
-    IFS=',' read -r -a labels <<<"$labels_csv"
-    for label in "${labels[@]}"; do
-      label="$(trim "$label")"
-      [[ -n "$label" ]] && issue_args+=(--label "$label")
-    done
-  fi
-
-  if [[ -n "$assignees_csv" ]]; then
-    IFS=',' read -r -a assignees <<<"$assignees_csv"
-    for assignee in "${assignees[@]}"; do
-      assignee="$(trim "$assignee")"
-      [[ -n "$assignee" ]] && issue_args+=(--assignee "$assignee")
-    done
-  fi
+  append_existing_labels issue_args "$labels_csv"
+  append_assignees issue_args "$assignees_csv"
 
   issue_url="$(gh "${issue_args[@]}" | tail -n1 | tr -d '\r')"
   [[ -n "$issue_url" ]] || die "Issue creation failed"
@@ -241,7 +408,7 @@ if [[ "$mode" == "issue" ]]; then
   [[ -n "$item_id" ]] || die "Failed to add issue to project"
 
   issue_number="${issue_url##*/}"
-else
+elif [[ -z "$issue_number" ]]; then
   draft_args=(project item-create "$project_number" --owner "$owner" --title "$title" --format json)
 
   if [[ -n "$body_file" ]]; then
@@ -254,18 +421,21 @@ else
   item_id="$(jq -r '.id // empty' <<<"$item_json")"
   [[ -n "$item_id" ]] || die "Draft item creation failed"
 
-  repo_id="$(gh repo view "$repo" --json id --jq '.id')"
-  [[ -n "$repo_id" ]] || die "Failed to resolve repository id"
+  convert_project_draft_to_issue "$item_id"
+fi
 
-  convert_query='mutation($projectItemId:ID!,$repositoryId:ID!){ convertProjectV2DraftIssueItemToIssue(input:{projectItemId:$projectItemId,repositoryId:$repositoryId}) { issue { number url } } }'
-  convert_json="$(gh api graphql -f query="$convert_query" -F projectItemId="$item_id" -F repositoryId="$repo_id")"
-
-  issue_number="$(jq -r '.data.convertProjectV2DraftIssueItemToIssue.issue.number // empty' <<<"$convert_json")"
-  issue_url="$(jq -r '.data.convertProjectV2DraftIssueItemToIssue.issue.url // empty' <<<"$convert_json")"
-  [[ -n "$issue_number" && -n "$issue_url" ]] || die "Draft item conversion to issue failed"
+if [[ -n "$issue_number" ]]; then
+  edit_args=(issue edit "$issue_number" -R "$repo")
+  append_existing_labels edit_args "$labels_csv" "--add-label"
+  append_assignees edit_args "$assignees_csv" "--add-assignee"
+  if [[ "${#edit_args[@]}" -gt 5 ]]; then
+    gh "${edit_args[@]}" >/dev/null
+  fi
 fi
 
 apply_single_select_field "$item_id" "$project_id" "$fields_json" "$area_field" "$area_option" false
+apply_single_select_field "$item_id" "$project_id" "$fields_json" "$priority_field" "$priority_option" false
+apply_single_select_field "$item_id" "$project_id" "$fields_json" "$size_field" "$size_option" false
 apply_single_select_field "$item_id" "$project_id" "$fields_json" "$status_field" "$status_option" true
 
 checked_out_branch=""

--- a/.codex/skills/repo-task-delivery/SKILL.md
+++ b/.codex/skills/repo-task-delivery/SKILL.md
@@ -47,6 +47,8 @@ In those cases, use the narrower workflow skill directly.
 
 2. Start GitHub tracking.
    - Use `gh-project-workflow` to create the issue/project item and branch.
+   - First let `gh-project-workflow` search the configured project for an existing exact-title item or issue; reuse it instead of creating duplicates.
+   - This repo's active GitHub Project is user project `Learning app` number `2`; do not use older project `1`.
    - In this repo, prefer base branch `master`.
    - For bug reports, default category/type to bug-oriented values when the project supports them.
 


### PR DESCRIPTION
Summary:
- point workflow defaults at Learning app project #2, not old casino project #1
- reuse existing project items/issues before creating new ones
- convert matching draft project items to issues
- set Area, Priority, Size, and Status fields consistently
- skip missing labels with warnings instead of aborting
- widen project item lookup and document lifecycle rules

Verification:
- bash -n start_issue_flow.sh
- bash -n finish_issue_flow.sh
- start_issue_flow.sh --issue 139 --skip-branch reused existing project item
- verified #139 fields in Learning app: Area=AI, Priority=Trivial, Status=In progress

Closes #139