### PR TITLE
GH-157 Make app reload work offline

### DIFF
--- a/openspec/changes/archive/2026-05-20-fix-offline-reload/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-20-fix-offline-reload/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-with-adr
+created: 2026-05-20

--- a/openspec/changes/archive/2026-05-20-fix-offline-reload/design.md
+++ b/openspec/changes/archive/2026-05-20-fix-offline-reload/design.md
@@ -1,0 +1,58 @@
+## Context
+
+The current Service Worker precaches `/` and static assets, but its fetch handler only responds to exact precache URL matches. A browser reload of `/home`, `/words`, or `/lesson` while offline is a navigation request for a route that is not in `PRECACHE_URLS`, so the request falls through to the network and Chromium shows its built-in offline page.
+
+In-force ADRs keep app execution on the main thread and use the Service Worker only as a passive cache layer. This change keeps that boundary: the Service Worker may return the cached static app shell document, but it must not run route logic, render hiccup, touch app state, or call APIs.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Offline reload of same-origin app routes returns the cached app shell instead of the browser offline page.
+- API calls and non-navigation resource failures do not receive the app shell as a fake response.
+- The Service Worker remains a cache/fallback layer, not an application runtime.
+- Browser verification proves actual Service Worker offline reload behavior.
+
+**Non-Goals:**
+
+- No new custom offline UI in this change.
+- No background sync, data sync, or task retry behavior changes.
+- No change to dictionary OPFS or PouchDB storage semantics.
+- No duplicate Cache Storage copy of the large dictionary SQLite file.
+
+## Decisions
+
+1. **Navigation-only fallback to cached `/`.**
+   - Decision: for same-origin `request.mode === "navigate"` requests outside `/api/`, try the network first; if it fails, return cached `/` from the precache.
+   - Rationale: this preserves fresh online navigations while giving offline reloads a deterministic app shell.
+   - Alternative considered: add every route to `PRECACHE_URLS`. Rejected because frontend routes are logical app states, not separate static documents.
+
+2. **Keep exact cache-first behavior for precached assets.**
+   - Decision: leave static asset handling cache-first for `PRECACHE_SET` paths.
+   - Rationale: the current asset behavior is working and independent from navigation fallback.
+   - Alternative considered: network-first all assets. Rejected as a larger caching policy change.
+
+3. **Do not fallback API/non-navigation requests to HTML.**
+   - Decision: only navigation requests can receive the cached app shell. `/api/` and worker/data requests either use their existing cache path or fail normally.
+   - Rationale: returning HTML for data requests hides failures and makes adapters harder to reason about.
+
+4. **Cache dictionary manifest as boot metadata.**
+   - Decision: cache `/dictionary/manifest` with network-first semantics and cached fallback.
+   - Rationale: an already-imported OPFS dictionary still needs the current manifest to find the content-addressed file while offline.
+   - Alternative considered: precache the whole dictionary SQLite file in Cache Storage. Rejected because that would duplicate the large dictionary beside OPFS.
+
+## Risks / Trade-offs
+
+- [Risk] First visit offline still cannot load because nothing is cached yet. → Mitigation: acceptance is for an already-loaded app with an installed Service Worker.
+- [Risk] A stale app shell can load after deploy while offline. → Mitigation: SW versioned cache already changes with deployed `SW_VERSION`; online visits refresh the cache.
+- [Risk] Browser verification can be flaky if the old SW controls the page. → Mitigation: force service-worker update/unregister or use update-on-reload during validation, then reload once online before switching offline.
+
+## Migration Plan
+
+- Update `sw.js` fetch handling.
+- Add focused tests/verification where feasible, plus browser smoke for real offline reload.
+- Archive the OpenSpec change before PR merge.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-05-20-fix-offline-reload/proposal.md
+++ b/openspec/changes/archive/2026-05-20-fix-offline-reload/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The app is marketed and used as offline-first, but an already-loaded app shows the browser's built-in "You're offline" page when network is disabled and the page is reloaded. This breaks the basic PWA promise: cached app routes must reload into our app shell, not into the browser error screen.
+
+## What Changes
+
+- Make the Service Worker serve the cached app shell for same-origin navigation requests when the network cannot provide the page.
+- Keep API requests and non-navigation resources out of the app-shell fallback path.
+- Cache the small dictionary manifest with network-first semantics so an already-imported OPFS dictionary can boot offline.
+- Keep the Service Worker passive: it may return cached static shell/assets, but it must not execute app logic, Ring handlers, or hiccup rendering.
+- Add verification for offline navigation reload behavior.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `main-thread-runtime`: clarify that passive Service Worker caching includes an offline navigation fallback to the cached app shell.
+
+## Impact
+
+- `resources/public/js/sw.js` fetch handling for navigation requests.
+- Main-thread runtime/PWA spec and OpenSpec archive.
+- Browser verification in real Chrome, because the bug is visible only through actual Service Worker control and offline reload behavior.

