### PR TITLE
Fix mobile autocapitalize handling

### DIFF
--- a/src/client/views/home.cljs
+++ b/src/client/views/home.cljs
@@ -25,12 +25,14 @@
 (defn- add-form
   [{:keys [oob?]}]
   [:form.home__add-form
-   (cond-> {:id            add-form-id
-            :hx-post       "/words"
-            :hx-push-url   "false"
-            :hx-swap       "none"
+   (cond-> {:id              add-form-id
+            :autocapitalize  "none"
+            :autocorrect     "off"
+            :hx-post         "/words"
+            :hx-push-url     "false"
+            :hx-swap         "none"
             :hx-disabled-elt "find button[type='submit']"
-            :hx-disinherit "hx-disabled-elt"}
+            :hx-disinherit   "hx-disabled-elt"}
      oob? (assoc :hx-swap-oob (str "outerHTML:#" add-form-id)))
    [:fieldset.home__add-fieldset
     [:legend.home__add-legend
@@ -44,7 +46,7 @@
        [:input.home__add-form-input
         {:id             "new-word-value"
          :name           "value"
-         :autocapitalize "off"
+         :autocapitalize "none"
          :autocomplete   "off"
          :autocorrect    "off"
          :enterkeyhint   "next"
@@ -70,7 +72,7 @@
        [:input.home__add-form-input
         {:id             "new-word-translation"
          :name           "translation"
-         :autocapitalize "off"
+         :autocapitalize "none"
          :autocomplete   "off"
          :autocorrect    "off"
          :enterkeyhint   "done"

--- a/src/client/views/lesson.cljs
+++ b/src/client/views/lesson.cljs
@@ -101,9 +101,11 @@
    {:hx-on:htmx:load input-focus-after-settle}
    ;; User focuses input manually (avoids auto keyboard open/layout jumps).
    [:form.lesson__footer.lesson__footer--input.page-footer
-    {:hx-post   "/lesson/answer"
-     :hx-target "#lesson-footer"
-     :hx-swap   "outerHTML"}
+    {:autocapitalize "none"
+     :autocorrect    "off"
+     :hx-post        "/lesson/answer"
+     :hx-target      "#lesson-footer"
+     :hx-swap        "outerHTML"}
     [:label.lesson__input-label
      {:for "lesson-answer"}
      "Ответ на немецком"]
@@ -111,7 +113,7 @@
      {:id             "lesson-answer"
       :name           "answer"
       :rows           4
-      :autocapitalize "off"
+      :autocapitalize "none"
       :autocomplete   "off"
       :autocorrect    "off"
       :enterkeyhint   "done"

--- a/src/client/views/vocabulary.cljs
+++ b/src/client/views/vocabulary.cljs
@@ -42,9 +42,11 @@
   (let [item-id  (str "word-" id)
         word-url (str "/words/" id)]
     [:form.word-edit-dialog__form
-     {:hx-put    word-url
-      :hx-target (str "#" item-id)
-      :hx-swap   "outerHTML"
+     {:autocapitalize "none"
+      :autocorrect    "off"
+      :hx-put         word-url
+      :hx-target      (str "#" item-id)
+      :hx-swap        "outerHTML"
       :hx-on:htmx:after-request
       "if(event.detail.successful) this.closest('dialog').close()"}
      [:div.word-edit-dialog__inputs
@@ -52,7 +54,7 @@
       [:span.word-edit-dialog__arrow {:aria-hidden "true"} "→"]
       [:input.word-edit-dialog__input
        {:name           "translation"
-        :autocapitalize "off"
+        :autocapitalize "none"
         :autocomplete   "off"
         :autocorrect    "off"
         :enterkeyhint   "done"
@@ -134,7 +136,7 @@
         {:class          base-input-classes
          :id             "new-word-value"
          :name           "value"
-         :autocapitalize "off"
+         :autocapitalize "none"
          :autocomplete   "off"
          :autocorrect    "off"
          :enterkeyhint   "next"
@@ -160,7 +162,7 @@
          :id             "new-word-translation"
          :name           "translation"
          :data-ac-role   "translation"
-         :autocapitalize "off"
+         :autocapitalize "none"
          :autocomplete   "off"
          :autocorrect    "off"
          :enterkeyhint   "done"
@@ -210,10 +212,12 @@
           "← Назад"]
          [:h1.vocabulary__title "Мои слова"]]
         [:form.vocabulary__search
+         {:autocapitalize "none"
+          :autocorrect    "off"}
          [:div.input
           [:span.input__search-icon]
           [:input.input__input-area.input__input-area--icon
-           {:autocapitalize "off"
+           {:autocapitalize "none"
             :autocomplete   "off"
             :autocorrect    "off"
             :enterkeyhint   "search"


### PR DESCRIPTION
## Summary
- switch learner text fields from autocapitalize=off to autocapitalize=none
- set form-level autocapitalize/autocorrect defaults for add, search, edit, and lesson answer flows
- keep the previous minimal text-input UX scope otherwise unchanged

## Why
On real mobile Safari/WebKit behavior, autocapitalize=off may not suppress the initial shifted keyboard state reliably. Apple docs recommend none, and form-level attributes provide inherited defaults.

## Verification
- npx shadow-cljs compile node-test

Follow-up to #142