### PR TITLE
Prevent finished or cancelled lessons from staying in browser history

### DIFF
--- a/openspec/changes/archive/2026-05-03-prevent-lesson-history-return/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-03-prevent-lesson-history-return/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-02

--- a/openspec/changes/archive/2026-05-03-prevent-lesson-history-return/design.md
+++ b/openspec/changes/archive/2026-05-03-prevent-lesson-history-return/design.md
@@ -1,0 +1,27 @@
+## Context
+
+Lesson entry uses HTMX navigation from home into `/lesson`. Lesson completion and cancellation both delete the local lesson state and render home into `#app`. Today exit navigation pushes `/home`, leaving the lesson URL and prior lesson screen in browser history.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make lesson completion replace the current history entry with `/home`.
+- Make explicit lesson cancellation use the same replacement behavior.
+- Preserve normal in-lesson answer and next-trial swaps.
+
+**Non-Goals:**
+
+- Do not change lesson persistence, trial selection, or progress semantics.
+- Do not add custom browser history JavaScript beyond HTMX metadata.
+
+## Decisions
+
+- Use HTMX replace-url semantics for lesson exit responses. HTMX already supports `HX-Replace-Url`, which matches the desired "current entry becomes home" behavior without custom client code.
+- Keep lesson entry as a pushed URL. The user can still land on a lesson URL while studying; only exit removes the completed or cancelled lesson screen from Back history.
+- Remove push-url from the cancel control and let the server response own the replacement URL. This keeps completion and cancellation behavior identical.
+
+## Risks / Trade-offs
+
+- Back behavior depends on HTMX history handling in the browser. Mitigation: verify with a browser-level flow, not only markup inspection.
+- Replacing only on exit means an unfinished active lesson still has a `/lesson` entry while the learner is inside it. This is intended; the requirement targets finished or cancelled lessons.

--- a/openspec/changes/archive/2026-05-03-prevent-lesson-history-return/proposal.md
+++ b/openspec/changes/archive/2026-05-03-prevent-lesson-history-return/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+Finished or cancelled lesson screens should not remain reachable through browser Back. After a learner exits the lesson flow, Back should return to the page before the lesson entry rather than restoring a completed or abandoned challenge.
+
+## What Changes
+
+- Replace lesson exit navigation history entries instead of pushing a new `/home` entry.
+- Apply the behavior to both final lesson completion and explicit lesson cancellation.
+- Keep lesson answer and next-trial interactions unchanged inside the lesson flow.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `lesson`: lesson exit history behavior changes for completion and cancellation.
+
+## Impact
+
+- Affects HTMX navigation metadata in lesson/home routes and lesson view controls.
+- No data model, dependency, or API shape changes.

--- a/openspec/changes/archive/2026-05-03-prevent-lesson-history-return/specs/lesson/spec.md
+++ b/openspec/changes/archive/2026-05-03-prevent-lesson-history-return/specs/lesson/spec.md
@@ -1,0 +1,14 @@
+## ADDED Requirements
+
+### Requirement: Lesson exit replaces browser history
+The system SHALL replace the current browser history entry when a learner exits a lesson through completion or cancellation.
+
+#### Scenario: Finished lesson exit
+- **WHEN** a learner completes the final lesson trial and exits the lesson flow
+- **THEN** the rendered home screen replaces the current lesson history entry with `/home`
+- **AND** the completed lesson screen is not restored by pressing browser Back
+
+#### Scenario: Cancelled lesson exit
+- **WHEN** a learner cancels an active lesson
+- **THEN** the rendered home screen replaces the current lesson history entry with `/home`
+- **AND** the cancelled lesson screen is not restored by pressing browser Back

--- a/openspec/changes/archive/2026-05-03-prevent-lesson-history-return/tasks.md
+++ b/openspec/changes/archive/2026-05-03-prevent-lesson-history-return/tasks.md
@@ -1,0 +1,10 @@
+## 1. Implementation
+
+- [x] 1.1 Update lesson exit response to replace the current browser URL with `/home`.
+- [x] 1.2 Update lesson cancellation control so exit history behavior is owned by the server response.
+
+## 2. Verification
+
+- [x] 2.1 Run OpenSpec validation for the change.
+- [x] 2.2 Run the relevant ClojureScript test/compile gate.
+- [x] 2.3 Verify browser history behavior for completed and cancelled lesson exits.

--- a/openspec/specs/lesson/spec.md
+++ b/openspec/specs/lesson/spec.md
@@ -101,3 +101,17 @@ The system SHALL keep example structure data on lesson example trials so the cor
 - **WHEN** lesson UI renders the correct answer for an example trial
 - **THEN** it builds answer segments from the German answer text plus each structure item `wordIndex`
 - **AND** annotated segments keep the matching `dictionaryForm` and `translation`
+
+### Requirement: Lesson exit replaces browser history
+The system SHALL replace the current browser history entry when a learner exits a lesson through completion or cancellation.
+
+#### Scenario: Finished lesson exit
+- **WHEN** a learner completes the final lesson trial and exits the lesson flow
+- **THEN** the rendered home screen replaces the current lesson history entry with `/home`
+- **AND** the completed lesson screen is not restored by pressing browser Back
+
+#### Scenario: Cancelled lesson exit
+- **WHEN** a learner cancels an active lesson
+- **THEN** the rendered home screen replaces the current lesson history entry with `/home`
+- **AND** the cancelled lesson screen is not restored by pressing browser Back
+

--- a/src/client/application.cljs
+++ b/src/client/application.cljs
@@ -237,7 +237,7 @@
                 (p/do
                   (lesson/finish! dbs)
                   (p/let [total (vocabulary/count dbs)]
-                    {:headers   {"HX-Push-Url" "/home"}
+                    {:headers   {"HX-Replace-Url" "/home"}
                      :html/body (views.home/page :empty-vocab? (zero? total))
                      :status    200})))}]
 

--- a/src/client/views/lesson.cljs
+++ b/src/client/views/lesson.cljs
@@ -212,7 +212,6 @@
       :type        "button"
       :aria-label  "Закрыть урок"
       :hx-delete   "/lesson"
-      :hx-push-url "true"
       :hx-target   "#app"
       :hx-swap     "innerHTML"}
      [:svg


### PR DESCRIPTION
## Summary
- replace the lesson exit URL instead of pushing /home
- remove cancel-button push-url so completion and cancellation use the same server-owned history behavior
- archive OpenSpec change prevent-lesson-history-return

## Verification
- OPENSPEC_TELEMETRY=0 openspec validate prevent-lesson-history-return --type change --json
- OPENSPEC_TELEMETRY=0 openspec validate lesson --type spec --json
- npx shadow-cljs compile node-test (131 tests, 311 assertions)
- browser CDP: finish lesson -> /home, Back -> /words, no lesson restored
- browser CDP: cancel lesson -> /home, Back -> /words, no lesson restored

Note: OPENSPEC_TELEMETRY=0 openspec validate --all --json still reports pre-existing unrelated active change lock-example-trials-until-word-success missing deltas.