--- a/openspec/changes/archive/2026-05-20-fix-offline-reload/specs/main-thread-runtime/spec.md
+++ b/openspec/changes/archive/2026-05-20-fix-offline-reload/specs/main-thread-runtime/spec.md
@@ -1,0 +1,43 @@
+## MODIFIED Requirements
+
+### Requirement: Replicant renders all UI from state
+The system SHALL use Replicant to diff and apply hiccup data to the DOM; the Service Worker SHALL NOT render application UI or route-specific HTML at runtime, but it MAY return a cached static app shell document for navigation fallback.
+
+#### Scenario: Initial render
+- **WHEN** the app state atom is first populated after boot
+- **THEN** Replicant renders the current page hiccup on the document body
+
+#### Scenario: State update triggers re-render
+- **WHEN** a Nexus effect writes to the app state atom
+- **THEN** Replicant re-renders the affected DOM from hiccup/state
+
+#### Scenario: Offline navigation fallback still renders on main thread
+- **WHEN** the Service Worker returns the cached app shell for an offline navigation request
+- **THEN** `main.cljs` boots on the main thread
+- **AND** Replicant renders the current route from app state
+- **AND** the Service Worker does not render route-specific UI
+
+### Requirement: Service Worker is a passive cache layer only
+The system SHALL keep the Service Worker limited to static asset caching, navigation fallback to the cached app shell, and simple lifecycle/message handling; it SHALL NOT import application namespaces, execute route logic, call APIs, or render hiccup/application UI.
+
+#### Scenario: SW uses network first for app navigations
+- **WHEN** the Service Worker intercepts a same-origin navigation request for `/`, `/home`, `/words`, or `/lesson` while the network is available
+- **THEN** it tries the network request first
+- **AND** it uses the network response when that request succeeds
+- **AND** it does not execute any ring handler or hiccup renderer
+
+#### Scenario: SW serves cached app shell for offline app navigations
+- **WHEN** the Service Worker intercepts a same-origin navigation request for `/`, `/home`, `/words`, or `/lesson`
+- **AND** the network request fails because the browser is offline
+- **THEN** it returns the cached app shell document from `/`
+- **AND** the browser does not show its built-in offline page
+- **AND** the main-thread app boots and handles the route
+
+#### Scenario: SW does not fallback API requests to app shell
+- **WHEN** the Service Worker intercepts a request for `/api/*`
+- **THEN** it does not return the cached app shell document
+- **AND** the request fails or succeeds according to normal network behavior
+
+#### Scenario: SW precaches static assets
+- **WHEN** the SW installs
+- **THEN** it precaches the static assets listed in its manifest

--- a/openspec/changes/archive/2026-05-20-fix-offline-reload/tasks.md
+++ b/openspec/changes/archive/2026-05-20-fix-offline-reload/tasks.md
@@ -1,0 +1,16 @@
+## 1. Reproduce and Scope
+
+- [x] 1.1 Confirm current offline reload failure with a controlled Service Worker/browser run.
+- [x] 1.2 Identify the exact navigation/resource fetch paths that must and must not use app-shell fallback.
+
+## 2. Service Worker Implementation
+
+- [x] 2.1 Add navigation-only network-first fallback to cached `/` app shell.
+- [x] 2.2 Preserve cache-first behavior for precached static assets.
+- [x] 2.3 Ensure `/api/*` and non-navigation requests never receive HTML app-shell fallback.
+
+## 3. Verification and Spec Closeout
+
+- [x] 3.1 Run static/compile checks relevant to the changed client assets.
+- [x] 3.2 Verify in a real browser that offline reload shows the app, not Chromium's offline page.
+- [x] 3.3 Validate and archive the OpenSpec change before PR merge.

