### PR TITLE
GH-161 Add /goal skill for parallel autonomous worktree task delivery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,10 @@ app.db
 /tools/dictionary/enrich-translations/.enrich_*
 /tools/dictionary/enrich-translations/enrich-translations
 
+# Worktree server artifacts (created by /goal skill)
+.worktree-backend.log
+.worktree-backend.pid
+
 # Local agent/tool artifacts
 /.codex/skills
 /.claude/

--- a/.skills/goal/SKILL.md
+++ b/.skills/goal/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: goal
+description: "Autonomous task execution in an isolated git worktree. Sets up the worktree, allocates ports, starts servers, runs the full repo-task-delivery workflow, and stops only for final PR review. Use when the user passes a task description and wants it delivered without interruption."
+---
+
+# /goal — Autonomous Worktree Task Delivery
+
+Invoke as `/goal <task description>`.
+
+This skill runs the full delivery workflow for one task, isolated in its own git worktree, using dedicated ports to coexist with other parallel `/goal` sessions.
+
+## Phase 0 — One clarifying question
+
+Ask a single focused question only if the task description is genuinely ambiguous about scope or target area. If the description is clear enough to start, skip directly to Phase 1.
+
+Do not ask about process, tooling, or preferences — those are fixed by this skill.
+
+## Phase 1 — Worktree setup
+
+Use `using-git-worktrees` to create (or detect) an isolated worktree for this task.
+
+- Branch name: derive from the task description (e.g. `feature/add-theme-tags`)
+- If already running inside a worktree (current dir ≠ main repo root), skip creation and use current worktree
+- Announce: "Worktree ready: `<path>` on branch `<branch>`"
+
+## Phase 2 — Port slot allocation
+
+Run the claim script from the worktree root:
+
+```bash
+bash .skills/goal/scripts/claim-slot.sh "$(pwd)"
+```
+
+This outputs a slot number N ≥ 1. Derive ports:
+
+| Resource       | Port formula       | Example (slot 1) |
+|----------------|--------------------|------------------|
+| Backend        | 8083 + N×100       | 8183             |
+| shadow-cljs    | 9630 + N×100       | 9730             |
+| nREPL          | 4444 + N×100       | 4544             |
+| HTTPS preview  | 4430 + N           | 4431             |
+
+Announce: "Slot N — backend :PORT_B, shadow-cljs :PORT_S, preview: https://sprecha.local:PORT_H"
+
+## Phase 3 — Server startup
+
+Start the Clojure backend in the background on the allocated port:
+
+```bash
+LEARNING_APP_PORT=<backend-port> clj -M:dev -m core &> .worktree-backend.log &
+echo $! > .worktree-backend.pid
+```
+
+Wait for the backend to become responsive (poll `curl -s http://localhost:<backend-port>/health` or any endpoint, up to 30 s).
+
+Do NOT start `shadow-cljs watch` — use `npx shadow-cljs compile app` for CLJS verification steps. This avoids dev-server port conflicts while agents run in parallel.
+
+## Phase 4 — Autonomous implementation
+
+Run the full `repo-task-delivery` workflow:
+
+1. GitHub issue + project item (via `gh-project-workflow`)
+2. OpenSpec change (via `openspec-propose-change`)
+3. Implementation (via `openspec-apply-change`)
+4. Verification:
+   - Compile CLJS: `npx shadow-cljs compile app`
+   - Run Clojure tests if any: `clj -M:test`
+   - Smoke-test the backend: curl key endpoints on `http://localhost:<backend-port>`
+5. OpenSpec sync/archive (via `openspec-archive-change`)
+
+Do NOT pause for questions during this phase. On ambiguity, make a reasonable decision, note it in the commit message or PR description, and continue.
+
+On hard blockers (build fails, dependency missing, test cannot pass): stop, describe the blocker clearly, and wait for user input.
+
+## Phase 5 — Nginx config (for browser review)
+
+Generate the nginx vhost config for this slot:
+
+```bash
+bash .skills/goal/scripts/gen-nginx-slot.sh <slot> <certs-dir>
+```
+
+Where `<certs-dir>` is the directory used in the existing `sprecha.local` nginx config (typically the value of `$NGINX_CERTS_DIR` set during initial setup — check `infra/development/etc/nginx/sites-available/sprecha.local.template` or the installed nginx config).
+
+Print the generated config and the activation commands so the user can copy-paste them when they want to preview.
+
+## Phase 6 — Review gate
+
+Stop and announce:
+
+```
+═══════════════════════════════════════════════════════
+READY FOR REVIEW
+  Branch:   <branch>
+  PR:       <gh-pr-url>
+  Preview:  https://sprecha.local:<https-port>/
+            (run the nginx commands above, then sudo nginx -s reload)
+  Backend:  http://localhost:<backend-port>  (already running)
+═══════════════════════════════════════════════════════
+Waiting for your approval. Say "merge" to merge the PR,
+or give feedback to continue.
+```
+
+## Phase 7 — Merge and cleanup
+
+On user approval ("merge", "ok", "go", "lgtm", or equivalent):
+
+1. Merge the PR (via `gh pr merge --squash` or as the repo uses)
+2. Kill the background backend process: `kill $(cat .worktree-backend.pid) 2>/dev/null`
+3. Release the port slot: `bash .skills/goal/scripts/release-slot.sh <slot>`
+4. Optionally remove the worktree: `git worktree remove <path>` (ask if unsure whether the user wants it kept)
+
+On feedback: implement the requested changes, re-verify, update the PR, and return to Phase 6.
+
+## Error handling
+
+- If `claim-slot.sh` fails: print the error and ask the user to check `.git/worktree-slots/`
+- If backend fails to start within 30 s: print `.worktree-backend.log` tail and stop
+- If CLJS compile fails: print the error, fix it before proceeding
+- If tests fail: fix them before proceeding to Phase 5
+
+## Port reference quick table
+
+| Slot | Backend | shadow-cljs | nREPL | HTTPS preview |
+|------|---------|-------------|-------|---------------|
+| 0    | 8083    | 9630        | 4444  | 443 (main)   |
+| 1    | 8183    | 9730        | 4544  | 4431          |
+| 2    | 8283    | 9830        | 4644  | 4432          |
+| 3    | 8383    | 9930        | 4744  | 4433          |

