### PR TITLE
Improve text input UX

### DIFF
--- a/src/client/views/home.cljs
+++ b/src/client/views/home.cljs
@@ -47,6 +47,8 @@
          :autocapitalize "off"
          :autocomplete   "off"
          :autocorrect    "off"
+         :enterkeyhint   "next"
+         :spellcheck     "false"
          :data-ac-role   "word"
          :hx-get         "/dictionary-entries"
          :hx-include     "this"
@@ -66,15 +68,17 @@
         {:for "new-word-translation"}
         "Перевод (русский)"]
        [:input.home__add-form-input
-        {:id           "new-word-translation"
-         :name         "translation"
+        {:id             "new-word-translation"
+         :name           "translation"
          :autocapitalize "off"
-         :autocomplete "off"
-         :autocorrect  "off"
-         :data-ac-role "translation"
-         :lang         "ru"
-         :placeholder  "Перевод"
-         :required     true}]]]]
+         :autocomplete   "off"
+         :autocorrect    "off"
+         :enterkeyhint   "done"
+         :spellcheck     "false"
+         :data-ac-role   "translation"
+         :lang           "ru"
+         :placeholder    "Перевод"
+         :required       true}]]]]
 
     [:button.home__add-form-submit.big-button.big-button--request-stable
      {:type "submit"}

--- a/src/client/views/lesson.cljs
+++ b/src/client/views/lesson.cljs
@@ -108,12 +108,17 @@
      {:for "lesson-answer"}
      "Ответ на немецком"]
     [:textarea.lesson__input
-     {:id          "lesson-answer"
-      :name        "answer"
-      :rows        4
-      :placeholder "Введите перевод..."
-      :maxlength   1000
-      :lang        "de"
+     {:id             "lesson-answer"
+      :name           "answer"
+      :rows           4
+      :autocapitalize "off"
+      :autocomplete   "off"
+      :autocorrect    "off"
+      :enterkeyhint   "done"
+      :placeholder    "Введите перевод..."
+      :maxlength      1000
+      :lang           "de"
+      :spellcheck     "false"
       :hx-on:keydown
       "if(event.key==='Enter' && (event.ctrlKey || event.metaKey)){event.preventDefault(); this.form.requestSubmit();}"}]
     [:div.lesson__action.page-footer__action

--- a/src/client/views/vocabulary.cljs
+++ b/src/client/views/vocabulary.cljs
@@ -55,8 +55,10 @@
         :autocapitalize "off"
         :autocomplete   "off"
         :autocorrect    "off"
+        :enterkeyhint   "done"
         :lang           "ru"
         :placeholder    "Перевод"
+        :spellcheck     "false"
         :value          translation
         :autofocus      true
         :hx-on:focus    "this.setSelectionRange(this.value.length, this.value.length)"}]]
@@ -135,6 +137,7 @@
          :autocapitalize "off"
          :autocomplete   "off"
          :autocorrect    "off"
+         :enterkeyhint   "next"
          :data-ac-role   "word"
          :hx-get         "/dictionary-entries"
          :hx-trigger     "input changed delay:300ms"
@@ -146,23 +149,26 @@
          :lang           "de"
          :placeholder    "Новое слово"
          :required       true
+         :spellcheck     "false"
          :value          ""}])
 
       translation-blank?
       (conj
        [:input
-        {:class        base-input-classes
-         :hx-swap-oob  "true"
-         :id           "new-word-translation"
-         :name         "translation"
-         :data-ac-role "translation"
+        {:class          base-input-classes
+         :hx-swap-oob    "true"
+         :id             "new-word-translation"
+         :name           "translation"
+         :data-ac-role   "translation"
          :autocapitalize "off"
-         :autocomplete "off"
-         :autocorrect  "off"
-         :lang         "ru"
-         :placeholder  "Перевод"
-         :required     true
-         :value        ""}]))))
+         :autocomplete   "off"
+         :autocorrect    "off"
+         :enterkeyhint   "done"
+         :lang           "ru"
+         :placeholder    "Перевод"
+         :required       true
+         :spellcheck     "false"
+         :value          ""}]))))
 
 
 (defn- state-marker
@@ -207,14 +213,18 @@
          [:div.input
           [:span.input__search-icon]
           [:input.input__input-area.input__input-area--icon
-           {:autocomplete "off"
-            :hx-get       base-list-url
-            :placeholder  "Поиск"
-            :hx-target    "#word-list"
-            :hx-swap      "outerHTML"
-            :hx-sync      "this:replace"
-            :hx-trigger   "input changed delay:500ms, keyup[key=='Enter']"
-            :name         "search"}]]]
+           {:autocapitalize "off"
+            :autocomplete   "off"
+            :autocorrect    "off"
+            :enterkeyhint   "search"
+            :hx-get         base-list-url
+            :placeholder    "Поиск"
+            :spellcheck     "false"
+            :hx-target      "#word-list"
+            :hx-swap        "outerHTML"
+            :hx-sync        "this:replace"
+            :hx-trigger     "input changed delay:500ms, keyup[key=='Enter']"
+            :name           "search"}]]]
         [:div.vocabulary__list
          (word-list
           {:words-query words-query


### PR DESCRIPTION
## Summary
- disable browser rewriting helpers across learner-facing text inputs
- add mobile keyboard action hints for add/search/edit/lesson flows
- add lesson German character helper buttons for ä/ö/ü/ß
- archive OpenSpec change and add text-input-ux spec

## Verification
- npx shadow-cljs compile node-test
- OPENSPEC_TELEMETRY=0 openspec validate text-input-ux --strict
- Browser CDP smoke: home fields, vocabulary search, lesson answer attrs, and ß insertion/focus

Closes #142