--- a/openspec/specs/main-thread-runtime/spec.md
+++ b/openspec/specs/main-thread-runtime/spec.md
@@ -18,7 +18,7 @@ The system SHALL initialise the application from a main-thread ClojureScript ent
 - **AND** it starts the frontend router last
 
 ### Requirement: Replicant renders all UI from state
-The system SHALL use Replicant to diff and apply hiccup data to the DOM; the Service Worker SHALL NOT serve application HTML at runtime.
+The system SHALL use Replicant to diff and apply hiccup data to the DOM; the Service Worker SHALL NOT render application UI or route-specific HTML at runtime, but it MAY return a cached static app shell document for navigation fallback.
 
 #### Scenario: Initial render
 - **WHEN** the app state atom is first populated after boot
@@ -27,6 +27,12 @@ The system SHALL use Replicant to diff and apply hiccup data to the DOM; the Ser
 #### Scenario: State update triggers re-render
 - **WHEN** a Nexus effect writes to the app state atom
 - **THEN** Replicant re-renders the affected DOM from hiccup/state
+
+#### Scenario: Offline navigation fallback still renders on main thread
+- **WHEN** the Service Worker returns the cached app shell for an offline navigation request
+- **THEN** `main.cljs` boots on the main thread
+- **AND** Replicant renders the current route from app state
+- **AND** the Service Worker does not render route-specific UI
 
 ### Requirement: Nexus dispatches all actions and effects
 The system SHALL use Nexus as the mechanism for mutating app state; UI events emit action maps, effect handlers perform side effects and write results into state.