--- a/.skills/goal/scripts/claim-slot.sh
+++ b/.skills/goal/scripts/claim-slot.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Atomically claim a port slot for a git worktree.
+# Usage: claim-slot.sh [worktree-path]
+# Outputs one line: the slot number (integer ≥ 1).
+# Slot 0 is the main repo — never claimed here.
+# Ports per slot N: backend=8083+N*100, nrepl=4444+N*100, shadow=9630+N*100
+
+set -euo pipefail
+
+WORKTREE_PATH="${1:-$(pwd)}"
+REPO_ROOT=$(git -C "$WORKTREE_PATH" rev-parse --show-toplevel 2>/dev/null || git rev-parse --show-toplevel)
+SLOTS_DIR="${REPO_ROOT}/.git/worktree-slots"
+LOCK_FILE="${REPO_ROOT}/.git/worktree-slots.lock"
+
+mkdir -p "$SLOTS_DIR"
+
+_is_worktree_live() {
+  git -C "$REPO_ROOT" worktree list --porcelain 2>/dev/null | grep -q "^worktree ${1}$"
+}
+
+(
+  flock 200
+
+  # Return existing slot if this worktree already claimed one.
+  for slot_dir in "$SLOTS_DIR"/*/; do
+    [[ -d "$slot_dir" ]] || continue
+    wt_file="${slot_dir}worktree"
+    [[ -f "$wt_file" ]] || continue
+    claimed_wt=$(cat "$wt_file")
+    if [[ "$claimed_wt" == "$WORKTREE_PATH" ]]; then
+      echo "$(basename "$slot_dir")"
+      exit 0
+    fi
+  done
+
+  # Remove stale slots (worktree no longer registered in git).
+  for slot_dir in "$SLOTS_DIR"/*/; do
+    [[ -d "$slot_dir" ]] || continue
+    wt_file="${slot_dir}worktree"
+    [[ -f "$wt_file" ]] || continue
+    wt=$(cat "$wt_file")
+    if ! _is_worktree_live "$wt"; then
+      rm -rf "$slot_dir"
+    fi
+  done
+
+  # Find the lowest free slot ≥ 1.
+  slot=1
+  while [[ -d "${SLOTS_DIR}/${slot}" ]]; do
+    slot=$((slot + 1))
+  done
+
+  mkdir -p "${SLOTS_DIR}/${slot}"
+  echo "$WORKTREE_PATH" > "${SLOTS_DIR}/${slot}/worktree"
+
+  echo "$slot"
+) 200>"$LOCK_FILE"

--- a/.skills/goal/scripts/gen-nginx-slot.sh
+++ b/.skills/goal/scripts/gen-nginx-slot.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Generate an nginx vhost config for a worktree slot.
+# Usage: gen-nginx-slot.sh <slot> <certs-dir>
+# Outputs the config to stdout and writes it to /etc/nginx/sites-available/sprecha-slot<N>.conf
+# Requires sudo for the write step.
+
+set -euo pipefail
+
+SLOT="${1:?slot number required}"
+CERTS_DIR="${2:?certs dir required}"
+
+BACKEND_PORT=$((8083 + SLOT * 100))
+NREPL_PORT=$((4444 + SLOT * 100))
+SHADOW_PORT=$((9630 + SLOT * 100))
+HTTPS_PORT=$((4430 + SLOT))
+DOMAIN="sprecha.local"
+
+CONFIG=$(cat <<EOF
+# Slot ${SLOT} — backend:${BACKEND_PORT}, shadow:${SHADOW_PORT}
+server {
+    listen 80;
+    server_name ${DOMAIN};
+    listen ${HTTPS_PORT};
+    return 301 https://\$host:${HTTPS_PORT}\$request_uri;
+}
+
+server {
+    listen ${HTTPS_PORT} ssl;
+    server_name ${DOMAIN};
+
+    ssl_certificate     ${CERTS_DIR}/sprecha.local+3.pem;
+    ssl_certificate_key ${CERTS_DIR}/sprecha.local+3-key.pem;
+
+    location /shadow-cljs/ {
+        proxy_pass http://localhost:${SHADOW_PORT}/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade \$http_upgrade;
+        proxy_set_header Connection "Upgrade";
+        proxy_read_timeout 1h;
+    }
+
+    proxy_set_header X-Auth-CouchDB-UserName "";
+    proxy_set_header X-Auth-CouchDB-Roles    "";
+    proxy_set_header X-Auth-CouchDB-Token    "";
+
+    location /db/dictionary-db/ {
+        proxy_pass http://localhost:5984/dictionary-db/;
+        proxy_redirect off;
+        proxy_buffering off;
+        proxy_set_header Host \$host;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+    }
+
+    location /db/ {
+        auth_request /auth/check;
+        auth_request_set \$couch_user  \$upstream_http_x_auth_user;
+        auth_request_set \$couch_roles \$upstream_http_x_auth_roles;
+        auth_request_set \$couch_token \$upstream_http_x_auth_token;
+        proxy_set_header X-Auth-CouchDB-UserName \$couch_user;
+        proxy_set_header X-Auth-CouchDB-Roles    \$couch_roles;
+        proxy_set_header X-Auth-CouchDB-Token    \$couch_token;
+        proxy_pass http://localhost:5984/;
+        proxy_redirect off;
+        proxy_buffering off;
+        proxy_set_header Host \$host;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+    }
+
+    location /auth/check {
+        internal;
+        proxy_pass http://localhost:${BACKEND_PORT}/auth/check;
+        proxy_set_header Content-Length "";
+        proxy_pass_request_body off;
+    }
+
+    location / {
+        proxy_pass http://localhost:${BACKEND_PORT};
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+    }
+}
+EOF
+)
+
+echo "$CONFIG"
+echo ""
+echo "# To activate (requires sudo):"
+echo "# sudo tee /etc/nginx/sites-available/sprecha-slot${SLOT}.conf <<'NGINXEOF'"
+echo "# $CONFIG"
+echo "# NGINXEOF"
+echo "# sudo ln -sf /etc/nginx/sites-available/sprecha-slot${SLOT}.conf /etc/nginx/sites-enabled/"
+echo "# sudo nginx -s reload"
+echo ""
+echo "# Preview URL: https://sprecha.local:${HTTPS_PORT}/"