@@ -59,12 +65,25 @@ The system SHALL maintain app state as namespaced flat page slices keyed by `:ap
 - **AND** `:app/page` and the current page slice remain intact
 
 ### Requirement: Service Worker is a passive cache layer only
-The system SHALL strip the Service Worker to static asset caching and simple lifecycle/message handling; it SHALL NOT import application namespaces or serve application HTML.
+The system SHALL keep the Service Worker limited to static asset caching, navigation fallback to the cached app shell, and simple lifecycle/message handling; it SHALL NOT import application namespaces, execute route logic, call APIs, or render hiccup/application UI.
 
-#### Scenario: SW does not handle app routes
-- **WHEN** the SW intercepts a fetch for `/home` or any app route not listed in its precache set
-- **THEN** it falls through to the network
+#### Scenario: SW uses network first for app navigations
+- **WHEN** the Service Worker intercepts a same-origin navigation request for `/`, `/home`, `/words`, or `/lesson` while the network is available
+- **THEN** it tries the network request first
+- **AND** it uses the network response when that request succeeds
 - **AND** it does not execute any ring handler or hiccup renderer
+
+#### Scenario: SW serves cached app shell for offline app navigations
+- **WHEN** the Service Worker intercepts a same-origin navigation request for `/`, `/home`, `/words`, or `/lesson`
+- **AND** the network request fails because the browser is offline
+- **THEN** it returns the cached app shell document from `/`
+- **AND** the browser does not show its built-in offline page
+- **AND** the main-thread app boots and handles the route
+
+#### Scenario: SW does not fallback API requests to app shell
+- **WHEN** the Service Worker intercepts a request for `/api/*`
+- **THEN** it does not return the cached app shell document
+- **AND** the request fails or succeeds according to normal network behavior
 
 #### Scenario: SW precaches static assets
 - **WHEN** the SW installs

--- a/resources/public/js/sw.js
+++ b/resources/public/js/sw.js
@@ -1,5 +1,14 @@
 // SW_VERSION is prepended by the server: const SW_VERSION = "abcd1234";
+//
+// SW_VERSION doubles as the cache bucket name. Each deploy gets a fresh bucket;
+// the activate handler deletes every bucket whose name isn't SW_VERSION, so
+// stale assets from old deployments are evicted automatically.
 
+// Static app-shell resources.
+//
+// These are safe to cache during SW install and serve cache-first because their
+// lifecycle is tied to SW_VERSION. Keep dynamic/runtime metadata out of this
+// list; it needs its own cache policy.
 const PRECACHE_URLS = [
   "/",
   "/css/base/colors.css",
@@ -11,7 +20,9 @@ const PRECACHE_URLS = [
   "/css/blocks/lesson.css",
   "/css/blocks/modal.css",
   "/css/blocks/page-footer.css",
+  "/css/blocks/popover.css",
   "/css/blocks/pwa-install.css",
+  "/css/blocks/token-card.css",
   "/css/blocks/vocabulary.css",
   "/css/blocks/word-edit-dialog.css",
   "/css/blocks/word-item.css",
@@ -21,24 +32,74 @@ const PRECACHE_URLS = [
   "/css/components/input.css",
   "/css/styles.css",
   "/favicon.ico",
+  "/fonts/Nunito/nunito-v26-cyrillic_latin-200.woff2",
+  "/fonts/Nunito/nunito-v26-cyrillic_latin-200italic.woff2",
+  "/fonts/Nunito/nunito-v26-cyrillic_latin-300.woff2",
+  "/fonts/Nunito/nunito-v26-cyrillic_latin-300italic.woff2",
   "/fonts/Nunito/nunito-v26-cyrillic_latin-500.woff2",
+  "/fonts/Nunito/nunito-v26-cyrillic_latin-500italic.woff2",
   "/fonts/Nunito/nunito-v26-cyrillic_latin-600.woff2",
   "/fonts/Nunito/nunito-v26-cyrillic_latin-600italic.woff2",
   "/fonts/Nunito/nunito-v26-cyrillic_latin-700.woff2",
+  "/fonts/Nunito/nunito-v26-cyrillic_latin-700italic.woff2",
   "/fonts/Nunito/nunito-v26-cyrillic_latin-800.woff2",
+  "/fonts/Nunito/nunito-v26-cyrillic_latin-800italic.woff2",
+  "/fonts/Nunito/nunito-v26-cyrillic_latin-900.woff2",
+  "/fonts/Nunito/nunito-v26-cyrillic_latin-900italic.woff2",
+  "/fonts/Nunito/nunito-v26-cyrillic_latin-italic.woff2",
   "/fonts/Nunito/nunito-v26-cyrillic_latin-regular.woff2",
   "/icons.svg",
+  "/icons/cancel.svg",
   "/icons/ue-192.png",
   "/icons/ue-512.png",
   "/js/app/main.js",
+  "/js/sqlite3-worker.js",
+  "/js/sqlite3.js",
+  "/js/sqlite3.wasm",
   "/manifest.json"
 ];
 
+// Set for O(1) path lookup in the fetch handler.
 const PRECACHE_SET = new Set(PRECACHE_URLS);
+
+// The cached document shell. On offline navigation reloads, the SW returns this
+// static HTML only; main.cljs still owns routing and UI rendering.
+const APP_SHELL_URL = "/";
+
+// Dynamic dictionary boot metadata. This is deliberately not in PRECACHE_URLS:
+// the dictionary version can change independently from resources/public, and
+// online boots must see the freshest manifest while offline boots may use the
+// last cached manifest for an already-imported OPFS dictionary.
+const DICTIONARY_MANIFEST_URL = "/dictionary/manifest";
+
+function sameOrigin(url) {
+  return url.origin === self.location.origin;
+}
+
+// Matches SPA navigations that should be handled by the app shell, not the server.
+// API/auth/dictionary paths are excluded so their network failures surface to app logic.
+function appNavigation(request, url) {
+  if (request.method !== "GET") return false;
+  if (!sameOrigin(url)) return false;
+  if (request.mode !== "navigate") return false;
+  if (url.pathname.startsWith("/api/")) return false;
+  if (url.pathname.startsWith("/auth/")) return false;
+  if (url.pathname.startsWith("/dictionary/")) return false;
+  if (url.pathname.startsWith("/db/")) return false;
+  return true;
+}
+
+function dictionaryManifestRequest(request, url) {
+  return request.method === "GET"
+    && sameOrigin(url)
+    && url.pathname === DICTIONARY_MANIFEST_URL;
+}
 
 self.addEventListener("install", event => {
   event.waitUntil(
     caches.open(SW_VERSION).then(cache =>
+      // { cache: "reload" } bypasses the HTTP cache so precached assets are
+      // always fresh at install time, not served from a stale browser cache.
       cache.addAll(PRECACHE_URLS.map(url => new Request(url, { cache: "reload" })))
     )
   );
@@ -48,29 +109,73 @@ self.addEventListener("activate", event => {
   event.waitUntil(
     caches.keys()
       .then(keys => Promise.all(keys.filter(k => k !== SW_VERSION).map(k => caches.delete(k))))
+      // claim() takes control of already-open tabs immediately, without waiting
+      // for them to reload — so they get the new SW's fetch handler right away.
       .then(() => self.clients.claim())
   );
 });
 
-self.addEventListener("message", event => {
-  if (event.data?.type === "ping") {
-    event.source?.postMessage({ type: "pong" });
-  }
-});
 
-async function cacheFirst(request) {
+async function cacheFirst(request, cacheKey) {
   const cached = await caches.match(request);
   if (cached) return cached;
+
+  // Fallback to bare path lookup: handles cases where the request URL has query
+  // params or Vary headers that prevent an exact match against the precached entry.
+  if (cacheKey) {
+    const cachedByPath = await caches.match(cacheKey);
+    if (cachedByPath) return cachedByPath;
+  }
+
   const response = await fetch(request);
   const cache = await caches.open(SW_VERSION);
+  // Clone before caching: Response body is a one-time-read stream; the original goes to the browser.
   cache.put(request, response.clone());
   return response;
 }
 
+// Network-first keeps online reloads fresh. Offline fallback returns only the
+// cached app shell, not route-specific HTML generated by the SW.
+async function navigationNetworkFirst(request) {
+  try {
+    return await fetch(request);
+  } catch (error) {
+    // Only catches network failures, not 4xx/5xx — those should reach the app.
+    const cachedShell = await caches.match(APP_SHELL_URL);
+    if (cachedShell) return cachedShell;
+    throw error;
+  }
+}
+
+// Runtime metadata uses network-first + cached fallback: fresh when online,
+// usable when offline. Do not use this for API responses that app logic should
+// observe as failures.
+async function networkFirstCached(request, cacheKey) {
+  try {
+    const response = await fetch(request);
+    const cache = await caches.open(SW_VERSION);
+    // Refresh the cache on every successful fetch so the offline copy stays warm.
+    cache.put(cacheKey || request, response.clone());
+    return response;
+  } catch (error) {
+    const cached = await caches.match(cacheKey || request);
+    if (cached) return cached;
+    throw error;
+  }
+}
+
 self.addEventListener("fetch", event => {
   const { request } = event;
-  const path = new URL(request.url).pathname;
-  if (!path.startsWith("/api/") && PRECACHE_SET.has(path)) {
-    event.respondWith(cacheFirst(request));
+  const url = new URL(request.url);
+  // Use pathname (not full URL) for PRECACHE_SET lookup so query params don't cause misses.
+  const path = url.pathname;
+
+  if (appNavigation(request, url)) {
+    event.respondWith(navigationNetworkFirst(request));
+  } else if (dictionaryManifestRequest(request, url)) {
+    event.respondWith(networkFirstCached(request, DICTIONARY_MANIFEST_URL));
+  } else if (request.method === "GET" && sameOrigin(url) && PRECACHE_SET.has(path)) {
+    // Pass path as cacheKey so cacheFirst can match even if request URL differs.
+    event.respondWith(cacheFirst(request, path));
   }
 });


### PR DESCRIPTION
## Summary
- Serve cached app shell for same-origin offline navigation reloads.
- Keep API routes out of HTML fallback.
- Cache dictionary manifest network-first with cached fallback for offline boot metadata.
- Archive OpenSpec change and update main-thread runtime spec.

Closes #157

## Verification
- `clj-kondo --lint src/client test/client`
- `npx shadow-cljs compile node-test`
- `node target/node-tests.js`
- `npx shadow-cljs compile app`
- `node --check resources/public/js/sw.js`
- `git diff --check`
- `OPENSPEC_TELEMETRY=0 openspec validate main-thread-runtime --strict`
- Headless Chrome SW proof: controlled `/words` offline reload stays in app with title `Sprecha`, not `chrome-error://chromewebdata/`