--- a/.skills/goal/scripts/release-slot.sh
+++ b/.skills/goal/scripts/release-slot.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Release a port slot when a worktree task finishes.
+# Usage: release-slot.sh <slot-number>
+
+set -euo pipefail
+
+SLOT="${1:?slot number required}"
+REPO_ROOT=$(git rev-parse --show-toplevel)
+SLOTS_DIR="${REPO_ROOT}/.git/worktree-slots"
+LOCK_FILE="${REPO_ROOT}/.git/worktree-slots.lock"
+
+(
+  flock 200
+  rm -rf "${SLOTS_DIR}/${SLOT}"
+) 200>"$LOCK_FILE"
+
+echo "Released slot ${SLOT}."

--- a/openspec/changes/archive/2026-05-22-goal-skill-parallel-worktrees/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-22-goal-skill-parallel-worktrees/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-with-adr
+created: 2026-05-22

--- a/openspec/changes/archive/2026-05-22-goal-skill-parallel-worktrees/design.md
+++ b/openspec/changes/archive/2026-05-22-goal-skill-parallel-worktrees/design.md
@@ -1,0 +1,66 @@
+## Context
+
+The repo uses a `repo-task-delivery` skill that drives one AI agent through a full GitHub issue → OpenSpec → implement → verify → PR loop. Opening two Claude Code windows on the same worktree causes port collisions (backend 8083, shadow-cljs nREPL 4444, dev server 9630) and makes parallel AI sessions impractical.
+
+The goal is a `/goal` slash command that sets up an isolated worktree with dedicated ports, runs `repo-task-delivery` autonomously, and pauses only for final review.
+
+Existing skills: `using-git-worktrees`, `repo-task-delivery`, `gh-project-workflow`, `openspec-*`. These are reused as sub-steps.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Allow N concurrent `/goal` sessions on the same machine without port conflicts
+- Fully autonomous: no mid-task interruptions except hard blockers
+- One clarifying question before start, then quiet until "READY FOR REVIEW"
+- Port slot registry is crash-safe: stale slots are detected via git worktree list
+
+**Non-Goals:**
+- CouchDB data isolation (parallel tasks are code-only changes; DB state is not mutated)
+- Automated nginx reload (requires sudo; user reloads manually for browser review)
+- shadow-cljs watch per worktree (agents use `compile` for verification, not hot-reload)
+
+## Decisions
+
+### D1: Slot-based port allocation via directory registry
+
+Each worktree claims a numbered slot ≥ 1 in `.git/worktree-slots/<N>/worktree`. Port offsets are `base + N×100`:
+- Backend: `8083 + N×100`
+- shadow-cljs dev server: `9630 + N×100`
+- nREPL: `4444 + N×100`
+- HTTPS preview: `4430 + N`
+
+**Why directory registry over JSON:** `mkdir` is atomic on POSIX filesystems; no need for jq. `flock` on a shared lock file serializes concurrent claims.
+
+**Stale detection via git worktree list:** A slot is stale when its worktree path is no longer registered in `git worktree list`. This is reliable — removing a worktree is the canonical cleanup step.
+
+**Alternative considered:** PID-based staleness check. Rejected: shell PIDs get recycled quickly; a new process could falsely appear alive.
+
+### D2: `compile` for CLJS verification, not `watch`
+
+Agents run `npx shadow-cljs compile app` for correctness checks instead of starting a watch process. This avoids needing to multiplex the shadow-cljs HTTP dev server (port 9630+) across worktrees.
+
+**Why:** Parallel agents do not need hot-reload. They need compile-time correctness and a running backend for smoke tests. Starting a watch server per worktree would require patching `shadow-cljs.edn` in each worktree and is unnecessary complexity.
+
+### D3: `LEARNING_APP_PORT` env var for backend
+
+`(def port (or (some-> (System/getenv "LEARNING_APP_PORT") Integer/parseInt) 8083))`
+
+Follows the existing `LEARNING_APP_*` naming convention. Default is unchanged.
+
+### D4: nginx config generated but not auto-reloaded
+
+`gen-nginx-slot.sh` emits a ready-to-paste nginx vhost that listens on `sprecha.local:<4430+N>`. User pastes it and runs `sudo nginx -s reload` manually when they want browser access during review. Automation would require `sudo` NOPASSWD for nginx, which is not set up.
+
+## Risks / Trade-offs
+
+- **Risk: Slot leak on hard session crash** → Mitigation: stale detection on next `claim-slot.sh` call cleans up orphaned slots automatically.
+- **Risk: Port arithmetic collides with other local services** → Mitigation: 100-port offset gives wide separation; documented in skill's port table.
+- **Risk: Skill diverges from repo workflow evolution** → Mitigation: `/goal` delegates to existing skills (`repo-task-delivery`, `using-git-worktrees`) so updates to those propagate automatically.
+
+## Migration Plan
+
+No migration needed. Existing single-session workflow is unchanged. The `LEARNING_APP_PORT` change is backward-compatible (default unchanged). Slot registry lives in `.git/` so it is never committed.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-05-22-goal-skill-parallel-worktrees/proposal.md
+++ b/openspec/changes/archive/2026-05-22-goal-skill-parallel-worktrees/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Running multiple AI-driven tasks simultaneously requires each session to have its own isolated git worktree with dedicated server ports so processes do not conflict. Without a structured skill, port collisions and manual setup make parallel development impractical.
+
+## What Changes
+
+- Add `/goal` skill (`goal-skill-parallel-worktrees`) to `.skills/goal/` — autonomous end-to-end task delivery in a worktree, stopping only for final PR review.
+- Add slot management scripts: `claim-slot.sh`, `release-slot.sh`, `gen-nginx-slot.sh` — atomic port allocation via `flock`, nginx vhost generation per slot.
+- Add `LEARNING_APP_PORT` env var support to `src/backend/core.clj` — backend port is now overridable so parallel worktrees can run on distinct ports.
+- Add `.worktree-backend.log` / `.worktree-backend.pid` to `.gitignore` — per-worktree server artifacts stay out of git.
+
+## Capabilities
+
+### New Capabilities
+
+- `goal-skill`: The `/goal <task>` slash command. Orchestrates worktree creation, port slot claiming, server startup, autonomous `repo-task-delivery` execution, and a final review gate.
+
+### Modified Capabilities
+
+- `repo-agent-infrastructure`: Backend now reads `LEARNING_APP_PORT` env var (falls back to 8083). Slot registry added at `.git/worktree-slots/` (outside tracked tree). New gitignore entries for worktree server artifacts.
+
+## Impact
+
+- `src/backend/core.clj` — one-line change to `(def port ...)`.
+- `.skills/goal/` — new skill directory (tracked via `.skills/`, symlinked into `.claude/skills/` and `.codex/skills/`).
+- `.gitignore` — two new entries.
+- No user-facing behavior change; only dev-environment tooling.

--- a/openspec/changes/archive/2026-05-22-goal-skill-parallel-worktrees/specs/goal-skill/spec.md
+++ b/openspec/changes/archive/2026-05-22-goal-skill-parallel-worktrees/specs/goal-skill/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: /goal skill provides autonomous task delivery in an isolated worktree
+The repository SHALL provide a `/goal` slash command that runs the full `repo-task-delivery` workflow inside a dedicated git worktree with dedicated ports, pausing only for a final review gate.
+
+#### Scenario: Developer starts a task with /goal
+- **WHEN** a developer invokes `/goal <task description>` in a Claude Code session
+- **THEN** the skill creates or detects a git worktree for the task
+- **AND** claims an unused port slot from the registry
+- **AND** starts the backend server on the allocated port
+- **AND** runs the full `repo-task-delivery` workflow without further interruptions
+- **AND** stops with a "READY FOR REVIEW" announcement when the PR is ready
+
+#### Scenario: /goal asks at most one clarifying question
+- **WHEN** the task description is clear enough to determine scope
+- **THEN** the skill proceeds without asking any questions
+- **WHEN** the task description is genuinely ambiguous
+- **THEN** the skill asks exactly one focused question before starting
+
+### Requirement: Port slot allocation is atomic and crash-safe
+The slot registry SHALL assign each `/goal` session a unique port slot such that no two concurrent sessions share ports, and stale slots from crashed sessions are recovered automatically.
+
+#### Scenario: Two /goal sessions start concurrently
+- **WHEN** two Claude Code sessions invoke `/goal` at the same time
+- **THEN** each session receives a distinct slot number
+- **AND** their backend ports differ by at least 100
+
+#### Scenario: Slot from a crashed session is recovered
+- **WHEN** a previous `/goal` session ended without releasing its slot
+- **AND** its worktree has since been removed from `git worktree list`
+- **THEN** the next `claim-slot.sh` call reclaims that slot
+
+### Requirement: Port slots are released on task completion
+The skill SHALL release the claimed port slot and stop background processes when the task is merged or explicitly abandoned.
+
+#### Scenario: Task merges successfully
+- **WHEN** the user approves the PR and it is merged
+- **THEN** the background backend process is stopped
+- **AND** the slot directory is removed from `.git/worktree-slots/`
+
+### Requirement: Nginx vhost config is generated per slot for browser review
+The skill SHALL produce a ready-to-activate nginx config for each slot so the user can access the worktree's running app via `https://sprecha.local:<4430+N>/`.
+
+#### Scenario: Developer wants to preview a worktree in the browser
+- **WHEN** the skill reaches the review gate
+- **THEN** it prints the nginx vhost config for the slot
+- **AND** provides the exact commands to activate it (write + `sudo nginx -s reload`)
+- **AND** the backend is already running on the slot's port so the app is immediately accessible after reload

--- a/openspec/changes/archive/2026-05-22-goal-skill-parallel-worktrees/specs/repo-agent-infrastructure/spec.md
+++ b/openspec/changes/archive/2026-05-22-goal-skill-parallel-worktrees/specs/repo-agent-infrastructure/spec.md
@@ -1,8 +1,5 @@
-# repo-agent-infrastructure Specification
+## MODIFIED Requirements
 
-## Purpose
-TBD - created by archiving change keep-only-codex-agent-files. Update Purpose after archive.
-## Requirements
 ### Requirement: Repository-owned agent infrastructure is Codex-only
 The repository SHALL keep only Codex-related agent infrastructure files under version control.
 
@@ -16,13 +13,7 @@ The repository SHALL keep only Codex-related agent infrastructure files under ve
 - **THEN** git ignores those local artifacts
 - **AND** repository-owned Codex files remain visible for tracking and review
 
-### Requirement: Local non-Codex agent artifacts do not reappear as repo noise
-The repository SHALL ignore local non-Codex agent artifacts so they do not keep showing up as worktree noise.
-
-#### Scenario: A developer uses local Claude or OpenCode tooling
-- **WHEN** local non-Codex agent files are created in the working tree
-- **THEN** git ignores those local artifacts
-- **AND** repository-owned Codex files remain visible for tracking and review
+## ADDED Requirements
 
 ### Requirement: Backend port is overridable via environment variable
 The backend server SHALL read its listening port from the `LEARNING_APP_PORT` environment variable when set, falling back to 8083 when absent.
@@ -41,4 +32,3 @@ The repository SHALL ignore per-worktree server log and PID files so they do not
 #### Scenario: /goal creates backend log and PID files
 - **WHEN** the `/goal` skill starts a background backend process in a worktree
 - **THEN** `.worktree-backend.log` and `.worktree-backend.pid` are not shown by `git status`
-

--- a/openspec/changes/archive/2026-05-22-goal-skill-parallel-worktrees/tasks.md
+++ b/openspec/changes/archive/2026-05-22-goal-skill-parallel-worktrees/tasks.md
@@ -1,0 +1,17 @@
+## 1. Backend port override
+
+- [x] 1.1 Add `LEARNING_APP_PORT` env var to `src/backend/core.clj` (fallback 8083)
+
+## 2. Slot management scripts
+
+- [x] 2.1 Write `claim-slot.sh` — flock-based atomic slot claim with stale detection via `git worktree list`
+- [x] 2.2 Write `release-slot.sh` — remove slot directory from registry
+- [x] 2.3 Write `gen-nginx-slot.sh` — emit nginx vhost config for slot N (port 4430+N, backend 8083+N×100)
+
+## 3. /goal skill
+
+- [x] 3.1 Write `.skills/goal/SKILL.md` with full autonomous workflow: one question → worktree → slot → servers → repo-task-delivery → review gate → cleanup
+
+## 4. Gitignore
+
+- [x] 4.1 Add `.worktree-backend.log` and `.worktree-backend.pid` to `.gitignore`

--- a/openspec/specs/goal-skill/spec.md
+++ b/openspec/specs/goal-skill/spec.md
@@ -1,0 +1,53 @@
+# goal-skill Specification
+
+## Purpose
+TBD - created by syncing change goal-skill-parallel-worktrees. Update Purpose after archive.
+
+## Requirements
+
+### Requirement: /goal skill provides autonomous task delivery in an isolated worktree
+The repository SHALL provide a `/goal` slash command that runs the full `repo-task-delivery` workflow inside a dedicated git worktree with dedicated ports, pausing only for a final review gate.
+
+#### Scenario: Developer starts a task with /goal
+- **WHEN** a developer invokes `/goal <task description>` in a Claude Code session
+- **THEN** the skill creates or detects a git worktree for the task
+- **AND** claims an unused port slot from the registry
+- **AND** starts the backend server on the allocated port
+- **AND** runs the full `repo-task-delivery` workflow without further interruptions
+- **AND** stops with a "READY FOR REVIEW" announcement when the PR is ready
+
+#### Scenario: /goal asks at most one clarifying question
+- **WHEN** the task description is clear enough to determine scope
+- **THEN** the skill proceeds without asking any questions
+- **WHEN** the task description is genuinely ambiguous
+- **THEN** the skill asks exactly one focused question before starting
+
+### Requirement: Port slot allocation is atomic and crash-safe
+The slot registry SHALL assign each `/goal` session a unique port slot such that no two concurrent sessions share ports, and stale slots from crashed sessions are recovered automatically.
+
+#### Scenario: Two /goal sessions start concurrently
+- **WHEN** two Claude Code sessions invoke `/goal` at the same time
+- **THEN** each session receives a distinct slot number
+- **AND** their backend ports differ by at least 100
+
+#### Scenario: Slot from a crashed session is recovered
+- **WHEN** a previous `/goal` session ended without releasing its slot
+- **AND** its worktree has since been removed from `git worktree list`
+- **THEN** the next `claim-slot.sh` call reclaims that slot
+
+### Requirement: Port slots are released on task completion
+The skill SHALL release the claimed port slot and stop background processes when the task is merged or explicitly abandoned.
+
+#### Scenario: Task merges successfully
+- **WHEN** the user approves the PR and it is merged
+- **THEN** the background backend process is stopped
+- **AND** the slot directory is removed from `.git/worktree-slots/`
+
+### Requirement: Nginx vhost config is generated per slot for browser review
+The skill SHALL produce a ready-to-activate nginx config for each slot so the user can access the worktree's running app via `https://sprecha.local:<4430+N>/`.
+
+#### Scenario: Developer wants to preview a worktree in the browser
+- **WHEN** the skill reaches the review gate
+- **THEN** it prints the nginx vhost config for the slot
+- **AND** provides the exact commands to activate it (write + `sudo nginx -s reload`)
+- **AND** the backend is already running on the slot's port so the app is immediately accessible after reload

--- a/src/backend/core.clj
+++ b/src/backend/core.clj
@@ -35,7 +35,7 @@
 (set! *warn-on-reflection* true)
 
 
-(def port 8083)
+(def port (or (some-> (System/getenv "LEARNING_APP_PORT") Integer/parseInt) 8083))
 
 
 (def ^:private console-log-handler-id :learning-app/console)


### PR DESCRIPTION
## Summary

- Adds `/goal` slash command (`.skills/goal/SKILL.md`) for autonomous task delivery in isolated git worktrees
- Adds `claim-slot.sh` / `release-slot.sh` / `gen-nginx-slot.sh` — flock-based port slot registry with stale detection via `git worktree list`
- `src/backend/core.clj`: backend port now reads `LEARNING_APP_PORT` env var (fallback 8083)
- `.gitignore`: adds `.worktree-backend.log` and `.worktree-backend.pid`

## How it works

Each `/goal` session claims a slot N ≥ 1 and gets dedicated ports (backend: 8083+N×100, shadow-cljs: 9630+N×100, nREPL: 4444+N×100). Stale slots (from crashed sessions) are auto-recovered. Browser review is via `https://sprecha.local:4430+N/` after a manual nginx reload.

## Test plan

- [ ] Open two Claude Code windows on this repo
- [ ] Run `/goal <task>` in each — both should claim different slot numbers
- [ ] Verify backend starts on distinct ports
- [ ] Run `claim-slot.sh` twice with same path — should return same slot (idempotent)
- [ ] Remove a worktree, run `claim-slot.sh` again — should reclaim the stale slot

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)