### PR TITLE
GH-146 Cross-device sync: invite-gated identity and trigger-driven replication

### DIFF
--- a/.zprint.edn
+++ b/.zprint.edn
@@ -47,7 +47,14 @@
            "async"         :arg1-body
            "async-testing" :arg1-body
            "extend-protocol" :arg1-body
+           ;; Macros whose first argument is a binding vector indent like `let`
            "jdbc/on-connection" :binding
+           "jdbc/on-connection+options" :binding
+           "jdbc/with-transaction" :binding
+           ;; Query fns: the connection stays on the first line, SQL indents by two
+           "jdbc/execute!" :arg1-body
+           "jdbc/execute-one!" :arg1-body
+           "on-connection" :binding
            "p/catch"       :none-body
            "p/do"          :none-body
            "p/finally"     :none-body

--- a/adr/0006-local-first-abuse-resistant-identity-provisioning.md
+++ b/adr/0006-local-first-abuse-resistant-identity-provisioning.md
@@ -1,0 +1,70 @@
+# 0006. Local-first abuse-resistant identity provisioning
+
+- Status: accepted
+- Date: 2026-06-04 (revised 2026-08-03)
+
+## Context
+
+Product anonymous by design: no account, email, phone. Current sync provisions eager — first load calls `POST /api/identity/claim`, server immediately makes SQLite user row + CouchDB `userdb-<id>`. Endpoint unauthenticated, ignores request. App is public (sprecha.de) → any random visitor provisions.
+
+Server never deletes databases → database count monotonic. Unauthenticated + free + permanent + monotonic = open abuse vector. Anyone drips `claim` calls — slow, distributed — piles unbounded empty CouchDB databases. Per-IP rate limit bounds inflow, not immortal stock → no prevent node death. CouchDB rots at high database count (shard files, descriptors, `_dbs`, startup scans) even when databases empty.
+
+Sybil defense needs a gate on provisioning with a controlled grant. Permanent identity anchors (account/email/phone) contradict anonymity. A **bearer grant token** gates provisioning without identity: operator controls who gets one, app layer stays PII-free. Phase 1 = **invites** — enough to dogfood + onboard testers now, no payment infra. Payment is the planned phase-2 grant source once demand is proven; the gate is the same slot.
+
+## Decision
+
+Default local-first. First launch provisions nothing server-side; all data (vocab, reviews, collections, examples) lives only in local PouchDB `user-db`. Replication needs a server identity to start. Eager `claim`-time database creation removed (public app → random visitor must not provision).
+
+A server database is born only via a valid grant, on opt-in to multi-device or recovery. Phase-1 grant = single-use invite token:
+
+1. Operator mints invite tokens — random, unguessable, single-use, revocable. Own `grants` table (a grant pre-dates any account, so no user reference; named for the gate slot — a phase-2 payment mints rows in the same table) reusing the sha256 burn-on-use mechanics already proven by recovery tokens.
+2. Trigger (provision a new identity) → device submits the invite.
+3. Server verifies invite unused + unexpired, burns it, then makes `userdb-<id>`, secures by role, mints a credential token. The device seeds the fresh `userdb` by pushing its local data over normal replication — no second ingest path.
+
+Provision only on valid grant → no anonymous free creation. Invite = bearer capability, not identity → app layer stores no PII.
+
+Identity = one high-entropy **bearer token**, not a username/password pair. The server stores `sha256(token)` inline on the account row (`users (id, token_sha256)` — same hashed-bearer shape as `grants`, one token per account); there is no `password`, no argon2, no session table, no login endpoint. A device proves itself by presenting the token as a cookie on every request; `/auth/check` (already an nginx subrequest per `/db/` call) does the sha256 lookup and emits the CouchDB role `u:<id>`. The token is the credential, the cookie, and the "session" collapsed into one thing — exactly "the device sends its key on every request".
+
+Why a token and not the prior `{id, secret}` + argon2 + session: argon2 exists to slow brute force on *low-entropy human passwords*; our secret is 256-bit random, where sha256 is already infeasible to brute-force. The session table existed only to avoid running argon2 per request — drop argon2 and the session disappears with it. The whole username/password/login/session apparatus was password-login machinery cargo-culted onto an anonymous high-entropy key.
+
+The key the user carries is the token itself — one opaque string, nothing packed around it. A device holding one asks the server which account it belongs to, and adopts it only if the answer comes back, so an invalid key changes nothing on the device.
+
+A credential rides in the URL **fragment** (`#key=`, `#invite=`), never in the query string. A fragment is not part of the request: a query lands in the server's access log and in `Referer` headers, which is no place for a permanent credential. The router drops the fragment when it redirects the unmatched `/`, replacing the history entry rather than pushing one, so the token leaves the address bar and the back button with it.
+
+Transports — QR (pairing) and a shareable link (incl. client-composed email — never server-sent, no PII); no manual entry, the link or QR is the only door. The invite travels the same way, redeemed on open.
+
+The saved recovery artifact **is the key itself** — durable, no expiry, no burn. A one-time wrapped link burns on first use or expires while the user believes they hold a backup; that trap is removed together with the old recovery-token flow. One-time burn-on-use semantics remain only where they belong: invites.
+
+**No per-device logout.** Every device that holds the key can re-present it, so deleting one device's cookie server-side is theater — the device just sends the key again. Meaningful per-device revocation would need leaf tokens a device cannot re-mint, plus a master key kept off devices and one-time pairing grants — real machinery for negligible value in a personal vocab app. So the only revocation is **rotation**: mint a new token, overwrite `users.token_sha256`, re-distribute the new key to your devices (re-scan QR / re-open the link). All-or-nothing, which is honest. One token per account inline on the row — a one-to-many `credentials` table (for rotation overlap or future non-re-mintable leaf tokens) was considered and dropped as premature, since it duplicated the account id across two tables for capabilities we do not need yet.
+
+Entering a key on a device adopts that account:
+- device has no account, or the same account → **merge** (replication union; local data pushed up, not wiped);
+- device was on a different account → wipe local, adopt the new account's data.
+
+The gate (invite, later payment) sits on **creating a new account** (new `userdb`); adopting an existing key on more devices is free and ungated — the account is already granted (Mullvad: account creation gated, devices free).
+
+The gate is pluggable: payment (Stripe Checkout, settled-payment grant) drops into the same point in phase 2 — no rework of local-first, backup, sync, or reaper.
+
+The export payload (manual backup / cold restore) becomes a dump of **every** `user-db` doc — a hand-kept type list already dropped collections silently once (GH-163); dumping everything kills the bug class, not the instance. Provision-seed does not use it (push-seed above).
+
+Reaper (systemd timer, mirrors `learning-app-backup-db.timer`) reclaims orphans (a `userdb` abandoned when a device adopts another identity); refund/lapsed-subscription reaping arrives with payment in phase 2. Deferred during the invite phase — blast radius = minted invites, and the column/timer are trivial to add when population grows.
+
+## Consequences
+
+- Default path makes nothing server-side → drive-by `claim` abuse has nothing to make; only invited devices provision.
+- Sybil bounded by minted invites (operator-controlled) → safe for closed testing + dogfood, no payment infra.
+- App stays anonymous — invite is a bearer token, no PII, no account/email.
+- One bearer token = the whole identity; one thing to save/share/back up. Lose it = lose the account — the saved key is the recovery.
+- The auth surface shrinks hard: no `password` column, no argon2, no `sessions` table, no `/api/identity/auth`, no Ring session middleware. `/auth/check` does one sha256 lookup; that's the entire per-request auth. Fewer moving parts than what was on the branch.
+- Adopting a key on more devices is free (no gate); only minting an account is gated. One invite → one account → many devices, all sharing the token.
+- Merge-on-adopt unions two local datasets: vocab dedups for free via content-addressed ids (ADR-0008, shipped); collections (mutable name) can still duplicate-by-value → post-merge concern, acceptable at invite scale.
+- The token never reaches the server as part of a URL, so it stays out of access logs and `Referer` headers; it is sent in a request body or the cookie.
+- The token is a long-lived bearer secret — in links, browser history, QR screenshots, IndexedDB (`device-db`), and a non-HttpOnly cookie. The cookie can't be HttpOnly because the client both sets it and must read the token to build the QR; this loses nothing, since the token already lives JS-readable in `device-db` (XSS reads it there regardless). Client-composed share only; rotation is the leak remedy.
+- No per-device logout (see Decision); rotation is the only revocation, all-or-nothing. Accepted for a personal app; leaf-token revocation can be added later by splitting the token hash into its own one-to-many table.
+- Forward-compatible: payment is a drop-in phase-2 grant source; the gate abstraction is unchanged, so no rework when it lands.
+- Free path = single-device local-only; multi-device/recovery/backup behind an invite. No-backup-until-granted risk → onboarding nudge, else lost/reset device = silent total data loss.
+- Invites must be single-use + unguessable + revocable; a leaked/shared invite costs at most the burns minted.
+- Reaper deferred (invite phase); orphans accumulate at most one per cross-account adoption — operator-visible scale.
+- Deferred — real payment now: no proven demand, fees/infra/compliance premature; revisit when demand is obvious, the gate slot is kept.
+- Rejected — PoW (compute-priced, adds solver/WASM/calibration, needless under controlled invites); rate-limiting alone (bounds inflow into an immortal stock); permanent identity/email anchors (contradict anonymity, beaten cheap by catch-all domains + disposable inboxes); `{id, secret}` + argon2 + sessions (password-login machinery on a high-entropy key — sha256 bearer token is equally secure and far simpler); per-device revocation (illusory unless devices hold non-re-mintable leaf tokens — disproportionate machinery here).
+- Implementation — invite mint/verify, provision + token mint, `users.token_sha256`, cookie-carried token, adopt/merge, export dump — deferred to an OpenSpec change referencing this ADR.

--- a/adr/0007-sync-trigger-strategy.md
+++ b/adr/0007-sync-trigger-strategy.md
@@ -1,0 +1,36 @@
+# 0007. Trigger-driven sync (baseline)
+
+- Status: accepted
+- Date: 2026-06-08
+
+## Context
+
+Cross-device data = PouchDB↔CouchDB replication. The shipped impl starts continuous live replication (`{:live true :retry true}`) per online device.
+
+Holding a connection is not inherently expensive — event-driven servers carry 100k+ idle sockets (C10k). The real costs here are specific:
+
+- **CouchDB, not TCP.** A continuous `_changes` feed is per-database; with db-per-user, each online device keeps its `userdb` hot (shards, file descriptors, Erlang processes, `max_dbs_open`) plus an nginx upstream conn per feed — heavier than an idle socket. But at hobby scale it likely holds; the "wall" was overstated.
+- **Mobile battery.** A held feed keeps the radio awake; every keepalive/change wakes it. This is the stronger driver — but it is **unmeasured** (battery-measurement TODO); treat it as a hypothesis, not a fact.
+
+Needed freshness is narrow: remote data matters only when a screen shows synced data — words, lesson, collections.
+
+## Decision
+
+Replace permanent live replication with trigger-driven one-shot passes. Each pass is `db.sync(remote, {live: false})` — completes and closes (a `_changes`+bulk burst, no held network feed; PouchDB's `retry` applies only to live mode, so a failed pass just ends). Two sides:
+
+- **Push** (local writes → server): driven by the **local** PouchDB `.changes` feed on `user-db` — an IndexedDB event stream, not a network feed — throttled, owned by the sync component. Any local write to a synced doc schedules a throttled push. The db's own change events are the single chokepoint (not a hand-listed set of Nexus write effects).
+- **Pull** (freshness for this device): a one-shot pass on entering a data page (words / collections) and on the `online` event. After the pass, the current page reloads its store slice via a `:page/load` action, so fresh data shows.
+
+Offline-first: entering a data page renders local data immediately and pulls in the background, re-rendering on arrival; render never blocks on the network. `navigator.onLine` is a cheap gate — it only reliably says "offline"; a never-rejecting pass plus the next trigger cover its false "online".
+
+Every data screen pulls on entry — words, collections, and lesson. Lesson is safe to include because the pass never touches a running lesson: `:page/load` is nil there, so the post-pass reload is a no-op. The pass still lands remote changes in the local database for whatever comes next, while the lesson stays exactly as it started.
+
+## Consequences
+
+- Sync cost scales with devices *active now*, not all online; no permanently held feeds.
+- Push uses a *local* changes listener (cheap, no network); pull is bursty short passes — better for battery (radio sleeps between), pending measurement.
+- "Used offline → closed → reopened online" is an app-start/foreground pull (a fresh page already online never sees an `online` transition); offline writes flush on the next `online` event or pull.
+- **Conscious gap: no real-time while two devices are open at once.** There is no notification, so device B sees A's change only on its next pull (page entry / online). This is the baseline.
+- Closing that gap is a **future** decision: push-notified sync via CouchDB `_db_updates` (one global fan-in feed) + a WebSocket fan-out — a separate ADR. Web Push is rejected for it: built for user-visible notifications (`userVisibleOnly`), not silent data sync, and iOS-fragile.
+- Rejected — sync on every user action (most actions touch no synced data; throttling collapses it back to push-on-write + periodic); permanent live feed (the held-feed costs above).
+- This ADR is the trigger **baseline**; the `_db_updates` + WebSocket layer will sit on top as the real-time enhancement, with these triggers as the fallback.

--- a/adr/0008-content-addressed-vocab-ids.md
+++ b/adr/0008-content-addressed-vocab-ids.md
@@ -1,6 +1,6 @@
 # 0008. Content-addressed vocab document ids
 
-- Status: proposed
+- Status: accepted
 - Date: 2026-06-04
 
 ## Context

--- a/adr/0008-content-addressed-vocab-ids.md
+++ b/adr/0008-content-addressed-vocab-ids.md
@@ -1,0 +1,33 @@
+# 0008. Content-addressed vocab document ids
+
+- Status: proposed
+- Date: 2026-06-04
+
+## Context
+
+Vocab docs get a random UUID `_id` — `new-word` sets no `_id`, PouchDB generates one. Dedup is add-time only: `add!` queries `find-duplicate` by normalized value, merges translations, before insert. Works within one device.
+
+Cross-device merge (ADR-0006) unions two local datasets via replication. Two devices each added the same word → two UUID-keyed docs, same value → replication keeps both → duplicate-by-value. Add-time dedup never fires (runs on add, not on sync).
+
+Word value is immutable — editing is restricted to translation (GH-96). So a value-derived id never needs to change.
+
+## Decision
+
+Content-address vocab docs: `_id = "vocab:" + normalize(value)`, not a random UUID. Same word on any device → same `_id` → replication yields one doc with a revision conflict, not two docs. Cross-device dedup is then free — no post-merge pass for words.
+
+Conflict resolution must **union translations**, not plain LWW: two devices adding the same word with different translations conflict on one doc, and LWW would drop the loser's translation. Reuse the existing `merge-translations` (today add-time) in the conflict resolver.
+
+`normalize` becomes a frozen contract: `_id` is permanent, so changing normalization (articles, case, umlauts) remaps the same word to a new `_id` and re-duplicates. Changing it = a data migration.
+
+Scope: vocab only. Collections keep surrogate ids — their name is mutable (`rename-collection`), so it cannot key the doc; collection merge stays a post-merge concern.
+
+## Consequences
+
+- Cross-device merge dedups vocab for free; the post-merge dedup pass (ADR-0006) drops for words, leaving only translation-union on conflict.
+- Homographs (788, e.g. "Abort") collapse to one doc — aligned with the merge-as-one-lemma policy.
+- `normalize` is now an immutable contract; any change needs a migration of all vocab `_id`s.
+- Translation merge moves from add-time row-dedup to conflict-time field-merge — cleaner (one doc, merge fields), but the resolver must run `merge-translations`, not LWW.
+- Migration: existing UUID-keyed vocab + reviews referencing them by `:word-id` must be rekeyed (new `_id`, repoint review `:word-id`). New installs unaffected.
+- Add-time `find-duplicate` can simplify to get-or-create by `_id`, as long as value normalization stays identical to the id scheme.
+- Collections excluded (mutable name); their cross-device dedup is unsolved here.
+- Implementation — id scheme, conflict resolver with `merge-translations`, migration of existing docs + review refs — deferred to an OpenSpec change referencing this ADR.

--- a/adr/0009-push-notified-sync-db-updates-websocket.md
+++ b/adr/0009-push-notified-sync-db-updates-websocket.md
@@ -1,0 +1,36 @@
+# 0009. Push-notified sync via _db_updates + WebSocket
+
+- Status: proposed
+- Date: 2026-06-09
+
+## Context
+
+ADR-0007 ships trigger-driven one-shot sync with a conscious gap: no real-time while two devices are open at once. Device B sees A's change only on its next pull (page entry / online event). Closing the gap means telling B "your db changed" without per-device held CouchDB feeds — N continuous `_changes` feeds per online device is exactly the cost 0007 removed.
+
+CouchDB has a global fan-in for this: `_db_updates` — **one** feed for the whole node, emitting `{db_name, type}` on any database write. Admin-only, so it must terminate in the backend, not the browser. With `global_changes` enabled it is durable and `since`-resumable; without, it is transient (missed events while the consumer is down are gone). Idle client sockets are cheap on an event-driven server (C10k) — the per-db feed wall was CouchDB's, not TCP's.
+
+Web Push was examined and rejected: built for user-visible notifications (`userVisibleOnly`), silent push is throttled/unreliable and iOS-fragile — semantically the wrong tool for a silent "go pull" signal.
+
+## Decision
+
+One fan-in, own fan-out. The backend holds a single `_db_updates` longpoll loop against CouchDB (localhost, admin creds) and fans out over WebSockets it owns.
+
+- **Fan-in**: a backend component loops `GET /_db_updates?feed=longpoll&since=<last>`, tracking `since` in memory. Longpoll over EventSource/continuous: trivial to consume from Clojure (one blocking request per wake), and it's a single localhost connection — streaming buys nothing. Filter events to `userdb-*`; map `userdb-<id>` → account id.
+- **Fan-out**: an http-kit WebSocket endpoint (native `as-channel`). Handshake authenticates via the existing session cookie; an atom registry `account-id → #{channels}` adds on open, removes on close. On a `_db_updates` event, send a tiny poke (no payload) to that account's channels. No payload → nothing secret in the message, no per-doc fan-out logic; the client pulls through the normal path.
+- **Client**: a system component opens the socket while the app is foregrounded (visibility API) and closes it on hidden — the radio sleeps in background, battery cost bounded by foreground use. On poke: dispatch `[:effect/sync-pull]` — the entire 0007 pull path (one-shot pass, conflict resolution, `:page/load` reload) is reused unchanged. On reconnect: one pull, covering pokes missed while disconnected.
+- **0007 stays as the fallback baseline**: page-entry and `online` pulls cover socket-down windows and `global_changes`-off gaps; the local-changes push side is untouched (the writer needs no notification).
+- **Infra**: nginx proxies the ws path with `Upgrade`/`Connection` headers and a long `proxy_read_timeout`; enable `global_changes` in CouchDB for durability (optional at first — reconnect-pull covers transience).
+
+Cost shape: one held CouchDB feed total (not per device) + idle ws sockets ∝ foregrounded clients — the cheap kind of held connection.
+
+## Consequences
+
+- Two open devices converge in seconds: A writes → throttled push → CouchDB → `_db_updates` → poke → B pulls. The 0007 gap closes.
+- Server adds two small components (fan-in loop, ws registry) and one nginx location; client adds one foreground-gated socket component. No schema, no new auth — the session cookie gates the handshake.
+- The poke carries nothing; a hijacked socket learns only "something changed". Auth failures close the socket at handshake.
+- In-memory registry and `since` mean a backend restart drops sockets and may miss events — covered by client reconnect-pull; no persistence needed until `global_changes` is enabled.
+- The own-poke echo is tolerated: A's push triggers a poke back to A, whose pull finds nothing (checkpoints converge) — same settled-echo class as 0007's local-feed echo. Server-side coalescing (throttle pokes per account) is an optional refinement.
+- Scale ceiling moves from "held CouchDB feeds per device" to "ws connections per foregrounded client" — far cheaper, single-node fine for the invite-phase population (ADR-0006).
+- Rejected: per-db `_changes`/EventSource feeds to clients (rebuilds the 0007 wall); Web Push (wrong tool, above); polling-while-foreground (wakes the radio on a timer for nothing — the poke wakes it only when there is data).
+- Whether the `online`-event pull stays or folds into reconnect-pull is decided at implementation (left open in the 0007 change).
+- Implementation — fan-in loop, ws endpoint + registry, client socket component, nginx — deferred to an OpenSpec change referencing this ADR.

--- a/infra/development/etc/nginx/sites-available/sprecha.local.template
+++ b/infra/development/etc/nginx/sites-available/sprecha.local.template
@@ -43,7 +43,11 @@ server {
         auth_request /auth/check;
 
         # 2. Take user/roles from the auth subrequest response headers
-        auth_request_set $couch_user  $upstream_http_x_auth_user;
+        #    nginx lowercases header names and replaces - with _ for $upstream_http_* vars.
+        #    X-Auth-UserName  → $upstream_http_x_auth_username
+        #    X-Auth-Roles     → $upstream_http_x_auth_roles
+        #    X-Auth-Token     → $upstream_http_x_auth_token
+        auth_request_set $couch_user  $upstream_http_x_auth_username;
         auth_request_set $couch_roles $upstream_http_x_auth_roles;
         auth_request_set $couch_token $upstream_http_x_auth_token;
 

--- a/infra/production/etc/environment.d/learning-app.conf
+++ b/infra/production/etc/environment.d/learning-app.conf
@@ -1,3 +1,3 @@
 # Comments are allowed
-LEARNING_APP_MODE=production
+LEARNING_APP__ENVIRONMENT=production
 LEARNING_APP_DB_PATH=/var/lib/learning-app/db.sqlite

--- a/infra/production/etc/nginx/sites-available/learning-app.conf
+++ b/infra/production/etc/nginx/sites-available/learning-app.conf
@@ -20,6 +20,46 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
     }
 
+    # Prevent clients from spoofing CouchDB proxy-auth headers
+    proxy_set_header X-Auth-CouchDB-UserName "";
+    proxy_set_header X-Auth-CouchDB-Roles    "";
+    proxy_set_header X-Auth-CouchDB-Token    "";
+
+    # CouchDB user databases (authenticated via session cookie)
+    location /db/ {
+        auth_request /auth/check;
+
+        # X-Auth-UserName  → $upstream_http_x_auth_username
+        # X-Auth-Roles     → $upstream_http_x_auth_roles
+        # X-Auth-Token     → $upstream_http_x_auth_token
+        auth_request_set $couch_user  $upstream_http_x_auth_username;
+        auth_request_set $couch_roles $upstream_http_x_auth_roles;
+        auth_request_set $couch_token $upstream_http_x_auth_token;
+
+        proxy_set_header X-Auth-CouchDB-UserName $couch_user;
+        proxy_set_header X-Auth-CouchDB-Roles    $couch_roles;
+        proxy_set_header X-Auth-CouchDB-Token    $couch_token;
+
+        proxy_pass http://127.0.0.1:5984/;
+        proxy_redirect off;
+        proxy_buffering off;
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 300s;
+        proxy_read_timeout 300s;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+        limit_req zone=couchdb burst=120;
+        limit_req_status 429;
+    }
+
+    location /auth/check {
+        internal;
+        proxy_pass http://127.0.0.1:8083/auth/check;
+        proxy_set_header Content-Length "";
+        proxy_pass_request_body off;
+    }
+
     # CouchDB dictionary-db (public read-only, rate limited)
     location /db/dictionary-db/ {
         # Replication uses _changes and _bulk_get bursts.

--- a/infra/production/etc/systemd/system/learning-app-run.service
+++ b/infra/production/etc/systemd/system/learning-app-run.service
@@ -10,13 +10,15 @@ LogsDirectory=learning-app
 StateDirectory=learning-app
 Restart=always
 RestartSec=10
-ExecStart=sh -c 'if [ -z "${OPENROUTER_API_KEY:-}" ] && [ -n "${OPENROUTER_API_KEY_PATH:-}" ] && [ -f "${OPENROUTER_API_KEY_PATH}" ]; then export OPENROUTER_API_KEY="$(cat "${OPENROUTER_API_KEY_PATH}")"; fi; java -jar /opt/learning-app/learning-app.jar'
+ExecStart=sh -c 'if [ -z "${OPENROUTER_API_KEY:-}" ] && [ -n "${OPENROUTER_API_KEY_PATH:-}" ] && [ -f "${OPENROUTER_API_KEY_PATH}" ]; then export OPENROUTER_API_KEY="$(cat "${OPENROUTER_API_KEY_PATH}")"; fi; if [ -z "${LEARNING_APP_DB_AUTH_SECRET:-}" ] && [ -n "${LEARNING_APP_DB_AUTH_SECRET_PATH:-}" ] && [ -f "${LEARNING_APP_DB_AUTH_SECRET_PATH}" ]; then export LEARNING_APP_DB_AUTH_SECRET="$(cat "${LEARNING_APP_DB_AUTH_SECRET_PATH}")"; fi; java -jar /opt/learning-app/learning-app.jar'
 
 # Environment
 EnvironmentFile=-/etc/learning-app/environment
 EnvironmentFile=-/etc/environment.d/learning-app.conf
 LoadCredentialEncrypted=openrouter_api_key:/etc/credstore.encrypted/openrouter_api_key
 Environment=OPENROUTER_API_KEY_PATH=%d/openrouter_api_key
+LoadCredentialEncrypted=db_auth_secret:/etc/credstore.encrypted/db_auth_secret
+Environment=LEARNING_APP_DB_AUTH_SECRET_PATH=%d/db_auth_secret
 
 # Security settings
 NoNewPrivileges=yes

--- a/infra/production/opt/couchdb/etc/local.d/10-learning-app.ini
+++ b/infra/production/opt/couchdb/etc/local.d/10-learning-app.ini
@@ -6,7 +6,11 @@
 bind_address = 127.0.0.1
 ; Allow anonymous access to databases with empty members list (e.g. dictionary-db).
 require_valid_user = false
+authentication_handlers = {chttpd_auth, cookie_authentication_handler}, {chttpd_auth, proxy_authentication_handler}, {chttpd_auth, default_authentication_handler}
 
 [chttpd_auth]
-; Proxy auth is not used for the public database setup.
+; Proxy auth relies on nginx controlling which requests reach /db/ — only the
+; /auth/check subrequest can set X-Auth-CouchDB-* headers. HMAC secret verification
+; adds a second layer; configure LEARNING_APP_DB_AUTH_SECRET in the app environment
+; and set the matching secret here (or via postinst) for defence-in-depth.
 proxy_use_secret = false

--- a/infra/production/usr/share/learning-app/admin-setup.sh
+++ b/infra/production/usr/share/learning-app/admin-setup.sh
@@ -187,6 +187,13 @@ else
 fi
 write_credential "borg-passphrase" "Enter encryption password for BorgBackup" "${rotate_borg}"
 
+# Signs the proxy-auth headers the app hands to CouchDB. Nobody types this one,
+# so it is generated rather than asked for; the app refuses to start without it.
+if [ ! -f "${CRED_DIR}/db_auth_secret" ]; then
+  store_credential "db_auth_secret" "$(openssl rand -hex 32)"
+  info "Generated db_auth_secret"
+fi
+
 if ! id -u deployer >/dev/null 2>&1; then
   adduser --disabled-password --gecos "" deployer
 fi

--- a/initial-setup.sql
+++ b/initial-setup.sql
@@ -78,3 +78,12 @@ CREATE TABLE IF NOT EXISTS reviews
 );
 
 
+CREATE TABLE IF NOT EXISTS recovery_tokens
+(
+    sha256     TEXT    PRIMARY KEY,
+    user_id    INTEGER NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+    created_at INTEGER DEFAULT (UNIXEPOCH()),
+    expires_at INTEGER NOT NULL
+);
+
+

--- a/openspec/changes/content-addressed-vocab-ids/.openspec.yaml
+++ b/openspec/changes/content-addressed-vocab-ids/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-with-adr
+created: 2026-06-04

--- a/openspec/changes/content-addressed-vocab-ids/design.md
+++ b/openspec/changes/content-addressed-vocab-ids/design.md
@@ -1,0 +1,33 @@
+## Context
+
+In-force ADRs: ADR-0008 (this change), with ADR-0006 (provisioning) and ADR-0007 (sync triggers) — none superseded. Current: `new-word` sets no `_id` so PouchDB assigns a UUID; `add!` dedups add-time via `find-duplicate` (normalized value) and `merge-translations`. Word value is immutable — editing is restricted to translation (GH-96), which makes a value-derived id safe.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Same word → same `_id` → free cross-device de-duplication via replication.
+- No lost translations when the same word is added concurrently.
+
+**Non-Goals:**
+- Collections de-duplication (mutable name) — out of scope.
+- The merge/replication mechanics themselves (ADR-0006/0007).
+
+## Decisions
+
+- **`_id = "vocab:" + normalize(value)`.** Deterministic, namespaced. Rationale: replication collapses same-word docs into one conflicted doc instead of duplicates. Safe because `value` is immutable. Alternative (keep UUID + post-merge dedup pass) rejected — fragile and recurring.
+- **Conflict resolver unions translations.** Reuse `merge-translations` (today add-time) inside the conflict handler. Rationale: plain LWW would drop the loser's translations. The work shifts from row-dedup to field-merge — one doc, merge fields.
+- **`normalize` is frozen.** Once it keys `_id`, any change remaps words and re-duplicates; treat as a contract, change only via migration.
+- **`find-duplicate` simplifies** to get-or-create by `_id` (normalization must match the id scheme exactly).
+
+## Risks / Trade-offs
+
+- Normalization change later → mass id migration → freeze and document it; cover the current rules with tests.
+- Homographs collapse to one doc — intended, matches the merge-as-one-lemma policy (788 homographs).
+
+## Migration Plan
+
+No migration. There are no users yet; the content-addressed `_id` applies to all new vocab docs. Reset any dev/test data instead of rewriting ids.
+
+## Open Questions
+
+- Where the conflict resolver lives relative to the sync-triggers change (ADR-0007) — it must run after a merge pass; coordinate ordering when both land.

--- a/openspec/changes/content-addressed-vocab-ids/proposal.md
+++ b/openspec/changes/content-addressed-vocab-ids/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+Vocab docs get a random UUID `_id`, and de-duplication is add-time only (`find-duplicate` by normalized value before insert). When two devices independently add the same word, cross-device merge (ADR-0006) unions two UUID-keyed docs with the same value into duplicates — add-time dedup never fires on sync. Per ADR-0008, content-addressing the vocab `_id` by normalized value makes the same word converge to one document, so merge de-duplicates for free.
+
+## What Changes
+
+- **BREAKING**: Vocab document `_id` becomes `"vocab:" + normalize(value)` instead of a random UUID. Same word → same `_id` on every device → one doc with a revision conflict instead of two docs.
+- Conflict resolution for vocab SHALL union translations (reuse `merge-translations`), not plain LWW, so a concurrent add with different translations does not drop one side.
+- `normalize(value)` becomes a frozen contract: `_id` is permanent, so changing normalization requires a data migration.
+- Scope is vocab only. Collections are excluded — their name is mutable (`rename-collection`), so it cannot key the doc.
+
+## Capabilities
+
+### New Capabilities
+<!-- None. -->
+
+### Modified Capabilities
+- `data-model`: the vocabulary-document requirement gains a content-addressed `_id` rule, and vocab conflict resolution is specified to union translations.
+
+## Impact
+
+- **Client**: `src/client/domain/vocabulary.cljs` (`new-word` sets a deterministic `_id`), `src/client/adapters/progress_store.cljs` (save path + conflict resolver running `merge-translations`), `src/client/use_cases/vocabulary.cljs` (`find-duplicate` can become get-or-create by `_id`).
+- **No migration**: no users yet; the content-addressed `_id` applies to new vocab docs only. Reset dev/test data if needed.
+- Enables the clean merge that ADR-0006 relies on. References ADR-0008.

--- a/openspec/changes/content-addressed-vocab-ids/specs/data-model/spec.md
+++ b/openspec/changes/content-addressed-vocab-ids/specs/data-model/spec.md
@@ -1,0 +1,36 @@
+## MODIFIED Requirements
+
+### Requirement: Vocabulary documents are stored
+The system SHALL store vocabulary documents with translations and ISO 8601 timestamps for creation and modification. The document `_id` SHALL be content-addressed as `"vocab:" + normalize(value)`, so the same word maps to the same document id on every device. Because the `_id` is permanent, the `value` normalization is a frozen contract — changing it requires migrating existing vocab ids.
+
+#### Scenario: Vocabulary document shape
+- **WHEN** a vocabulary word is stored
+- **THEN** the document includes `type`, `value`, `translation`, `created-at`, and `modified-at`
+- **AND** the document `_id` equals `"vocab:" + normalize(value)`
+
+Example:
+```json
+{
+  "_id": "vocab:hund",
+  "type": "vocab",
+  "value": "der Hund",
+  "translation": [{"lang": "en", "value": "dog"}],
+  "created-at": "2026-01-20T10:00:00.000Z",
+  "modified-at": "2026-01-20T10:10:00.000Z"
+}
+```
+
+#### Scenario: Same word converges across devices
+- **WHEN** two devices independently add the same word and then sync
+- **THEN** both produce the same `_id`
+- **AND** replication yields one document with a revision conflict, not two duplicate documents
+
+## ADDED Requirements
+
+### Requirement: Vocab conflict resolution unions translations
+The system SHALL resolve a vocab document revision conflict by unioning the translations of the conflicting revisions, not by plain last-write-wins.
+
+#### Scenario: Concurrent translations merge
+- **WHEN** two devices add the same word with different translations and sync
+- **THEN** the resolved document contains the union of both translation sets
+- **AND** neither side's translation is dropped

--- a/openspec/changes/content-addressed-vocab-ids/tasks.md
+++ b/openspec/changes/content-addressed-vocab-ids/tasks.md
@@ -1,0 +1,15 @@
+## 1. Content-addressed id
+
+- [x] 1.1 In `domain/vocabulary.cljs`, set the vocab `_id` to `"vocab:" + normalize(value)` in `new-word`
+- [x] 1.2 Freeze the `normalize` contract — add tests pinning current normalization (articles, case, umlauts)
+- [x] 1.3 Simplify `find-duplicate` to get-or-create by `_id` (keep normalization identical to the id scheme)
+
+## 2. Conflict resolution
+
+- [x] 2.1 Add a vocab conflict resolver that unions translations via `merge-translations` instead of plain LWW
+
+## 3. Verify
+
+- [x] 3.1 Two devices add the same word → same `_id` → after sync one doc, no duplicate
+- [x] 3.2 Two devices add the same word with different translations → resolved doc has the union, nothing dropped
+- [x] 3.3 `npx shadow-cljs compile app` clean and node tests green

--- a/openspec/changes/local-first-invite-provisioning/.openspec.yaml
+++ b/openspec/changes/local-first-invite-provisioning/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-with-adr
+created: 2026-06-04

--- a/openspec/changes/local-first-invite-provisioning/design.md
+++ b/openspec/changes/local-first-invite-provisioning/design.md
@@ -1,0 +1,57 @@
+## Context
+
+In-force ADRs (none superseded): ADR-0006 (this change's decision), ADR-0007 (sync triggers — shipped), ADR-0008 (content-addressed vocab ids — shipped). This design implements ADR-0006 phase 1.
+
+Current state: the shipped feature provisions eagerly (`/api/identity/claim` → immediate `userdb`), identity is `{:id, :secret}` with an argon2 password verified at a `/api/identity/auth` login that issues a DB-backed Ring session, pairing destroys the local `user-db` unconditionally, recovery uses one-time server tokens.
+
+## Goals / Non-Goals
+
+**Goals:**
+- No server resource until a user opts in with a valid invite.
+- One opaque bearer token in the user's hands, on every transport (QR, link).
+- Key entry adopts an account by merging local data, wiping only on a cross-account switch.
+- Export covers every synced doc type, permanently.
+
+**Non-Goals:**
+- Payment (ADR-0006 phase 2) — only the pluggable gate shape is preserved.
+- Per-device logout — illusory without non-re-mintable leaf tokens; rotation is the only revocation.
+- Reaper + `last_synced_at` — deferred; orphan scale during the invite phase is operator-visible.
+- Collection cross-device de-duplication — flagged as an open question.
+
+## Decisions
+
+- **Identity = one high-entropy bearer token, not `{id, secret}` + argon2 + session.** The server stores `sha256(token) → account` inline on the `users` row; the token is presented as a cookie and validated per request. Rationale: argon2 exists to slow brute force on low-entropy human passwords; a 160-bit random token is infeasible to brute-force, so sha256 is the right hash (same as `grants`). The session table existed only to avoid argon2-per-request — drop argon2 and the session disappears with it. Alternative (keep the password/session apparatus) rejected as cargo-culted machinery on an anonymous high-entropy key.
+- **Single `users` table holds the credential.** `users (id INTEGER PK, token_sha256 TEXT UNIQUE, created_at)`. The account id is the single source of truth, derived from the token; the token hash sits on the same row, so the two cannot diverge. One token per account (rotation = `UPDATE token_sha256`); a separate one-to-many `credentials` table was considered and dropped as premature flexibility (it duplicated the id across two tables for leaf-token/rotation-overlap features we do not need).
+- **Token = 160-bit URL-safe random (`random-token`).** `SecureRandom` → 20 bytes → 40 hex chars. Used for both account tokens and grant tokens, replacing the cargo-culted `(str (random-uuid) (random-uuid))`. No dashes, fixed length, QR-safe.
+- **Grants = own table, borrowed mechanics.** `grants (sha256 PK, created_at, expires_at, used_at NULL)` — a grant pre-dates any account, so no user reference. Named for the gate slot, not the phase-1 source: a phase-2 payment mints rows in the same table. Verify+burn atomically (`UPDATE … WHERE used_at IS NULL AND expires_at > ? RETURNING`). Mint = REPL function returning the plaintext token; no admin endpoint.
+- **Provision endpoint.** `POST /api/identity/provision {invite}` → verify + burn invite → mint token, INSERT the account row, create + role-secure the `userdb` → return `{id, token}`. Called by the boot hook on an `#invite=` link; a device that already has an account ignores the invite (no accidental second account).
+- **Account endpoint for adopt.** The key carries only the token, so a device adopting it learns its account id from `POST /api/identity/account` — the token goes in the body, not the cookie, so the device can find out whether the key is valid and whose it is *before* making it this device's identity. An invalid key writes no cookie, saves no identity and touches no data.
+- **Credentials ride in the URL fragment, never the query.** `#key=`, `#invite=`. A fragment is not part of the request: with a query string the token landed in nginx's access log, confirmed by reading it there, and would ride along in `Referer` headers. The router's redirect of the unmatched `/` uses `replace-state`, so the fragment leaves the address bar and the history entry with it — a path with no route is a redirect, not a visit.
+- **`/auth/check` = the entire per-request auth.** Reads the `sprecha-token` cookie, `sha256` lookup → account id, emits `X-Auth-UserName/Roles/Token` for the CouchDB proxy, else 401. One sha256 + lookup; this is what the removed session machinery is replaced by.
+- **Cookie is a client-set, derived cache of the token.** `use-identity!` writes `sprecha-token=<token>; path=/; SameSite=Lax; Secure` from `device-db`; not HttpOnly (the client owns it and builds the QR from it; the token already lives JS-readable in `device-db`, so HttpOnly buys nothing). No `Max-Age` — a session cookie rebuilt every boot. Rationale: in an offline-first PWA the cookie is the fragile store (Safari ITP caps JS cookies at 7 days; storage-pressure eviction), while `navigator.storage.persist()`-protected IndexedDB is durable. So the token's home is `device-db`, and the cookie is re-derived offline on each boot — eviction of the cookie is a non-event. The server never issues `Set-Cookie` (rejected: it would bet on cookie durability and need a network re-establish when the cookie is evicted).
+- **Persistent storage.** A `:storage/persistent` boot component calls `navigator.storage.persist()` to exempt `device-db` (and all PouchDB stores) from automatic eviction. The grant is environmental (browsers gate it on engagement / install); requesting it is the ceiling the standard API offers.
+- **Seed via first-sync push, not a separate ingest.** The provisioning device replicates its existing `user-db` into the fresh `userdb` on the next 0007 sync trigger. No payload upload at provision.
+- **Adopt/merge.** `check-incoming-auth!` handles one `#key=<token>` param: set the cookie → `account-id!`; nil (401) → invalid key, bail with no save and no wipe; else compare the server-returned id to the stored one → no stored / same id → keep local `user-db` (merge: replication unions local up, account down); different id → destroy local `user-db`, then save. The server id is authoritative (no client-parsed claim). A bad key that clobbers the cookie self-heals: `start!` (later in boot) re-sets the cookie from the stored `device-db` identity.
+- **Export = full dump.** `export-data!` returns every `user-db` doc (minus `_rev`), schema 2. `import-data!` dispatches by `:type`: vocab → LWW by `:modified-at`, anything else → insert-if-absent. Accepts schema 1 and 2. A hand-kept type list already dropped collections silently (GH-163); the dump kills the class. The manual export/import UI is removed; the functions stay for cold restore / REPL.
+- **Local-first start.** `sync/start!` reads the stored identity; present → `use-identity!` + triggers; absent → inert `{:sync/pull! (constantly nil)}` without any network call. `ensure-identity!`/`claim!`/`auth!` die. The 0007 wiring (capabilities, triggers, pull path) is untouched.
+- **No manual entry — links and QR only.** The invite is redeemed by opening an `#invite=` link; an account is adopted by opening a `#key=` link or scanning the pairing QR (same link). Both handled by the boot hook (`check-incoming-auth!`) — one code path, no prompt dialogs. The sync menu keeps its two items (pairing QR, recovery link), now carrying the token. Phase-2 payment redirects fit the `#invite=` door unchanged.
+
+## Risks / Trade-offs
+
+- Token leak = full account access → 160-bit secret, client-side transport only, rotation as remedy; the QR flow already carried the raw credential, so exposure does not widen.
+- No per-device logout → accepted for a personal app; deleting one device's cookie is theater while the device holds a re-presentable key. Rotation invalidates all devices at once.
+- `persist()` may be denied (environmental) → `device-db` stays best-effort in low-engagement contexts; the cookie-rebuild design tolerates eviction, and installed PWAs are typically granted persistence.
+- Cross-device merge can duplicate collections (mutable name; vocab is solved by ADR-0008) → accepted at invite scale, post-merge cleanup manual; open question.
+- Wrong merge direction could wipe data → wipe only on a confirmed account-id mismatch after the token validates against the server; default is merge.
+- Invite leak/guess → single-use + 160-bit + revocable (delete the row); blast radius = minted invites.
+- No server backup until provision → onboarding nudge toward saving the key early.
+
+## Migration Plan
+
+The feature only just merged and has no real users; existing eagerly-created `userdb`s are dev/test artifacts. Plan: drop existing `userdb`s, recreate `app.db` from the new schema (single `users`, `grants`, no `sessions`/`recovery_tokens`), ship local-first + invite gate, mint one operator invite to self-provision. Rollback: re-enable the `claim` route (kept in git history) if invite provisioning blocks testing.
+
+## Open Questions
+
+- Collection cross-device de-duplication: name is mutable so it can't key the doc — needs a post-merge dedup pass or a stable surrogate id. Out of scope here; revisit.
+- Token rotation endpoint: in this change or when first needed? Leaning minimal — ship the gate first, rotation lands with the first leak concern.
+- Phase-2 payment shape (one-time vs subscription) — deferred, does not constrain this change.

--- a/openspec/changes/local-first-invite-provisioning/proposal.md
+++ b/openspec/changes/local-first-invite-provisioning/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+The shipped sync feature provisions eagerly: the first app load calls `POST /api/identity/claim` and the server immediately creates a permanent CouchDB `userdb`, which is never deleted. Any anonymous visitor — or an attacker dripping requests — can pile unbounded empty databases until the node degrades. Per ADR-0006, the fix is local-first by default (no server resource until the user opts in) plus a grant gate on account creation. Phase 1 uses invites, enough to dogfood and onboard testers without payment infrastructure.
+
+## What Changes
+
+- **BREAKING**: Remove eager `claim`-time database creation. First launch provisions nothing server-side; all data lives only in the local PouchDB `user-db`. `POST /api/identity/claim` is removed.
+- Provision a server account (and its `userdb`) only against a valid single-use invite token. Grants get their own table named for the gate slot (`grants` — a phase-2 payment mints rows in the same table; a grant pre-dates any account) reusing the sha256 burn-on-use mechanics; minting is a REPL function — the operator is the developer.
+- **Identity becomes a single high-entropy bearer token**, replacing the `{id, secret}` + argon2 + session apparatus. The server stores only `sha256(token) → account` inline on the `users` row; there is no password, no argon2, no `sessions` table, no `/api/identity/auth`, no Ring session middleware. A device proves itself by presenting the token as a cookie; `/auth/check` (already an nginx subrequest per `/db/` call) does the sha256 lookup and emits the CouchDB role. The token is the credential, the cookie, and the session collapsed into one.
+- The user's key **is the token itself** — one opaque string, URL- and QR-safe as is (no packing, no `id.secret`). The pairing QR and shareable links carry it in the URL **fragment** (`#key=`, `#invite=`), which the browser never sends to the server — a query string would put a permanent credential in access logs and `Referer` headers. No manual entry.
+- The saved recovery artifact is the key (token) — durable, no expiry, no burn. The one-time recovery-token endpoints and table are removed (their burn-on-use role belongs to invites). No per-device logout: rotation (mint new token, drop the old) is the only revocation.
+- Entering a key on a device **adopts** that account: the device asks the server which account the token authenticates (`POST /api/identity/account`, token in the body) and adopts it only if an account comes back, so an invalid key leaves the device untouched; it then merges when it has no account or the same account (replication union, local pushed up), or wipes-and-replaces only on a confirmed cross-account switch. (Replaces the current unconditional local-db destroy on pairing.)
+- A newly provisioned account is seeded by the device pushing its local `user-db` up over normal replication — no payload upload at provision.
+- The auth cookie is set **client-side** from `device-db` (the durable home of the token) and rebuilt on every boot — in an offline-first PWA the cookie is the fragile store (ITP/eviction) and IndexedDB the durable one, so truth lives in `device-db` and the cookie is a derived cache. `navigator.storage.persist()` is requested at boot to shield `device-db` from eviction.
+- Export becomes a dump of **every** `user-db` doc (the hand-kept type list already dropped collections silently); import dispatches by `:type` with an insert-if-absent default. Schema version bumps. The manual export/import UI (words-page `⋮` menu) is removed — the functions stay for cold restore and REPL use.
+- Reaper and `last_synced_at` are deferred for the invite phase — orphans accumulate at most one per cross-account adoption.
+- Payment as a second grant source is explicitly deferred (ADR-0006 phase 2); the gate is designed pluggable so it drops in without rework.
+
+## Capabilities
+
+### New Capabilities
+- `account-provisioning`: local-first default; server account + `userdb` created only via a valid grant (phase-1 invite, single-use); single bearer-token identity validated per request at `/auth/check`; adopt-on-key-entry with merge vs cross-account wipe; rotation as the only revocation. Gate is pluggable for a later payment source.
+- `account-backup`: export as a full `user-db` dump (versioned), import by `:type` dispatch; account seeding via first-sync push; export/share is client-side only (no server-held PII).
+
+### Modified Capabilities
+<!-- None. The shipped sync/identity behavior was never captured in a spec, so it is introduced fresh under account-provisioning rather than modifying an existing capability. -->
+
+## Impact
+
+- **Client**: `src/client/sync.cljs` (no `ensure-identity!`/`claim!` at startup; replication only with a stored token; `start!` sets the cookie via `use-identity!`; `check-incoming-auth!` reads `#key=` and `#invite=` from the fragment), `src/client/adapters/identity.cljs` (`claim!`/`auth!` gone; `provision!`, `use-identity!` cookie writer, `account-id!`), `src/client/adapters/data_export.cljs` (full-dump export, type-dispatched import), `src/client/application.cljs` (`account-key-url` carries the token; export/import UI removed), `src/client/main.cljs` (`:storage/persistent` requests durable storage).
+- **Backend**: `src/backend/core.clj` (drop `claim`, `recovery-token`, `redeem`, `auth` routes and the session middleware/`Sessions` store; add invite mint REPL fn + `POST /api/identity/provision` + `POST /api/identity/account`; `/auth/check` reads the cookie token; `random-token` for grants and accounts; cookie parsing via `ring.middleware.cookies`).
+- **Schema**: `initial-setup.sql` — single `users (id, token_sha256, created_at)`; `grants` table (sha256 PK, expires_at, used_at nullable); `sessions` and `recovery_tokens` dropped.
+- **Migration**: existing eagerly-created `userdb`s and user rows are dev/test artifacts — drop them, recreate the schema, mint one operator invite to self-provision.
+- Reworks behavior on branch `feature/sync-delivery`. References ADR-0006.

--- a/openspec/changes/local-first-invite-provisioning/specs/account-backup/spec.md
+++ b/openspec/changes/local-first-invite-provisioning/specs/account-backup/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: Export covers every synced document
+The system SHALL export a versioned payload containing every document in the local `user-db`, regardless of type, so a new document type can never be silently dropped.
+
+#### Scenario: Backup includes collections
+- **WHEN** an export is produced on a device that has vocab, reviews, and collections
+- **THEN** the payload contains all of them
+
+#### Scenario: New doc type survives export
+- **WHEN** a future feature adds a new synced document type
+- **THEN** exports include it with no export-code change
+
+#### Scenario: Versioned payload
+- **WHEN** an export payload is produced
+- **THEN** it carries a schema version
+
+### Requirement: Import merges by document type
+The system SHALL import a payload by dispatching on each document's `:type`: vocab merges last-write-wins by `:modified-at`; any other type inserts if absent (idempotent union).
+
+#### Scenario: Re-import is idempotent
+- **WHEN** the same payload is imported twice
+- **THEN** the second import changes nothing
+
+#### Scenario: Unknown type still imports
+- **WHEN** a payload contains a document type the importer has no special handling for
+- **THEN** the document is inserted if absent rather than dropped
+
+### Requirement: Provisioned account is seeded by first-sync push
+The system SHALL seed a newly provisioned `userdb` by the device pushing its local `user-db` over normal replication; provisioning SHALL NOT upload a payload.
+
+#### Scenario: Seed on provision
+- **WHEN** an account is provisioned from a device holding local data
+- **THEN** the device's next sync pass pushes that data into the fresh `userdb`
+
+#### Scenario: Joining device sees the data
+- **WHEN** a second device enters the account key after the seed push
+- **THEN** replication delivers the first device's vocab, reviews, and collections
+
+### Requirement: Key share is client-side
+The system SHALL compose any share or email of the account key on the client, and the server SHALL NOT receive or store user email addresses for this purpose.
+
+#### Scenario: Client-composed share
+- **WHEN** a user shares their account key
+- **THEN** the link is composed by the client via share, copy, or mailto
+- **AND** the server does not receive the address

--- a/openspec/changes/local-first-invite-provisioning/specs/account-provisioning/spec.md
+++ b/openspec/changes/local-first-invite-provisioning/specs/account-provisioning/spec.md
@@ -1,0 +1,115 @@
+## ADDED Requirements
+
+### Requirement: Local-first default
+The system SHALL operate fully on-device by default and SHALL NOT create any server-side account or database on first launch or for users who never opt into cross-device sync.
+
+#### Scenario: Fresh launch creates no server resource
+- **WHEN** the app is launched on a device with no stored account token
+- **THEN** all data is read from and written to the local PouchDB only
+- **AND** no server account or `userdb` is created and no network identity call is made
+
+#### Scenario: Public visitor cannot provision
+- **WHEN** a request reaches the server without a valid grant
+- **THEN** no `userdb` is created
+
+### Requirement: Account creation requires a valid invite grant
+The system SHALL create a server account and its `userdb` only when presented with a valid, unexpired, single-use invite token, and SHALL burn the token on successful provision.
+
+#### Scenario: Provision with valid invite
+- **WHEN** a device submits a provision request with a valid unused invite
+- **THEN** the server mints a bearer token, creates the account row holding its hash and the role-secured `userdb`, and returns `{id, token}`
+- **AND** the invite is marked used
+
+#### Scenario: Provision with used or expired invite
+- **WHEN** a device submits a provision request with an already-used or expired invite
+- **THEN** the server rejects the request and creates no `userdb`
+
+#### Scenario: Invite arrives as a link
+- **WHEN** the app is opened via an `#invite=<token>` link
+- **THEN** the device provisions against that invite on boot
+
+#### Scenario: Provisioned device ignores an invite
+- **WHEN** an `#invite=` link is opened on a device that already has an account
+- **THEN** no provision request is made and the invite is not burned
+
+#### Scenario: Operator mints invites
+- **WHEN** the operator mints an invite via the REPL
+- **THEN** a single-use, expiring token is generated, returned in plaintext once, and stored hashed (sha256)
+
+### Requirement: Bearer-token identity
+The account identity SHALL be a single high-entropy bearer token. The server SHALL store only its sha256 against the account and SHALL authenticate every request by looking that hash up — there is no password, no session, and no separate login step.
+
+#### Scenario: Token authenticates per request
+- **WHEN** a request to the user's `userdb` carries the account token as the cookie
+- **THEN** the auth check resolves the account from the token's sha256 and authorizes the matching CouchDB role
+
+#### Scenario: Unknown token is rejected
+- **WHEN** a request carries no token or a token matching no account
+- **THEN** the auth check returns unauthorized
+
+#### Scenario: Key is the token, transported client-side
+- **WHEN** a user shares their account
+- **THEN** the key is the token itself, carried by the pairing QR or a client-composed link — there is no manual entry
+- **AND** the server never receives a user email address
+
+### Requirement: A credential never travels in a request URL
+Keys and invites SHALL be carried in the URL fragment, which browsers do not send to the server, so a permanent credential cannot reach access logs or `Referer` headers. The application SHALL clear the fragment once it has been read.
+
+#### Scenario: Opening a key link leaves no trace on the server
+- **WHEN** a device opens a link carrying a key or an invite
+- **THEN** the server's request log contains no part of the credential
+
+#### Scenario: The address bar is cleared
+- **WHEN** the credential has been read on boot
+- **THEN** the fragment is gone from the address bar and from the history entry, so navigating back does not restore it
+
+### Requirement: Recovery artifact is the token itself
+The system SHALL use the durable account token as the recovery artifact — no expiry, no burn-on-use. One-time semantics SHALL apply only to invites. Revocation SHALL be by rotation only (a new token replaces the old); there is no per-device logout.
+
+#### Scenario: Recovery link composed locally
+- **WHEN** the user asks for a recovery link
+- **THEN** the client composes a link carrying the token from the stored identity, with no server call
+
+#### Scenario: Saved recovery link stays valid
+- **WHEN** a saved recovery link is used a second time, or after a long delay
+- **THEN** it still adopts the account (until the token is rotated)
+
+### Requirement: Adopt account on key entry with data merge
+When a key is entered, the system SHALL validate the token against the server, then adopt the account by merging local and account data, except when the device currently belongs to a different account, in which case it SHALL replace the local database with the account's data. A destructive wipe SHALL happen only after the token validates and a confirmed account-id mismatch.
+
+#### Scenario: Invalid key adopts nothing
+- **WHEN** a key is entered whose token authenticates no account
+- **THEN** no identity is saved and the local database is not touched
+
+#### Scenario: Merge into same or empty account
+- **WHEN** a valid key is entered on a device that has no account or the same account
+- **THEN** local data is kept and merged into the account via replication union
+
+#### Scenario: Replace on cross-account switch
+- **WHEN** a valid key is entered on a device that currently belongs to a different account
+- **THEN** the local database is wiped and replaced with the entered account's data
+
+### Requirement: Account id is derived from the token
+The system SHALL let a device that holds only the token learn its account id from the server, so the key need not carry the id.
+
+#### Scenario: Adopting device resolves its account
+- **WHEN** a device presents the token and asks for its account
+- **THEN** the server returns the account id the token authenticates, or unauthorized for an unknown token
+
+### Requirement: Eager claim provisioning is removed
+The system SHALL NOT expose an unauthenticated endpoint that creates a server account; the prior `POST /api/identity/claim`, the password login, and the one-time recovery-token endpoints SHALL be removed.
+
+#### Scenario: Claim endpoint gone
+- **WHEN** a client calls the former `/api/identity/claim`
+- **THEN** the route does not exist and no account is created
+
+### Requirement: Auth cookie is a derived cache protected by durable storage
+The account token's durable home SHALL be local device storage (IndexedDB); the auth cookie SHALL be derived from it and re-established on each launch, so cookie eviction does not lose sign-in. The system SHALL request persistent storage to shield that durable store from automatic eviction.
+
+#### Scenario: Cookie rebuilt on launch
+- **WHEN** the app launches on a device that has a stored token but no auth cookie
+- **THEN** the cookie is re-written from the stored token with no network call
+
+#### Scenario: Persistent storage requested
+- **WHEN** the app boots
+- **THEN** it requests persistent storage for its origin

--- a/openspec/changes/local-first-invite-provisioning/tasks.md
+++ b/openspec/changes/local-first-invite-provisioning/tasks.md
@@ -1,0 +1,51 @@
+## 1. Backend: schema + invites
+
+- [x] 1.1 Single `users (id, token_sha256 UNIQUE, created_at)` in `initial-setup.sql`; drop `sessions` and `recovery_tokens` and the `name`/`password` columns
+- [x] 1.2 `grants` table (`sha256` PK, `created_at`, `expires_at`, `used_at` NULL)
+- [x] 1.3 `random-token` (160-bit hex, `SecureRandom`) shared by accounts and grants; replaces `(str (random-uuid) …)`
+- [x] 1.4 REPL mint fn (`mint-grant!`): generate token, store sha256 + expiry, return plaintext once
+
+## 2. Backend: token auth + provision + cleanup
+
+- [x] 2.1 `create-account!`: mint token, INSERT `users (token_sha256)`, create + role-secure the `userdb`, return `{id, token}`
+- [x] 2.2 `POST /api/identity/provision {invite}`: verify + burn invite atomically → `create-account!` → `{id, token}`
+- [x] 2.3 `POST /api/identity/account`: token in body → `{id}` or 401 (adopt id-resolution + token validation)
+- [x] 2.4 `/auth/check`: read `sprecha-token` cookie → sha256 lookup → CouchDB proxy headers, else 401
+- [x] 2.5 Remove `claim`, `auth`, `recovery-token`, `redeem` routes; drop the Ring session middleware + `Sessions` store + argon2; parse cookies via `ring.middleware.cookies`
+
+## 3. Client: token identity
+
+- [x] 3.1 `adapters/identity.cljs`: `use-identity!` (writes the `sprecha-token` cookie, `Secure`), `account-id!` (`POST /account` with the token in the body), `provision!`; drop `auth!`/`claim!`
+- [x] 3.2 `sync.cljs` `load`/`save-identity!` store `{:user-id :token}` in `device-db`
+- [x] 3.3 `application.cljs` `account-key-url` carries the token directly (`/#key=<token>`); QR + recovery link use it
+
+## 4. Client: local-first start + durable storage
+
+- [x] 4.1 `sync/start!`: stored identity → `use-identity!` + triggers; absent → inert `{:sync/pull! (constantly nil)}`, no network call
+- [x] 4.2 `main.cljs` `:storage/persistent` component requests `navigator.storage.persist()` at boot
+
+## 5. Client: adopt / provision on boot
+
+- [x] 5.1 `check-incoming-auth!` `#key=<token>`: set cookie → `account-id!`; nil → bail (no save/wipe); else compare server id with stored → same/none → keep local db (merge); different → destroy local db, then save
+- [x] 5.2 `check-incoming-auth!` `#invite=`: no stored identity → `provision!` + save; already provisioned → ignore (invite not burned)
+- [x] 5.3 Remove the `?recover=` and `?id=&secret=` branches
+
+## 6. Export / import
+
+- [x] 6.1 `export-data!` dumps every `user-db` doc (minus `_rev`), schema 2
+- [x] 6.2 `import-data!` dispatches by `:type`: vocab LWW, default insert-if-absent; accepts schema 1 and 2
+- [x] 6.3 Remove the manual export/import UI (words-page `⋮` menu, its effects and actions); functions stay for cold restore / REPL
+
+## 7. Migration (operator)
+
+- [x] 7.1 Drop dev/test `userdb`s; recreate `app.db` from the new schema; mint one invite and self-provision
+
+## 8. Verify
+
+- [x] 8.1 Fresh launch (cleared site data): zero identity/auth network calls, no server `userdb`; words work locally
+- [x] 8.2 Provision: junk invite → 403, no `userdb`; valid → `{id, token}`, burned, `userdb` + role; reuse → 403; `#invite=` link provisions on boot; provisioned device ignores a second invite
+- [x] 8.3 Auth: `/auth/check` with cookie → 200 + `X-Auth-*`; `/account` with cookie → `{id}`; both 401 on a bad/absent token
+- [x] 8.4 Seed-push: pre-provision local word (`vocab:tisch`, content-addressed) reached `userdb-N` on the next sync pass
+- [x] 8.5 Adopt: same-account `#key=` → merge, local data kept; cross-account `#key=` → local wipe + switch; cookie set client-side from JS each time
+- [ ] 8.6 Export round-trip: full dump includes collections; double import idempotent (no UI — verify via REPL or unit test)
+- [x] 8.7 `npx shadow-cljs compile app` clean (0 warnings) and node tests green (130 tests / 305 assertions)

--- a/openspec/changes/local-first-invite-provisioning/tasks.md
+++ b/openspec/changes/local-first-invite-provisioning/tasks.md
@@ -47,5 +47,5 @@
 - [x] 8.3 Auth: `/auth/check` with cookie → 200 + `X-Auth-*`; `/account` with cookie → `{id}`; both 401 on a bad/absent token
 - [x] 8.4 Seed-push: pre-provision local word (`vocab:tisch`, content-addressed) reached `userdb-N` on the next sync pass
 - [x] 8.5 Adopt: same-account `#key=` → merge, local data kept; cross-account `#key=` → local wipe + switch; cookie set client-side from JS each time
-- [ ] 8.6 Export round-trip: full dump includes collections; double import idempotent (no UI — verify via REPL or unit test)
+- [x] 8.6 Export round-trip: full dump includes collections, round-trips, double import is idempotent, vocab merges last-write-wins while other types insert-if-absent, schema 1 still imports
 - [x] 8.7 `npx shadow-cljs compile app` clean (0 warnings) and node tests green (130 tests / 305 assertions)

--- a/openspec/changes/sync-trigger-strategy/.openspec.yaml
+++ b/openspec/changes/sync-trigger-strategy/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-with-adr
+created: 2026-06-04

--- a/openspec/changes/sync-trigger-strategy/design.md
+++ b/openspec/changes/sync-trigger-strategy/design.md
@@ -1,0 +1,40 @@
+## Context
+
+In-force ADRs: ADR-0007 (this change), alongside ADR-0006 (provisioning) and ADR-0008 (vocab ids) — none superseded. Current state: `sync/start!` runs `db.sync(..., {:live true :retry true})` per online device. The client routes via Reitit controllers whose `:start` already dispatches per-page load effects (`:effect/load-words`, etc.); each page's show action writes its state slice through `:effect/save`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Cost scales with devices actively in use, not all online devices.
+- Pull only where freshness is needed (data pages); push on every local write.
+- Offline-first: never block render on the network.
+
+**Non-Goals:**
+- Real-time updates for two devices open simultaneously — the conscious gap of ADR-0007's baseline; closed later by the `_db_updates` + WebSocket layer (separate ADR).
+- Account provisioning (ADR-0006) and conflict de-duplication semantics (ADR-0008 — this change only runs the resolver per pass).
+
+## Decisions
+
+- **One-shot over live.** `db.sync(remote, {live: false})` single pass instead of `{:live true}`. Rationale: removes the held-feed costs; cost follows activity. PouchDB's `retry` applies only to live mode, so a failed pass just ends; the pass never rejects (failure logs and resolves nil) and the next trigger retries. Each pass resolves vocab conflicts before completing, so triggers can fire it freely.
+- **Push off the local changes feed, not Nexus write effects.** The sync component listens to `user-db`'s own `.changes({since: "now", live: true})` — IndexedDB events, no network — and runs a throttled pass. Rationale: a hand-listed effect set drifts (it already had a stale `:effect/delete-collection!` name and missed transitive writes); the database is the single chokepoint that cannot miss a write.
+- **Throttle, not debounce.** Leading-edge throttle (3s): the first write syncs immediately, a sustained burst (a lesson's reviews) coalesces into periodic passes. Debounce starves under sustained writing — the pass would never fire until the burst ends.
+- **Pull on data-page entry; `online` pull unconditional, reload state-gated.** The words, collections and lesson controllers dispatch `:effect/sync-pull` next to their load effect. The `online` listener pulls on any page — the pass also flushes offline writes, so gating it by page would delay push. What is page-gated is the *reload*: after the pass, `:action/reload-page` re-dispatches the effect stored in `:page/load`, which each page's show action sets ( `[:effect/load-words]`, `[:effect/load-collections]`, nil for home/lesson). State carries the target; no page→effect map to maintain.
+- **Lesson pulls on entry too, and that is safe.** The lesson route dispatches `:effect/sync-pull` beside its load effect. It cannot disturb the session: the pass is asynchronous (the lesson builds from local data without waiting), and the post-pass `:action/reload-page` reads `:page/load`, which is nil on lesson — so no reload fires. Remote changes land in the local database for what comes next while the running lesson stays as it started. Alternative (excluding lesson entirely) rejected: it skipped a natural sync point for no gain, since the reload gate already prevents mid-session disruption.
+- **`navigator.onLine` as a cheap gate** (true ≠ reachable): a false "online" just yields a failed pass that resolves nil; the next trigger retries.
+- **No `stop!`.** The sync component lives for the page lifetime; the listener dies with the page. A stop handler would be dead code.
+
+## Risks / Trade-offs
+
+- Two devices open simultaneously on a data page don't update in real time → baseline gap; the `_db_updates` + WebSocket ADR closes it.
+- "Used offline → closed → reopened online" is an app-start/foreground pull, not an `online` event (a fresh page already online never observes the transition) → covered by data-page-entry pull, not the listener.
+- A pull that writes remote docs locally fires the local changes feed → one throttled echo pass that finds nothing new (replication checkpoints converge); harmless, costs one short round-trip.
+- Throttle window too long loses recency, too short hammers the server → 3s placeholder; tune against the battery measurement methodology (tracked separately).
+
+## Migration Plan
+
+Swap `{:live true}` for the trigger wiring in one change; no data migration. Rollback: restore the `{:live true}` call (in git history). Independent of provisioning, so it can ship before or after ADR-0006.
+
+## Open Questions
+
+- Throttle exact value — tune against the battery measurement methodology (tracked separately).
+- Whether the `_db_updates` + WebSocket layer obsoletes the `online`-event pull or keeps it as the reconnect fallback.

--- a/openspec/changes/sync-trigger-strategy/proposal.md
+++ b/openspec/changes/sync-trigger-strategy/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+The shipped feature starts continuous live replication (`{:live true :retry true}`) for every online device. The held feed is not a TCP problem — the specific costs are CouchDB's per-database `_changes` feeds (shards, file descriptors, Erlang processes under db-per-user) and mobile radio battery (an unmeasured hypothesis, tracked separately). Needed freshness is narrow: remote data matters only on screens that display synced data. Per ADR-0007, replication becomes trigger-driven one-shot passes — the baseline under a future `_db_updates` + WebSocket push layer.
+
+## What Changes
+
+- **BREAKING**: Stop permanent live replication. Each pass is a one-shot `db.sync(remote, {live: false})` that completes and closes; the pass resolves vocab conflicts (LWW + translation union, ADR-0008) before reporting done.
+- **Push**: the local PouchDB `.changes` feed on `user-db` (an IndexedDB event stream, not a network feed) drives a throttled (3s, leading-edge) pass when online. The db's own change events are the single chokepoint — no hand-listed set of Nexus write effects to drift.
+- **Pull**: a pass on entering a data page — words, collections, lesson (route controllers) — and on the `online` event — the online pass runs regardless of page, since it also flushes offline writes. After a pass, the current page reloads its store slice via `:page/load` set in state by the page's show action; pages without it (home, lesson) skip the reload.
+- Lesson pulls on entry as well; a running lesson is never rebuilt by it, since `:page/load` is nil there and the post-pass reload is a no-op.
+- Offline-first render: entering a data page renders local data immediately and pulls in the background, re-rendering on arrival; rendering never blocks on the network.
+
+## Capabilities
+
+### New Capabilities
+- `sync-triggers`: trigger-driven replication — throttled push from the local changes feed, pull on data-page entry and on `online`, state-driven post-pull reload — replacing permanent live replication; offline-first render that never blocks on the network.
+
+### Modified Capabilities
+<!-- None. Live replication was never captured in a spec, so trigger-driven replication is introduced fresh under sync-triggers. -->
+
+## Impact
+
+- **Client**: `src/client/sync.cljs` (one-shot `sync-once!` with conflict resolution, throttled push off the local changes feed, expose `:sync/pull!`; `stop!` removed), `src/client/application.cljs` (`:effect/sync-pull`, `:action/reload-page`, pull on words/collections controllers, top-level nil-stripping render fix), `src/client/main.cljs` (`:app/sync` online listener, `:capabilities/sync` wiring), page show actions (`:page/current` + `:page/load`).
+- References ADR-0007 (baseline) and ADR-0008 (conflict resolution); independent of ADR-0006.

--- a/openspec/changes/sync-trigger-strategy/specs/sync-triggers/spec.md
+++ b/openspec/changes/sync-trigger-strategy/specs/sync-triggers/spec.md
@@ -1,0 +1,61 @@
+## ADDED Requirements
+
+### Requirement: No permanent live replication
+The system SHALL NOT hold a continuous replication feed open per online device. Replication SHALL run as discrete one-shot passes that complete and close the connection, resolving vocab conflicts before completing.
+
+#### Scenario: No held feed
+- **WHEN** a device is online but idle
+- **THEN** no continuous `_changes` feed is held open for it
+
+### Requirement: Push on local write
+The system SHALL run a replication pass shortly after any local write to the synced database, throttled and only when online, independent of the current screen and of which effect performed the write.
+
+#### Scenario: Write propagates without a feed
+- **WHEN** the user adds or edits a word, review, or collection while online
+- **THEN** a one-shot pass runs shortly after, and the change reaches the server without a held feed
+
+#### Scenario: Write burst coalesces
+- **WHEN** a burst of writes happens (a lesson's reviews)
+- **THEN** the first write triggers a pass immediately and the rest coalesce into periodic passes
+
+#### Scenario: Offline write defers
+- **WHEN** a write happens offline
+- **THEN** it is persisted locally and synced on the next `online` event or pull
+
+### Requirement: Pull on data-page entry
+The system SHALL run a replication pass when a screen showing synced data — words, collections, or lesson — is entered while online. A running lesson SHALL NOT be altered by that pass.
+
+#### Scenario: Entering words pulls
+- **WHEN** the user navigates to the words page while online
+- **THEN** a one-shot pass runs
+
+#### Scenario: Entering a lesson pulls without disturbing it
+- **WHEN** the user starts a lesson while online
+- **THEN** a one-shot pass runs and its results land in the local database
+- **AND** the lesson in progress is not reloaded or rebuilt
+
+### Requirement: Pull on regaining connectivity
+The system SHALL run a replication pass on the `online` event regardless of the current page, since the pass also flushes offline writes.
+
+#### Scenario: Online pulls and flushes
+- **WHEN** connectivity returns
+- **THEN** a one-shot pass runs, pushing any offline writes and pulling remote changes
+
+### Requirement: Post-pull reload is state-driven
+After a pull completes, the system SHALL reload the current page's data via the load effect stored in state by the page's show action; pages that store none SHALL NOT reload.
+
+#### Scenario: Fresh data shows on a data page
+- **WHEN** a pull completes while the user is on the words or collections page
+- **THEN** the page's load effect re-runs and the view shows the fresh data
+
+#### Scenario: No reload outside data pages
+- **WHEN** a pull completes while the user is on the home or lesson page
+- **THEN** no reload runs
+
+### Requirement: Offline-first render
+Entering a data page SHALL render local data immediately and pull in the background, re-rendering on arrival; rendering SHALL NOT block on the network.
+
+#### Scenario: Local-first then refresh
+- **WHEN** a data page is entered
+- **THEN** local data renders immediately
+- **AND** when the background pull completes, the view re-renders with fresh data

--- a/openspec/changes/sync-trigger-strategy/tasks.md
+++ b/openspec/changes/sync-trigger-strategy/tasks.md
@@ -1,0 +1,28 @@
+## 1. Replication primitive
+
+- [x] 1.1 One-shot `sync-once!` in `sync.cljs` — `db.sync(remote, {live: false})`, resolves vocab conflicts on completion, never rejects
+- [x] 1.2 Remove the permanent `{:live true :retry true}` replication and `stop!` from `sync/start!`
+
+## 2. Push on write
+
+- [x] 2.1 Throttled (3s, leading-edge) pass driven by the local `user-db` `.changes({since: "now", live: true})` feed, gated on `navigator.onLine`
+
+## 3. Pull triggers
+
+- [x] 3.1 Expose the pass as `:sync/pull!` through `:capabilities/sync`; `:effect/sync-pull` calls it and dispatches `:action/reload-page` on completion
+- [x] 3.2 Dispatch `:effect/sync-pull` from the words, collections and lesson route controllers
+- [x] 3.3 `:app/sync` component: `online` listener dispatching `:effect/sync-pull` (unconditional — also flushes offline writes)
+- [x] 3.4 Lesson pulls on entry too (reload stays a no-op there); home does not pull
+
+## 4. State-driven reload
+
+- [x] 4.1 Page show actions write `:page/current` and `:page/load` (`[:effect/load-words]`, `[:effect/load-collections]`, nil for home/lesson)
+- [x] 4.2 `:action/reload-page` re-dispatches the effect in `:page/load`; no-op when nil
+- [x] 4.3 Top-level render strips nil children (Replicant issue #70) so conditional shell fragments can't freeze the render loop
+
+## 5. Verify
+
+- [x] 5.1 `npx shadow-cljs compile app` clean and node tests green
+- [ ] 5.2 Two-browser check: write on device A → pass runs, no held feed; B pulls A's change on words/collections entry
+- [ ] 5.3 Data-page entry renders local instantly, fresh data appears after the pull
+- [ ] 5.4 `online` event triggers a pass; reload only on data pages

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "learning-app",
+  "name": "sync-delivery",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -9,7 +9,8 @@
         "@thi.ng/hiccup": "^5.3.15",
         "events": "^3.3.0",
         "pouchdb": "^9.0.0",
-        "pouchdb-find": "^9.0.0"
+        "pouchdb-find": "^9.0.0",
+        "qrcode": "^1.5.4"
       },
       "devDependencies": {
         "shadow-cljs": "3.4.9"
@@ -247,6 +248,30 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -298,6 +323,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/catering": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/catering/-/catering-2.1.1.tgz",
@@ -307,11 +341,49 @@
         "node": ">=6"
       }
     },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/deferred-leveldown": {
       "version": "5.3.0",
@@ -327,10 +399,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
+    },
     "node_modules/double-ended-queue": {
       "version": "2.1.0-0",
       "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
       "integrity": "sha512-+BNfZ+deCo8hMNpDqDnvT+c0XpJ5cUa6mqYq89bho2Ifze4URTqRkcwR399hWoTrTkbZ/XJYDgP6rc7pRgffEQ==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
     },
     "node_modules/encoding-down": {
@@ -388,6 +472,28 @@
         "tough-cookie": "^4.0.0"
       }
     },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -441,6 +547,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/isarray": {
@@ -745,6 +860,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ltgt": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
@@ -786,6 +913,60 @@
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/pouchdb": {
@@ -945,6 +1126,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
@@ -993,6 +1191,21 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
+    },
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -1018,6 +1231,12 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/set-cookie-parser": {
       "version": "2.7.1",
@@ -1086,6 +1305,32 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
       "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/through2": {
       "version": "3.0.2",
@@ -1219,6 +1464,26 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/write-stream": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/write-stream/-/write-stream-0.4.3.tgz",
@@ -1262,6 +1527,47 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@thi.ng/hiccup": "^5.3.15",
     "events": "^3.3.0",
     "pouchdb": "^9.0.0",
-    "pouchdb-find": "^9.0.0"
+    "pouchdb-find": "^9.0.0",
+    "qrcode": "^1.5.4"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,6 @@ Quick start (local, https://sprecha.local):
 2) Run:
 ```bash
 npm install
-sqlite3 app.db < initial-setup.sql
 COUCHDB_URL=http://localhost:5984 COUCHDB_PASS=<pass> clojure -X:dictionary-import
 npx shadow-cljs watch app  # terminal 1
 clj -M:dev -m core         # terminal 2

--- a/resources/migrations/001-initial-schema.sql
+++ b/resources/migrations/001-initial-schema.sql
@@ -7,14 +7,13 @@ CREATE TABLE IF NOT EXISTS users
     password   TEXT,
     created_at INTEGER DEFAULT (UNIXEPOCH())
 );
-
+--;;
 CREATE TABLE IF NOT EXISTS user_settings
 (
     user_id  INTEGER PRIMARY KEY REFERENCES users (id) ON DELETE CASCADE,
     settings BLOB DEFAULT '{}'
 );
-
-
+--;;
 CREATE TABLE IF NOT EXISTS sessions
 (
     id         INTEGER PRIMARY KEY,
@@ -23,8 +22,7 @@ CREATE TABLE IF NOT EXISTS sessions
     value      BLOB,
     created_at INTEGER DEFAULT (UNIXEPOCH())
 );
-
-
+--;;
 CREATE TABLE IF NOT EXISTS words
 (
     id          INTEGER PRIMARY KEY,
@@ -34,10 +32,9 @@ CREATE TABLE IF NOT EXISTS words
     created_at  INTEGER DEFAULT (UNIXEPOCH()),
     modified_at INTEGER
 );
-
-CREATE UNIQUE INDEX unique_user_word ON words (user_id, value);
-
-
+--;;
+CREATE UNIQUE INDEX IF NOT EXISTS unique_user_word ON words (user_id, value);
+--;;
 CREATE TABLE IF NOT EXISTS examples
 (
     id          INTEGER PRIMARY KEY,
@@ -49,16 +46,14 @@ CREATE TABLE IF NOT EXISTS examples
     created_at  INTEGER DEFAULT (UNIXEPOCH()),
     modified_at INTEGER
 );
-
-
+--;;
 CREATE TABLE IF NOT EXISTS lessons
 (
     id                   INTEGER PRIMARY KEY,
     user_id              INTEGER REFERENCES users (id) UNIQUE,
     current_challenge_id INTEGER
 );
-
-
+--;;
 CREATE TABLE IF NOT EXISTS challenges
 (
     id           INTEGER PRIMARY KEY,
@@ -67,8 +62,7 @@ CREATE TABLE IF NOT EXISTS challenges
     lesson_id    INTEGER REFERENCES lessons (id) ON DELETE CASCADE ON UPDATE CASCADE,
     passed       INTEGER DEFAULT (0)
 );
-
-
+--;;
 CREATE TABLE IF NOT EXISTS reviews
 (
     id          INTEGER PRIMARY KEY,
@@ -76,8 +70,7 @@ CREATE TABLE IF NOT EXISTS reviews
     retained    INTEGER,
     reviewed_at INTEGER DEFAULT (UNIXEPOCH())
 );
-
-
+--;;
 CREATE TABLE IF NOT EXISTS recovery_tokens
 (
     sha256     TEXT    PRIMARY KEY,
@@ -85,5 +78,3 @@ CREATE TABLE IF NOT EXISTS recovery_tokens
     created_at INTEGER DEFAULT (UNIXEPOCH()),
     expires_at INTEGER NOT NULL
 );
-
-

--- a/resources/migrations/002-bearer-token-identity.sql
+++ b/resources/migrations/002-bearer-token-identity.sql
@@ -1,0 +1,37 @@
+-- -*- mode: sql; sql-product: sqlite; -*-
+--
+-- One account = one bearer token (ADR-0006). The token replaces the
+-- name + argon2 password pair, so sessions and one-time recovery tokens are
+-- no longer needed: `/auth/check` resolves the account from the token itself.
+--
+-- Existing accounts keep their id, their settings and their CouchDB database,
+-- but come out with no token — their old credential cannot be turned into one.
+-- The operator issues each of them a new key.
+
+CREATE TABLE users_new
+(
+    id           INTEGER PRIMARY KEY,
+    token_sha256 TEXT UNIQUE,
+    created_at   INTEGER DEFAULT (UNIXEPOCH())
+);
+--;;
+INSERT INTO users_new (id, created_at) SELECT id, created_at FROM users;
+--;;
+DROP TABLE users;
+--;;
+ALTER TABLE users_new RENAME TO users;
+--;;
+DROP TABLE sessions;
+--;;
+DROP TABLE recovery_tokens;
+--;;
+-- Named for the gate it fills, not for its phase-1 source: a later payment
+-- mints rows here too. A grant pre-dates the account it creates, so it
+-- references no user.
+CREATE TABLE grants
+(
+    sha256     TEXT    PRIMARY KEY,
+    created_at INTEGER DEFAULT (UNIXEPOCH()),
+    expires_at INTEGER NOT NULL,
+    used_at    INTEGER
+);

--- a/resources/public/css/blocks/app-shell.css
+++ b/resources/public/css/blocks/app-shell.css
@@ -64,19 +64,28 @@
 }
 
 
+/* Shell actions sit in one row so any of them can be absent without
+   leaving a hole: install shows only when installable, sync only with
+   an account, the corner icon only on home/collections. */
+.app-shell__actions {
+  align-items: center;
+  display: flex;
+  gap: 4px;
+  position: fixed;
+  right: 16px;
+  top: 16px;
+  z-index: 20;
+}
+
 .app-shell__corner-icon {
   align-items: center;
   color: rgb(var(--color-black-text));
   display: inline-flex;
   height: 28px;
   justify-content: center;
-  position: fixed;
-  right: 16px;
   text-decoration: none;
-  top: 16px;
   transition: opacity 0.15s, transform 0.15s;
   width: 28px;
-  z-index: 20;
 }
 
 @media (hover: hover) {
@@ -96,7 +105,7 @@
 }
 
 
-.app-shell__menu-button {
+.app-shell__icon-button {
   align-items: center;
   background: none;
   border: none;
@@ -104,27 +113,27 @@
   color: rgb(var(--color-wolf));
   cursor: pointer;
   display: inline-flex;
-  font-size: 22px;
   height: 32px;
   justify-content: center;
   line-height: 1;
   min-height: auto;
   padding: 0 6px;
-  position: fixed;
-  right: 56px;
-  top: 16px;
   transition: color 0.15s, background-color 0.15s;
-  z-index: 20;
+}
+
+.app-shell__icon {
+  height: 20px;
+  width: 20px;
 }
 
 @media (hover: hover) {
-  .app-shell__menu-button:hover {
+  .app-shell__icon-button:hover {
     background: rgb(var(--color-polar));
     color: rgb(var(--color-owl));
   }
 }
 
-.app-shell__menu-button:active {
+.app-shell__icon-button:active {
   background: rgb(var(--color-polar));
   color: rgb(var(--color-owl));
 }

--- a/resources/public/css/blocks/app-shell.css
+++ b/resources/public/css/blocks/app-shell.css
@@ -96,41 +96,35 @@
 }
 
 
-.app-shell__install-button {
+.app-shell__menu-button {
   align-items: center;
   background: none;
   border: none;
-  border-radius: 0;
-  color: rgb(var(--color-kiwi));
+  border-radius: 8px;
+  color: rgb(var(--color-wolf));
   cursor: pointer;
   display: inline-flex;
-  font-family: Nunito, sans-serif;
-  font-size: 11px;
-  font-weight: 800;
-  height: 28px;
-  letter-spacing: 0.03em;
+  font-size: 22px;
+  height: 32px;
+  justify-content: center;
   line-height: 1;
   min-height: auto;
-  padding: 0;
+  padding: 0 6px;
   position: fixed;
   right: 56px;
   top: 16px;
-  text-transform: none;
-  transition: color 0.15s, opacity 0.15s;
+  transition: color 0.15s, background-color 0.15s;
   z-index: 20;
 }
 
 @media (hover: hover) {
-  .app-shell__install-button:hover {
+  .app-shell__menu-button:hover {
+    background: rgb(var(--color-polar));
     color: rgb(var(--color-owl));
   }
 }
 
-.app-shell__install-button:active {
+.app-shell__menu-button:active {
+  background: rgb(var(--color-polar));
   color: rgb(var(--color-owl));
-  opacity: 0.9;
-}
-
-.app-shell__install-button[hidden] {
-  display: none;
 }

--- a/resources/public/css/blocks/pwa-install.css
+++ b/resources/public/css/blocks/pwa-install.css
@@ -132,29 +132,3 @@
   font-weight: 700;
 }
 
-/* PWA Install Warning Icon - Top Right */
-
-.pwa-install-warn {
-  position: fixed;
-  top: 14px;
-  right: 16px;
-  z-index: 21;
-  background: none;
-  border: none;
-  font-size: 22px;
-  cursor: pointer;
-  color: #f59e0b;
-  line-height: 1;
-  padding: 4px;
-  transition: color 0.2s;
-  -webkit-appearance: none;
-  appearance: none;
-}
-
-.pwa-install-warn:active {
-  color: #d97706;
-}
-
-.pwa-install-warn:hover {
-  color: #d97706;
-}

--- a/resources/public/css/blocks/sync-dialogs.css
+++ b/resources/public/css/blocks/sync-dialogs.css
@@ -1,0 +1,94 @@
+/* Sync menu dialog — sheet of action buttons */
+
+.sync-menu-dialog__content {
+  display: flex;
+  flex-direction: column;
+  padding: 8px 0;
+}
+
+.sync-menu-dialog__item {
+  background: none;
+  border: none;
+  border-radius: 0;
+  color: rgb(var(--color-black-text));
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 16px;
+  font-weight: 600;
+  min-height: 52px;
+  padding: 14px 20px;
+  text-align: left;
+  transition: background-color 0.1s;
+  width: 100%;
+}
+
+@media (hover: hover) {
+  .sync-menu-dialog__item:hover {
+    background: rgb(var(--color-polar));
+  }
+}
+
+.sync-menu-dialog__item:active {
+  background: rgb(var(--color-polar));
+}
+
+.sync-menu-dialog__item--cancel {
+  color: rgb(var(--color-cardinal));
+  margin-top: 4px;
+}
+
+
+/* Pairing dialog — QR code for connecting a new device */
+
+.pairing-dialog__content {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 24px 20px 20px;
+  text-align: center;
+}
+
+.pairing-dialog__title {
+  font-size: 18px;
+  font-weight: 700;
+  margin: 0;
+}
+
+.pairing-dialog__hint {
+  color: rgb(var(--color-wolf));
+  font-size: 14px;
+  margin: 0;
+}
+
+.pairing-dialog__qr {
+  border-radius: 12px;
+  display: block;
+  height: 220px;
+  width: 220px;
+}
+
+.pairing-dialog__close {
+  background: rgb(var(--color-polar));
+  border: none;
+  border-radius: 10px;
+  color: rgb(var(--color-black-text));
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 15px;
+  font-weight: 600;
+  height: 44px;
+  margin-top: 4px;
+  padding: 0 28px;
+  transition: background-color 0.15s;
+}
+
+@media (hover: hover) {
+  .pairing-dialog__close:hover {
+    background: rgb(var(--color-swan));
+  }
+}
+
+.pairing-dialog__close:active {
+  background: rgb(var(--color-swan));
+}

--- a/resources/public/css/styles.css
+++ b/resources/public/css/styles.css
@@ -22,3 +22,4 @@
 @import url("./blocks/vocabulary.css") layer(blocks);
 @import url("./blocks/pwa-install.css") layer(blocks);
 @import url("./blocks/collections.css") layer(blocks);
+@import url("./blocks/sync-dialogs.css") layer(blocks);

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -6,7 +6,7 @@
   [metosin/reitit "0.10.1"]
   [no.cjohansen/dataspex "2026.04.1"]
   [no.cjohansen/nexus "2025.11.1"]
-  [no.cjohansen/replicant "2025.12.1"]
+  [no.cjohansen/replicant "2026.07.1"]
 
   [philoskim/debux "0.9.1"]
   [refactor-nrepl/refactor-nrepl "3.11.0"]

--- a/src/backend/README.md
+++ b/src/backend/README.md
@@ -44,7 +44,10 @@ See [readme.md](../../readme.md) for full dev setup (nginx, TLS, DB init).
 
 ## Database
 
-Server-side SQLite file: `app.db` (created by `initial-setup.sql`).
+Server-side SQLite file: `app.db`, built and kept current by the migrations in
+`resources/migrations/`, which `start-server!` applies before serving. The
+migration list in `migrations.clj` is the schema's single source of truth: add a
+new file for every change, never edit one that has shipped.
 Custom SQL functions registered at startup live in `sqlite/application_defined_functions.clj`.
 Queries built with HoneySQL; executed via next.jdbc.
 

--- a/src/backend/core.clj
+++ b/src/backend/core.clj
@@ -83,12 +83,12 @@
                                                           :debug)])))
                                     (jdbc/with-options jdbc/unqualified-snake-kebab-opts))]
 
-                               ;; Enable foreign key constraints in SQLite, as they are disabled by default.
-                               ;; This constraint must be enabled separately for each connection.
-                               ;; See https://www.sqlite.org/foreignkeys.html#fk_enable
-                               (jdbc/execute! ~sym ["PRAGMA foreign_keys = on"])
+     ;; Enable foreign key constraints in SQLite, as they are disabled by default.
+     ;; This constraint must be enabled separately for each connection.
+     ;; See https://www.sqlite.org/foreignkeys.html#fk_enable
+     (jdbc/execute! ~sym ["PRAGMA foreign_keys = on"])
 
-                               ~@body))
+     ~@body))
 
 
 ;; This makes possible to pass clojure map or vector as a query parameter.
@@ -127,8 +127,8 @@
   (when (and (utils/non-blank user-name)
              (utils/non-blank password))
     (let [user (jdbc/execute-one! db
-                                  ["SELECT id, password FROM users WHERE name = ?" user-name]
-                                  {:builder-fn result-set/as-unqualified-maps})]
+                 ["SELECT id, password FROM users WHERE name = ?" user-name]
+                 {:builder-fn result-set/as-unqualified-maps})]
       (when (:valid (hashers/verify password (:password user)))
         (:id user)))))
 
@@ -141,8 +141,8 @@
   ([db user-name password]
    (let [password-hash (hashers/derive password {:alg :argon2id})
          {:keys [id]}  (jdbc/execute-one! db
-                                          ["INSERT INTO users (name, password) VALUES (?, ?) RETURNING id"
-                                           user-name password-hash])
+                         ["INSERT INTO users (name, password) VALUES (?, ?) RETURNING id"
+                          user-name password-hash])
          couch-db      (db/use (str "userdb-" id))]
      (db/secure couch-db {:members {:names [] :roles [(str "u:" id)]}})
      {:id id :secret password})))
@@ -153,8 +153,8 @@
   [db id secret]
   (when (and (some? id) (utils/non-blank secret))
     (let [user (jdbc/execute-one! db
-                                  ["SELECT id, password FROM users WHERE id = ?" id]
-                                  {:builder-fn result-set/as-unqualified-maps})]
+                 ["SELECT id, password FROM users WHERE id = ?" id]
+                 {:builder-fn result-set/as-unqualified-maps})]
       (when (:valid (hashers/verify secret (or (:password user) "")))
         (:id user)))))
 
@@ -178,9 +178,9 @@
 
 (comment
   (on-connection [db db-spec]
-                 (add-user db "shundeevegor@gmail.com" "3434"))
+    (add-user db "shundeevegor@gmail.com" "3434"))
   (on-connection [db db-spec]
-                 (user-id db "shundeevegor@gmail.com" "3434")))
+    (user-id db "shundeevegor@gmail.com" "3434")))
 
 
 ;;
@@ -193,8 +193,8 @@
     (read-session [_ token]
       (:value
        (jdbc/execute-one! db
-                          ["SELECT value FROM sessions WHERE token = ?" token]
-                          {:builder-fn result-set/as-unqualified-maps})))
+         ["SELECT value FROM sessions WHERE token = ?" token]
+         {:builder-fn result-set/as-unqualified-maps})))
     (write-session [_ token value]
       (let [token (or token (str (random-uuid)))]
         (jdbc/execute! db ["INSERT INTO sessions (token, value) VALUES (?, ?)" token value])
@@ -381,61 +381,61 @@
       {:post
        (fn [_request]
          (on-connection [db db-spec]
-                        (let [{:keys [id secret]} (add-user db)]
-                          (-> {:status  200
-                               :headers {"Content-Type" "application/json"}
-                               :body    (cheshire/generate-string {:id id :secret secret})}
-                              (assoc :session {:user-id id})))))}]
+           (let [{:keys [id secret]} (add-user db)]
+             (-> {:status  200
+                  :headers {"Content-Type" "application/json"}
+                  :body    (cheshire/generate-string {:id id :secret secret})}
+                 (assoc :session {:user-id id})))))}]
 
      ["/api/identity/auth"
       {:post
        (fn [request]
          (on-connection [db db-spec]
-                        (let [{:keys [id secret]} (some-> (:body request) io/reader (cheshire/parse-stream true))]
-                          (if-let [uid (identity-user-id db id secret)]
-                            (-> {:status 200}
-                                (assoc :session {:user-id uid}))
-                            {:status 401 :body ""}))))}]
+           (let [{:keys [id secret]} (some-> (:body request) io/reader (cheshire/parse-stream true))]
+             (if-let [uid (identity-user-id db id secret)]
+               (-> {:status 200}
+                   (assoc :session {:user-id uid}))
+               {:status 401 :body ""}))))}]
 
      ["/api/identity/recovery-token"
       {:post
        (fn [{:keys [session]}]
          (if-let [uid (:user-id session)]
            (on-connection [db db-spec]
-                          (let [token      (str (random-uuid) (random-uuid))
-                                token-hash (sha256-hex token)
-                                expires-at (+ (System/currentTimeMillis) (* 30 24 60 60 1000))]
-                            (jdbc/execute! db
-                                           ["INSERT INTO recovery_tokens (sha256, user_id, expires_at) VALUES (?, ?, ?)"
-                                            token-hash uid expires-at])
-                            {:status  200
-                             :headers {"Content-Type" "application/json"}
-                             :body    (cheshire/generate-string {:token token})}))
+             (let [token      (str (random-uuid) (random-uuid))
+                   token-hash (sha256-hex token)
+                   expires-at (+ (System/currentTimeMillis) (* 30 24 60 60 1000))]
+               (jdbc/execute! db
+                 ["INSERT INTO recovery_tokens (sha256, user_id, expires_at) VALUES (?, ?, ?)"
+                  token-hash uid expires-at])
+               {:status  200
+                :headers {"Content-Type" "application/json"}
+                :body    (cheshire/generate-string {:token token})}))
            {:status 401 :body ""}))}]
 
      ["/api/identity/redeem"
       {:post
        (fn [request]
          (on-connection [db db-spec]
-                        (let [{:keys [token]} (some-> (:body request) io/reader (cheshire/parse-stream true))]
-                          (if (utils/non-blank token)
-                            (let [token-hash (sha256-hex token)
-                                  now        (System/currentTimeMillis)
-                                  row        (jdbc/execute-one!
-                                              db
-                                              ["SELECT user_id FROM recovery_tokens WHERE sha256 = ? AND expires_at > ?"
-                                               token-hash now]
-                                              {:builder-fn result-set/as-unqualified-maps})]
-                              (if row
-                                (let [uid        (:user-id row)
-                                      new-secret (identity-secret-reset! db uid)]
-                                  (jdbc/execute! db ["DELETE FROM recovery_tokens WHERE sha256 = ?" token-hash])
-                                  (-> {:status  200
-                                       :headers {"Content-Type" "application/json"}
-                                       :body    (cheshire/generate-string {:id uid :secret new-secret})}
-                                      (assoc :session {:user-id uid})))
-                                {:status 401 :body ""}))
-                            {:status 400 :body ""}))))}]]
+           (let [{:keys [token]} (some-> (:body request) io/reader (cheshire/parse-stream true))]
+             (if (utils/non-blank token)
+               (let [token-hash (sha256-hex token)
+                     now        (System/currentTimeMillis)
+                     row        (jdbc/execute-one!
+                                  db
+                                  ["SELECT user_id FROM recovery_tokens WHERE sha256 = ? AND expires_at > ?"
+                                   token-hash now]
+                                  {:builder-fn result-set/as-unqualified-maps})]
+                 (if row
+                   (let [uid        (:user-id row)
+                         new-secret (identity-secret-reset! db uid)]
+                     (jdbc/execute! db ["DELETE FROM recovery_tokens WHERE sha256 = ?" token-hash])
+                     (-> {:status  200
+                          :headers {"Content-Type" "application/json"}
+                          :body    (cheshire/generate-string {:id uid :secret new-secret})}
+                         (assoc :session {:user-id uid})))
+                   {:status 401 :body ""}))
+               {:status 400 :body ""}))))}]]
 
     {:data {:interceptors [#_session-interceptor
                            (parameters/parameters-interceptor)

--- a/src/backend/core.clj
+++ b/src/backend/core.clj
@@ -10,6 +10,7 @@
    [examples :as examples]
    [hiccup :as hiccup]
    [honey.sql :as sql]
+   [migrations :as migrations]
    [next.jdbc :as jdbc]
    [next.jdbc.prepare :as prepare]
    [next.jdbc.result-set :as result-set]
@@ -540,6 +541,9 @@
 (defn -main
   []
   (let [url (str "http://localhost:" port "/")]
+    ;; Migrate before serving: the app never runs against an outdated schema.
+    (on-connection [db db-spec]
+      (migrations/ensure-migrated! db))
     (restart-server! #'ring-handler port)
     (println "Serving" url)))
 

--- a/src/backend/core.clj
+++ b/src/backend/core.clj
@@ -1,7 +1,6 @@
 (ns core
   (:gen-class)
   (:require
-   [buddy.hashers :as hashers]
    [cheshire.core :as cheshire]
    [clojure.edn :as edn]
    [clojure.java.io :as io]
@@ -9,7 +8,6 @@
    [db :as db]
    [examples :as examples]
    [hiccup :as hiccup]
-   [honey.sql :as sql]
    [migrations :as migrations]
    [next.jdbc :as jdbc]
    [next.jdbc.prepare :as prepare]
@@ -20,13 +18,12 @@
    [reitit.http.interceptors.parameters :as parameters]
    [reitit.interceptor.sieppari :as sieppari]
    [reitit.ring :as ring]
-   [ring.middleware.session :as session]
-   [ring.middleware.session.store :as store]
+   [ring.middleware.cookies :as cookies]
    [ring.util.response :as response]
    [taoensso.telemere :as t]
    [utils :as utils])
   (:import
-   [java.security MessageDigest]
+   [java.security MessageDigest SecureRandom]
    [java.sql PreparedStatement ResultSetMetaData]
    [java.util HexFormat]
    [javax.crypto Mac]
@@ -127,52 +124,6 @@
 ;;
 
 
-(defn user-id
-  [db user-name password]
-  (when (and (utils/non-blank user-name)
-             (utils/non-blank password))
-    (let [user (jdbc/execute-one! db
-                 ["SELECT id, password FROM users WHERE name = ?" user-name]
-                 {:builder-fn result-set/as-unqualified-maps})]
-      (when (:valid (hashers/verify password (:password user)))
-        (:id user)))))
-
-
-(defn add-user
-  "Creates user in SQLite and provisions a CouchDB userdb.
-   Returns {:id int :secret plaintext-password}."
-  ([db]
-   (add-user db (str (random-uuid)) (str (random-uuid) (random-uuid))))
-  ([db user-name password]
-   (let [password-hash (hashers/derive password {:alg :argon2id})
-         {:keys [id]}  (jdbc/execute-one! db
-                         ["INSERT INTO users (name, password) VALUES (?, ?) RETURNING id"
-                          user-name password-hash])
-         couch-db      (db/use (str "userdb-" id))]
-     (db/secure couch-db {:members {:names [] :roles [(str "u:" id)]}})
-     {:id id :secret password})))
-
-
-(defn- identity-user-id
-  "Returns integer user-id when id+secret are valid, nil otherwise."
-  [db id secret]
-  (when (and (some? id) (utils/non-blank secret))
-    (let [user (jdbc/execute-one! db
-                 ["SELECT id, password FROM users WHERE id = ?" id]
-                 {:builder-fn result-set/as-unqualified-maps})]
-      (when (:valid (hashers/verify secret (or (:password user) "")))
-        (:id user)))))
-
-
-(defn- identity-secret-reset!
-  "Generates a new secret for user-id, updates the stored hash, returns plaintext secret."
-  [db user-id]
-  (let [secret (str (random-uuid) (random-uuid))
-        hash   (hashers/derive secret {:alg :argon2id})]
-    (jdbc/execute! db ["UPDATE users SET password = ? WHERE id = ?" hash user-id])
-    secret))
-
-
 (defn- sha256-hex
   [^String s]
   (.formatHex
@@ -181,32 +132,82 @@
               (.update (.getBytes s "UTF-8"))))))
 
 
+(def ^:private ^SecureRandom secure-random (SecureRandom.))
+
+
+(defn- random-token
+  "A 160-bit URL-safe bearer token (40 hex chars)."
+  []
+  (let [bytes (byte-array 20)]
+    (.nextBytes secure-random bytes)
+    (.formatHex (HexFormat/of) bytes)))
+
+
+(defn create-account!
+  "Mints a bearer token, creates the account row holding its sha256, and its
+   role-secured CouchDB userdb. Returns {:id int :token str} — the raw token
+   is the user's key, stored nowhere on the server."
+  [db]
+  (let [token        (random-token)
+        {:keys [id]} (jdbc/execute-one! db
+                       ["INSERT INTO users (token_sha256) VALUES (?) RETURNING id"
+                        (sha256-hex token)])]
+    (db/secure (db/use (str "userdb-" id)) {:members {:names [] :roles [(str "u:" id)]}})
+    {:id id :token token}))
+
+
+(defn- authenticated-user-id
+  "Returns the account id a bearer token authenticates, or nil."
+  [db token]
+  (when (utils/non-blank token)
+    (:id (jdbc/execute-one! db
+           ["SELECT id FROM users WHERE token_sha256 = ?"
+            (sha256-hex token)]
+           {:builder-fn result-set/as-unqualified-maps}))))
+
+
+(defn mint-grant!
+  "Stores the sha256 of a fresh single-use grant token and returns the
+   plaintext token — shown once, REPL-only (ADR-0006 phase-1 invites)."
+  ([db]
+   (mint-grant! db (* 30 24 60 60 1000)))
+  ([db ttl-ms]
+   (let [token (random-token)]
+     (jdbc/execute! db
+       ["INSERT INTO grants (sha256, expires_at) VALUES (?, ?)"
+        (sha256-hex token) (+ (System/currentTimeMillis) ttl-ms)])
+     token)))
+
+
+(defn- burn-grant!
+  "Atomically burns an unused, unexpired grant. Returns true when burned."
+  [db token]
+  (some?
+   (jdbc/execute-one!
+     db
+     ["UPDATE grants SET used_at = UNIXEPOCH()
+      WHERE sha256 = ? AND used_at IS NULL AND expires_at > ?
+      RETURNING sha256"
+      (sha256-hex token) (System/currentTimeMillis)])))
+
+
 (comment
   (on-connection [db db-spec]
-    (add-user db "shundeevegor@gmail.com" "3434"))
-  (on-connection [db db-spec]
-    (user-id db "shundeevegor@gmail.com" "3434")))
+    (mint-grant! db)))
 
 
 ;;
-;; User Session
+;; Auth — bearer token in a cookie, validated per request (ADR-0006)
 ;;
 
 
-(deftype Sessions [db]
-  store/SessionStore
-    (read-session [_ token]
-      (:value
-       (jdbc/execute-one! db
-         ["SELECT value FROM sessions WHERE token = ?" token]
-         {:builder-fn result-set/as-unqualified-maps})))
-    (write-session [_ token value]
-      (let [token (or token (str (random-uuid)))]
-        (jdbc/execute! db ["INSERT INTO sessions (token, value) VALUES (?, ?)" token value])
-        token))
-    (delete-session [_ token]
-      (jdbc/execute! db (sql/format {:delete-from :sessions :where [:= :token token]}))
-      nil))
+(def ^:private token-cookie "sprecha-token")
+
+
+(defn- request-token
+  "Reads the bearer token from the parsed cookies, or nil."
+  [request]
+  (get-in request [:cookies token-cookie :value]))
 
 
 (defn hmac-sign
@@ -219,45 +220,17 @@
     (.getBytes user-name))))
 
 
-(defn auth-proxy-response
-  "Produce the `/auth/check` response map expected by the CouchDB proxy.
-
-  When the session is missing, or empty, a `401` response is returned.
-  Otherwise the response includes the proxy auth headers populated from
-  the current `:user-id`."
-  [session]
-  (if (seq session)
-    (let [user-name  (-> session :user-id str)
-          user-roles (str/join "," [(str "u:" user-name)])
-          token      (hmac-sign user-name db-auth-secret)]
-      (-> {:status 200}
-          (response/header "X-Auth-UserName" user-name)
-          (response/header "X-Auth-Roles" user-roles)
-          (response/header "X-Auth-Token" token)))
-    {:status 401}))
-
-
 ;;
 ;; Interceptors
 ;;
 
 
-(def session-interceptor
-  {:name  ::session-interceptor
+(def cookie-interceptor
+  "Parses the Cookie header into the request's :cookies map. The server only
+   reads the bearer token — the client sets it — so there is no response leg."
+  {:name  ::cookie-interceptor
    :enter (fn [ctx]
-            (jdbc/on-connection [db db-spec]
-              (let [opts {:store        (->Sessions db)
-                          :set-cookies? true
-                          :cookie-name  "ring-session"
-                          :cookie-attrs {:path "/" :http-only true}}]
-                (update ctx :request session/session-request opts))))
-   :leave (fn [ctx]
-            (jdbc/on-connection [db db-spec]
-              (let [opts {:store        (->Sessions db)
-                          :set-cookies? true
-                          :cookie-name  "ring-session"
-                          :cookie-attrs {:path "/" :http-only true}}]
-                (update ctx :response session/session-response (:request ctx) opts))))})
+            (update ctx :request cookies/cookies-request))})
 
 
 ;;
@@ -352,8 +325,15 @@
 
      ["/auth/check"
       {:get
-       (fn [{:keys [session] :as _request}]
-         (auth-proxy-response session))}]
+       (fn [request]
+         (on-connection [db db-spec]
+           (if-let [user-id (authenticated-user-id db (request-token request))]
+             ;; Tell the CouchDB proxy which account + role to act as.
+             (-> {:status 200}
+                 (response/header "X-Auth-UserName" user-id)
+                 (response/header "X-Auth-Roles" (str "u:" user-id))
+                 (response/header "X-Auth-Token" (hmac-sign (str user-id) db-auth-secret)))
+             {:status 401})))}]
 
      ["/api/examples"
       {:get
@@ -382,67 +362,33 @@
                   :body    (cheshire/generate-string
                             {:error "Examples are temporarily unavailable"})})))))}]
 
-     ["/api/identity/claim"
-      {:post
-       (fn [_request]
-         (on-connection [db db-spec]
-           (let [{:keys [id secret]} (add-user db)]
-             (-> {:status  200
-                  :headers {"Content-Type" "application/json"}
-                  :body    (cheshire/generate-string {:id id :secret secret})}
-                 (assoc :session {:user-id id})))))}]
-
-     ["/api/identity/auth"
+     ["/api/identity/provision"
       {:post
        (fn [request]
          (on-connection [db db-spec]
-           (let [{:keys [id secret]} (some-> (:body request) io/reader (cheshire/parse-stream true))]
-             (if-let [uid (identity-user-id db id secret)]
-               (-> {:status 200}
-                   (assoc :session {:user-id uid}))
-               {:status 401 :body ""}))))}]
+           (let [{:keys [invite]} (some-> (:body request) io/reader (cheshire/parse-stream true))]
+             (if (and (utils/non-blank invite) (burn-grant! db invite))
+               (let [{:keys [id token]} (create-account! db)]
+                 {:status  200
+                  :headers {"Content-Type" "application/json"}
+                  :body    (cheshire/generate-string {:id id :token token})})
+               {:status 403 :body ""}))))}]
 
-     ["/api/identity/recovery-token"
-      {:post
-       (fn [{:keys [session]}]
-         (if-let [uid (:user-id session)]
-           (on-connection [db db-spec]
-             (let [token      (str (random-uuid) (random-uuid))
-                   token-hash (sha256-hex token)
-                   expires-at (+ (System/currentTimeMillis) (* 30 24 60 60 1000))]
-               (jdbc/execute! db
-                 ["INSERT INTO recovery_tokens (sha256, user_id, expires_at) VALUES (?, ?, ?)"
-                  token-hash uid expires-at])
-               {:status  200
-                :headers {"Content-Type" "application/json"}
-                :body    (cheshire/generate-string {:token token})}))
-           {:status 401 :body ""}))}]
-
-     ["/api/identity/redeem"
+     ;; Adopting a key means holding a token and nothing else. The token comes
+     ;; in the body rather than the cookie so a device can find out whether it
+     ;; is valid, and whose it is, before making it this device's identity.
+     ["/api/identity/account"
       {:post
        (fn [request]
          (on-connection [db db-spec]
            (let [{:keys [token]} (some-> (:body request) io/reader (cheshire/parse-stream true))]
-             (if (utils/non-blank token)
-               (let [token-hash (sha256-hex token)
-                     now        (System/currentTimeMillis)
-                     row        (jdbc/execute-one!
-                                  db
-                                  ["SELECT user_id FROM recovery_tokens WHERE sha256 = ? AND expires_at > ?"
-                                   token-hash now]
-                                  {:builder-fn result-set/as-unqualified-maps})]
-                 (if row
-                   (let [uid        (:user-id row)
-                         new-secret (identity-secret-reset! db uid)]
-                     (jdbc/execute! db ["DELETE FROM recovery_tokens WHERE sha256 = ?" token-hash])
-                     (-> {:status  200
-                          :headers {"Content-Type" "application/json"}
-                          :body    (cheshire/generate-string {:id uid :secret new-secret})}
-                         (assoc :session {:user-id uid})))
-                   {:status 401 :body ""}))
-               {:status 400 :body ""}))))}]]
+             (if-let [user-id (authenticated-user-id db token)]
+               {:status  200
+                :headers {"Content-Type" "application/json"}
+                :body    (cheshire/generate-string {:id user-id})}
+               {:status 401 :body ""}))))}]]
 
-    {:data {:interceptors [#_session-interceptor
+    {:data {:interceptors [cookie-interceptor
                            (parameters/parameters-interceptor)
                            (keyword-parameters/keyword-parameters-interceptor)]}})
 
@@ -546,13 +492,12 @@
   []
   (let [url (str "http://localhost:" port "/")]
     ;; Migrate before serving: the app never runs against an outdated schema.
-    (on-connection [db db-spec]
-      (migrations/ensure-migrated! db))
+    (migrations/ensure-migrated! db-spec)
     (restart-server! #'ring-handler port)
     (println "Serving" url)))
 
 
 (comment
-  ;; Clear sessions
-  (jdbc/on-connection [db db-spec]
-    (jdbc/execute! db (sql/format {:delete-from :sessions}))))
+  ;; Mint an operator invite (ADR-0006 phase-1)
+  (on-connection [db db-spec]
+    (mint-grant! db)))

--- a/src/backend/core.clj
+++ b/src/backend/core.clj
@@ -134,18 +134,46 @@
 
 
 (defn add-user
-  [db user-name password]
-  ;; create user in SQLite DB
-  (let [password-hash (hashers/derive password {:alg :argon2id})
-        {:keys [id]}  (jdbc/execute-one! db
-                                         ["INSERT INTO users (name, password) VALUES (?, ?) RETURNING id" user-name
-                                          password-hash])
+  "Creates user in SQLite and provisions a CouchDB userdb.
+   Returns {:id int :secret plaintext-password}."
+  ([db]
+   (add-user db (str (random-uuid)) (str (random-uuid) (random-uuid))))
+  ([db user-name password]
+   (let [password-hash (hashers/derive password {:alg :argon2id})
+         {:keys [id]}  (jdbc/execute-one! db
+                                          ["INSERT INTO users (name, password) VALUES (?, ?) RETURNING id"
+                                           user-name password-hash])
+         couch-db      (db/use (str "userdb-" id))]
+     (db/secure couch-db {:members {:names [] :roles [(str "u:" id)]}})
+     {:id id :secret password})))
 
-        ;; create user DB in CouchDB
-        couch-db      (db/use (str "userdb-" id))]
 
-    ;; create user role in CouchDB
-    (db/secure couch-db {:members {:names [] :roles [(str "u:" id)]}})))
+(defn- identity-user-id
+  "Returns integer user-id when id+secret are valid, nil otherwise."
+  [db id secret]
+  (when (and (some? id) (utils/non-blank secret))
+    (let [user (jdbc/execute-one! db
+                                  ["SELECT id, password FROM users WHERE id = ?" id]
+                                  {:builder-fn result-set/as-unqualified-maps})]
+      (when (:valid (hashers/verify secret (or (:password user) "")))
+        (:id user)))))
+
+
+(defn- identity-secret-reset!
+  "Generates a new secret for user-id, updates the stored hash, returns plaintext secret."
+  [db user-id]
+  (let [secret (str (random-uuid) (random-uuid))
+        hash   (hashers/derive secret {:alg :argon2id})]
+    (jdbc/execute! db ["UPDATE users SET password = ? WHERE id = ?" hash user-id])
+    secret))
+
+
+(defn- sha256-hex
+  [^String s]
+  (.formatHex
+   (HexFormat/of)
+   (.digest (doto (MessageDigest/getInstance "SHA-256")
+              (.update (.getBytes s "UTF-8"))))))
 
 
 (comment
@@ -347,7 +375,67 @@
                              (assoc "Retry-After"
                                     (str (max 1 (long (Math/ceil (/ (:retry-after-ms result) 1000.0)))))))
                   :body    (cheshire/generate-string
-                            {:error "Examples are temporarily unavailable"})})))))}]]
+                            {:error "Examples are temporarily unavailable"})})))))}]
+
+     ["/api/identity/claim"
+      {:post
+       (fn [_request]
+         (on-connection [db db-spec]
+                        (let [{:keys [id secret]} (add-user db)]
+                          (-> {:status  200
+                               :headers {"Content-Type" "application/json"}
+                               :body    (cheshire/generate-string {:id id :secret secret})}
+                              (assoc :session {:user-id id})))))}]
+
+     ["/api/identity/auth"
+      {:post
+       (fn [request]
+         (on-connection [db db-spec]
+                        (let [{:keys [id secret]} (some-> (:body request) io/reader (cheshire/parse-stream true))]
+                          (if-let [uid (identity-user-id db id secret)]
+                            (-> {:status 200}
+                                (assoc :session {:user-id uid}))
+                            {:status 401 :body ""}))))}]
+
+     ["/api/identity/recovery-token"
+      {:post
+       (fn [{:keys [session]}]
+         (if-let [uid (:user-id session)]
+           (on-connection [db db-spec]
+                          (let [token      (str (random-uuid) (random-uuid))
+                                token-hash (sha256-hex token)
+                                expires-at (+ (System/currentTimeMillis) (* 30 24 60 60 1000))]
+                            (jdbc/execute! db
+                                           ["INSERT INTO recovery_tokens (sha256, user_id, expires_at) VALUES (?, ?, ?)"
+                                            token-hash uid expires-at])
+                            {:status  200
+                             :headers {"Content-Type" "application/json"}
+                             :body    (cheshire/generate-string {:token token})}))
+           {:status 401 :body ""}))}]
+
+     ["/api/identity/redeem"
+      {:post
+       (fn [request]
+         (on-connection [db db-spec]
+                        (let [{:keys [token]} (some-> (:body request) io/reader (cheshire/parse-stream true))]
+                          (if (utils/non-blank token)
+                            (let [token-hash (sha256-hex token)
+                                  now        (System/currentTimeMillis)
+                                  row        (jdbc/execute-one!
+                                              db
+                                              ["SELECT user_id FROM recovery_tokens WHERE sha256 = ? AND expires_at > ?"
+                                               token-hash now]
+                                              {:builder-fn result-set/as-unqualified-maps})]
+                              (if row
+                                (let [uid        (:user-id row)
+                                      new-secret (identity-secret-reset! db uid)]
+                                  (jdbc/execute! db ["DELETE FROM recovery_tokens WHERE sha256 = ?" token-hash])
+                                  (-> {:status  200
+                                       :headers {"Content-Type" "application/json"}
+                                       :body    (cheshire/generate-string {:id uid :secret new-secret})}
+                                      (assoc :session {:user-id uid})))
+                                {:status 401 :body ""}))
+                            {:status 400 :body ""}))))}]]
 
     {:data {:interceptors [#_session-interceptor
                            (parameters/parameters-interceptor)

--- a/src/backend/core.clj
+++ b/src/backend/core.clj
@@ -67,29 +67,33 @@
 
 
 (defmacro on-connection
+  "Runs body with a configured connection bound to sym and closes it afterwards.
+   `jdbc/on-connection+options` closes only connections it opened itself, so a
+   connection obtained here has to be released here — otherwise every call
+   leaves one behind for the life of the process."
   [[sym connectable] & body]
-  `(jdbc/on-connection+options [~sym
-                                (-> (jdbc/get-connection ~connectable)
-                                    (jdbc/with-logging
-                                     (fn [_sym# sql-params#]
-                                       {:time  (System/currentTimeMillis)
-                                        :query sql-params#})
-                                     (fn [_sym# state# result#]
-                                       (let [data#      {:time   (str (- (System/currentTimeMillis) (:time state#))
-                                                                      " ms")
-                                                         :query  (:query state#)
-                                                         :result result#}
-                                             log-level# (if (instance? Throwable result#)
-                                                          :error
-                                                          :debug)])))
-                                    (jdbc/with-options jdbc/unqualified-snake-kebab-opts))]
+  `(with-open [connection# (jdbc/get-connection ~connectable)]
+     (let [~sym (-> connection#
+                    (jdbc/with-logging
+                     (fn [_sym# sql-params#]
+                       {:time  (System/currentTimeMillis)
+                        :query sql-params#})
+                     (fn [_sym# state# result#]
+                       (let [data#      {:time   (str (- (System/currentTimeMillis) (:time state#))
+                                                      " ms")
+                                         :query  (:query state#)
+                                         :result result#}
+                             log-level# (if (instance? Throwable result#)
+                                          :error
+                                          :debug)])))
+                    (jdbc/with-options jdbc/unqualified-snake-kebab-opts))]
 
-     ;; Enable foreign key constraints in SQLite, as they are disabled by default.
-     ;; This constraint must be enabled separately for each connection.
-     ;; See https://www.sqlite.org/foreignkeys.html#fk_enable
-     (jdbc/execute! ~sym ["PRAGMA foreign_keys = on"])
+       ;; Enable foreign key constraints in SQLite, as they are disabled by default.
+       ;; This constraint must be enabled separately for each connection.
+       ;; See https://www.sqlite.org/foreignkeys.html#fk_enable
+       (jdbc/execute! ~sym ["PRAGMA foreign_keys = on"])
 
-     ~@body))
+       ~@body)))
 
 
 ;; This makes possible to pass clojure map or vector as a query parameter.

--- a/src/backend/core.clj
+++ b/src/backend/core.clj
@@ -45,13 +45,21 @@
     (t/add-handler! console-log-handler-id (t/handler:console) {:async nil})))
 
 
-(def dev-mode? (or (System/getenv "LEARNING_APP__ENVIRONMENT") true))
+(def running-from-source?
+  "Whether this process runs from a checkout rather than from the packaged jar.
+   The jar carries compiled classes and resources but no `.clj`, so finding our
+   own source on the classpath answers the question — unlike an environment
+   variable, which is a promise about the environment that nothing enforces."
+  (some? (io/resource "core.clj")))
 
 
 (def db-auth-secret
-  (if dev-mode?
-    "secret"
-    (System/getenv "LEARNING_APP_DB_AUTH_SECRET")))
+  "Signs the proxy-auth headers `/auth/check` hands to CouchDB. A checkout may
+   fall back to a well-known value; a packaged app may not, and says so instead
+   of signing with something an attacker can guess."
+  (or (System/getenv "LEARNING_APP_DB_AUTH_SECRET")
+      (when running-from-source? "secret")
+      (throw (ex-info "LEARNING_APP_DB_AUTH_SECRET is required outside a source checkout" {}))))
 
 
 ;;
@@ -454,7 +462,7 @@
 
 (def ring-handler
   (let [ring-handler #(ring/routes service-worker-handler wasm-handler resource-handler app-handler)]
-    (if dev-mode?
+    (if running-from-source?
       (ring/reloading-ring-handler ring-handler)
       (ring-handler))))
 

--- a/src/backend/migrations.clj
+++ b/src/backend/migrations.clj
@@ -1,0 +1,162 @@
+(ns migrations
+  "Schema migrations for the server database.
+
+   This list is the single source of truth for the schema: a fresh database is
+   built by running every migration in order, an existing one by running only
+   what it has not run yet. `CREATE TABLE IF NOT EXISTS` alone cannot express a
+   change to an existing table, which is why a schema file applied by hand is
+   not enough.
+
+   Never edit a migration that has shipped — a database that already ran it
+   will not run it again. Add the next one instead."
+  (:require
+   [clojure.java.io :as io]
+   [clojure.string :as str]
+   [next.jdbc :as jdbc]
+   [next.jdbc.result-set :as result-set]
+   [taoensso.telemere :as t])
+  (:import
+   [java.io File]
+   [java.net JarURLConnection URL]
+   [java.util.jar JarEntry]))
+
+
+(set! *warn-on-reflection* true)
+
+
+(def ^:private migration-name #"\d{3}-.+\.sql")
+
+
+(defn- directory-entries
+  "Names inside a resource directory that lives on the filesystem."
+  [^URL url]
+  (map File/.getName (.listFiles (io/file url))))
+
+
+(defn- directory-prefix
+  "Entries in an archive are paths, so its directories are just names ending
+   in a slash."
+  [^JarURLConnection connection]
+  (let [name (.getEntryName connection)]
+    (if (str/ends-with? name "/")
+      name
+      (str name "/"))))
+
+
+(defn- archive-entries
+  "Names inside a resource directory that lives in a jar. An archive has no
+   directory to open — only a flat list of entries — so the list is filtered
+   by prefix and the prefix stripped back off."
+  [^URL url]
+  ;; Caching off first: by default the connection hands back a JarFile the JVM
+  ;; shares with the classloader, and closing that one would take every later
+  ;; resource in the same archive with it.
+  (let [^JarURLConnection connection (doto (.openConnection url)
+                                       (.setUseCaches false))
+        directory (directory-prefix connection)]
+    (with-open [jar (.getJarFile connection)]
+      (->> (enumeration-seq (.entries jar))
+           (map JarEntry/.getName)
+           (filter #(str/starts-with? % directory))
+           (mapv #(subs % (count directory)))))))
+
+
+(defn migrations
+  "The migration files, in the order their names give them. Read on every call
+   rather than baked in at compile time: the compiler tracks this namespace's
+   source, not the directory the names come from, so a compiled copy would keep
+   answering with the migrations that existed when it was built."
+  []
+  (if-let [url (io/resource "migrations")]
+    (->> (if (= "jar" (.getProtocol ^URL url))
+           (archive-entries url)
+           (directory-entries url))
+         (filter #(re-matches migration-name %))
+         sort
+         vec)
+    (throw (ex-info "No migrations directory on the classpath" {}))))
+
+
+(def ^:private statement-separator
+  "Statements within a migration are separated by a `--;;` line. The driver
+   executes only the first statement of a multi-statement string and drops the
+   rest without raising, so statements have to be sent one at a time; splitting
+   on `;` instead would break on the first semicolon inside a string literal or
+   a trigger body."
+  #"(?m)^\s*--;;\s*$")
+
+
+(defn- statements
+  [sql]
+  (->> (str/split sql statement-separator)
+       (map str/trim)
+       (remove str/blank?)))
+
+
+(defn- migration-sql
+  [id]
+  (if-let [file (io/resource (str "migrations/" id))]
+    (slurp file)
+    (throw (ex-info "Migration file missing" {:id id}))))
+
+
+(def ^:private tracking-table
+  "CREATE TABLE IF NOT EXISTS schema_migrations
+   (
+       id         TEXT PRIMARY KEY,
+       applied_at INTEGER DEFAULT (UNIXEPOCH())
+   )")
+
+
+(defn- ensure-tracking-table!
+  [db]
+  (jdbc/execute! db [tracking-table]))
+
+
+(defn- applied-ids
+  [db]
+  (into #{}
+        (map :id)
+        (jdbc/execute! db
+          ["SELECT id FROM schema_migrations"]
+          {:builder-fn result-set/as-unqualified-maps})))
+
+
+(def ^:private lock-wait-ms
+  "How long to wait for another process that is already migrating. Applying
+   the whole chain is a handful of DDL statements — milliseconds — so this is
+   three orders of magnitude more than a migration needs: long enough that a
+   process started at the same moment waits its turn, short enough that a lock
+   held by something else fails the boot instead of hanging it."
+  10000)
+
+
+(defn ensure-migrated!
+  "Applies every migration this database has not run yet, all of them in a
+   single transaction: the database ends up either fully migrated or untouched.
+
+   Opens and closes a connection of its own. Every setting this depends on
+   belongs to a connection rather than to the database, and the exclusive lock
+   it takes has to be given back — a connection left open would hold the
+   database read-only for everyone else. Exclusive locking is what keeps a
+   second process from migrating alongside this one.
+
+   Foreign keys are enforced everywhere else but switched off here, as SQLite's
+   table-rebuild procedure requires: `DROP TABLE` runs an implicit `DELETE FROM`
+   while they are on, so rebuilding a table cascades its children away — a
+   migration that renames a column would silently take `user_settings` with it.
+   `PRAGMA foreign_keys` is a no-op inside a transaction, so it cannot be left
+   to a migration."
+  [db-spec]
+  (with-open [conn (jdbc/get-connection db-spec)]
+    (jdbc/execute! conn ["PRAGMA foreign_keys = OFF"])
+    (jdbc/execute! conn [(str "PRAGMA busy_timeout = " lock-wait-ms)])
+    (jdbc/execute! conn ["PRAGMA locking_mode = EXCLUSIVE"])
+    (ensure-tracking-table! conn)
+    (jdbc/with-transaction [tx conn]
+      (doseq [id (remove (applied-ids tx) (migrations))]
+        (t/event! ::applying {:level :info :data {:id id}})
+        (doseq [statement (statements (migration-sql id))]
+          (jdbc/execute! tx [statement]))
+        (jdbc/execute! tx ["INSERT INTO schema_migrations (id) VALUES (?)" id])
+        (t/event! ::applied {:level :info :data {:id id}})))))

--- a/src/client/adapters/data_export.cljs
+++ b/src/client/adapters/data_export.cljs
@@ -6,16 +6,13 @@
 
 
 (defn ^:async export-data!
-  "Exports all vocab and review docs from user-db.
-   Returns {:schema 1 :exported-at iso :vocab [...] :review [...]}."
+  "Exports every user-db doc, so no doc type can be silently dropped.
+   Returns {:schema 2 :exported-at iso :docs [...]}."
   [db-map]
-  (let [user-db         (:user/db db-map)
-        {vocab :docs}   (await (db/find-all user-db {:selector {:type "vocab"}}))
-        {reviews :docs} (await (db/find-all user-db {:selector {:type "review"}}))]
-    {:schema      1
+  (let [{rows :rows} (await (db/all-docs (:user/db db-map) {:include-docs true}))]
+    {:schema      2
      :exported-at (utils/now-iso)
-     :vocab       (mapv #(dissoc % :_rev) vocab)
-     :review      (mapv #(dissoc % :_rev) reviews)}))
+     :docs        (mapv #(dissoc (:doc %) :_rev) rows)}))
 
 
 (defn- conflict?
@@ -39,8 +36,8 @@
         (throw err)))))
 
 
-(defn ^:async import-review-doc!
-  "Inserts a review doc; skips if the _id already exists (idempotent union)."
+(defn ^:async import-doc!
+  "Inserts a doc; skips if the _id already exists (idempotent union)."
   [user-db incoming]
   (try
     (await (db/insert user-db incoming (:_id incoming)))
@@ -49,14 +46,27 @@
         (throw err)))))
 
 
+(defn- payload-docs
+  "Returns the docs of an export payload, accepting schema 1
+   ({:vocab [...] :review [...]}) and schema 2 ({:docs [...]})."
+  [{:keys [schema docs review vocab]}]
+  (case schema
+    1 (concat vocab review)
+    2 docs
+    (throw (ex-info "Unsupported export schema" {:schema schema}))))
+
+
 (defn ^:async import-data!
-  "Merges an export map into user-db.
-   Vocab: LWW by :modified-at.  Reviews: union (skip duplicates by _id)."
-  [db-map {:keys [schema vocab review]}]
-  (when-not (= schema 1)
-    (throw (ex-info "Unsupported export schema" {:schema schema})))
-  (let [user-db (:user/db db-map)]
-    (log/info :data-export/importing {:vocab (count vocab) :review (count review)})
-    (await (js/Promise.all (into-array (map #(import-vocab-doc! user-db %) vocab))))
-    (await (js/Promise.all (into-array (map #(import-review-doc! user-db %) review))))
-    (log/info :data-export/import-done {:vocab (count vocab) :review (count review)})))
+  "Merges an export payload into user-db by doc type:
+   vocab LWW by :modified-at, anything else insert-if-absent."
+  [db-map payload]
+  (let [user-db (:user/db db-map)
+        docs    (payload-docs payload)]
+    (log/info :data-export/importing {:count (count docs)})
+    (await (js/Promise.all
+            (into-array
+             (map #(if (= "vocab" (:type %))
+                     (import-vocab-doc! user-db %)
+                     (import-doc! user-db %))
+                  docs))))
+    (log/info :data-export/import-done {:count (count docs)})))

--- a/src/client/adapters/data_export.cljs
+++ b/src/client/adapters/data_export.cljs
@@ -1,0 +1,62 @@
+(ns adapters.data-export
+  (:require
+   [db :as db]
+   [lambdaisland.glogi :as log]
+   [utils :as utils]))
+
+
+(defn ^:async export-data!
+  "Exports all vocab and review docs from user-db.
+   Returns {:schema 1 :exported-at iso :vocab [...] :review [...]}."
+  [db-map]
+  (let [user-db         (:user/db db-map)
+        {vocab :docs}   (await (db/find-all user-db {:selector {:type "vocab"}}))
+        {reviews :docs} (await (db/find-all user-db {:selector {:type "review"}}))]
+    {:schema      1
+     :exported-at (utils/now-iso)
+     :vocab       (mapv #(dissoc % :_rev) vocab)
+     :review      (mapv #(dissoc % :_rev) reviews)}))
+
+
+(defn- conflict?
+  [err]
+  (let [status (or (.-status err) (:status err))
+        n      (or (.-name err) (:name err))]
+    (or (= status 409) (= status "409") (= n "conflict"))))
+
+
+(defn ^:async import-vocab-doc!
+  "Inserts or LWW-merges a single vocab doc into user-db."
+  [user-db incoming]
+  (try
+    (await (db/insert user-db incoming (:_id incoming)))
+    (catch js/Error err
+      (if (conflict? err)
+        (let [existing (await (db/get user-db (:_id incoming)))]
+          (when (pos? (compare (or (:modified-at incoming) "")
+                               (or (:modified-at existing) "")))
+            (await (db/insert user-db (assoc incoming :_rev (:_rev existing)) (:_id incoming)))))
+        (throw err)))))
+
+
+(defn ^:async import-review-doc!
+  "Inserts a review doc; skips if the _id already exists (idempotent union)."
+  [user-db incoming]
+  (try
+    (await (db/insert user-db incoming (:_id incoming)))
+    (catch js/Error err
+      (when-not (conflict? err)
+        (throw err)))))
+
+
+(defn ^:async import-data!
+  "Merges an export map into user-db.
+   Vocab: LWW by :modified-at.  Reviews: union (skip duplicates by _id)."
+  [db-map {:keys [schema vocab review]}]
+  (when-not (= schema 1)
+    (throw (ex-info "Unsupported export schema" {:schema schema})))
+  (let [user-db (:user/db db-map)]
+    (log/info :data-export/importing {:vocab (count vocab) :review (count review)})
+    (await (js/Promise.all (into-array (map #(import-vocab-doc! user-db %) vocab))))
+    (await (js/Promise.all (into-array (map #(import-review-doc! user-db %) review))))
+    (log/info :data-export/import-done {:vocab (count vocab) :review (count review)})))

--- a/src/client/adapters/identity.cljs
+++ b/src/client/adapters/identity.cljs
@@ -1,0 +1,44 @@
+(ns adapters.identity)
+
+
+(defn ^:async claim!
+  "Creates a new anonymous identity on the server. Returns {:id int :secret str}."
+  []
+  (let [response (await (js/fetch "/api/identity/claim"
+                                  #js {:method "POST"}))]
+    (if (.-ok response)
+      (js->clj (await (.json response)) :keywordize-keys true)
+      (throw (ex-info "Identity claim failed" {:status (.-status response)})))))
+
+
+(defn ^:async auth!
+  "Authenticates with {:id :secret}, establishing a session cookie."
+  [{:keys [id secret]}]
+  (let [response (await (js/fetch "/api/identity/auth"
+                                  #js {:method  "POST"
+                                       :headers #js {"Content-Type" "application/json"}
+                                       :body    (js/JSON.stringify #js {:id id :secret secret})}))]
+    (when-not (.-ok response)
+      (throw (ex-info "Identity auth failed" {:status (.-status response) :id id})))))
+
+
+(defn ^:async recovery-token!
+  "Generates a burn-on-use recovery token. Returns {:token str}."
+  []
+  (let [response (await (js/fetch "/api/identity/recovery-token"
+                                  #js {:method "POST"}))]
+    (if (.-ok response)
+      (js->clj (await (.json response)) :keywordize-keys true)
+      (throw (ex-info "Recovery token request failed" {:status (.-status response)})))))
+
+
+(defn ^:async redeem!
+  "Redeems a recovery token. Returns {:id int :secret str} and sets session."
+  [token]
+  (let [response (await (js/fetch "/api/identity/redeem"
+                                  #js {:method  "POST"
+                                       :headers #js {"Content-Type" "application/json"}
+                                       :body    (js/JSON.stringify #js {:token token})}))]
+    (if (.-ok response)
+      (js->clj (await (.json response)) :keywordize-keys true)
+      (throw (ex-info "Recovery token redemption failed" {:status (.-status response)})))))

--- a/src/client/adapters/identity.cljs
+++ b/src/client/adapters/identity.cljs
@@ -1,44 +1,75 @@
-(ns adapters.identity)
+(ns adapters.identity
+  (:require
+   [db :as db]))
 
 
-(defn ^:async claim!
-  "Creates a new anonymous identity on the server. Returns {:id int :secret str}."
+(def ^:private token-cookie "sprecha-token")
+
+
+(def ^:private identity-doc-id "identity:local")
+
+
+(defonce ^:private device-db
+  ;; Held rather than reopened: in ClojureScript `db/use` is a PouchDB
+  ;; constructor call, so asking for the database twice builds two objects over
+  ;; the same store. Opened here instead of taken from the system's db map
+  ;; because an incoming credential is handled before `:db/pouch` starts, when
+  ;; that map does not exist yet.
+  (delay (db/use "device-db")))
+
+
+(defn ^:async load-identity!
+  "Returns {:id :token} for this device, or nil if it has none."
   []
-  (let [response (await (js/fetch "/api/identity/claim"
-                                  #js {:method "POST"}))]
-    (if (.-ok response)
-      (js->clj (await (.json response)) :keywordize-keys true)
-      (throw (ex-info "Identity claim failed" {:status (.-status response)})))))
+  (when-let [doc (await (db/get @device-db identity-doc-id))]
+    {:id    (:user-id doc)
+     :token (:token doc)}))
 
 
-(defn ^:async auth!
-  "Authenticates with {:id :secret}, establishing a session cookie."
-  [{:keys [id secret]}]
-  (let [response (await (js/fetch "/api/identity/auth"
-                                  #js {:method  "POST"
-                                       :headers #js {"Content-Type" "application/json"}
-                                       :body    (js/JSON.stringify #js {:id id :secret secret})}))]
-    (when-not (.-ok response)
-      (throw (ex-info "Identity auth failed" {:status (.-status response) :id id})))))
+(defn ^:async save-identity!
+  "Persists {:id :token}, updating _rev if the doc already exists. device-db is
+   the durable home of the token; the cookie below is derived from it on every
+   boot, which is why losing device-db is what loses the account."
+  [{:keys [id token]}]
+  (let [existing (await (db/get @device-db identity-doc-id))
+        doc      (cond-> {:_id     identity-doc-id
+                          :token   token
+                          :type    "identity"
+                          :user-id id}
+                   existing (assoc :_rev (:_rev existing)))]
+    (await (db/insert @device-db doc))))
 
 
-(defn ^:async recovery-token!
-  "Generates a burn-on-use recovery token. Returns {:token str}."
-  []
-  (let [response (await (js/fetch "/api/identity/recovery-token"
-                                  #js {:method "POST"}))]
-    (if (.-ok response)
-      (js->clj (await (.json response)) :keywordize-keys true)
-      (throw (ex-info "Recovery token request failed" {:status (.-status response)})))))
+(defn use-identity!
+  "Makes the server authenticate requests as this identity by writing its
+   token to the cookie `/auth/check` reads. Not HttpOnly — the client owns the
+   token, it builds the QR and the recovery link from it."
+  [{:keys [token]}]
+  (set! js/document.cookie
+        (str token-cookie "=" token "; path=/; SameSite=Lax; Secure")))
 
 
-(defn ^:async redeem!
-  "Redeems a recovery token. Returns {:id int :secret str} and sets session."
+(defn ^:async account-id!
+  "Returns the account id the token authenticates, or nil. Lets a device that
+   was handed a key find out whether it is valid — and whose — before adopting
+   it, which is why the token travels in the body instead of the cookie."
   [token]
-  (let [response (await (js/fetch "/api/identity/redeem"
+  (let [response (await (js/fetch "/api/identity/account"
                                   #js {:method  "POST"
                                        :headers #js {"Content-Type" "application/json"}
                                        :body    (js/JSON.stringify #js {:token token})}))]
+    (when (.-ok response)
+      (:id (js->clj (await (.json response)) :keywordize-keys true)))))
+
+
+(defn ^:async provision!
+  "Creates a server account against a single-use invite (ADR-0006).
+   Returns the new identity {:id int :token str}."
+  [invite]
+  (let [response (await (js/fetch "/api/identity/provision"
+                                  #js {:method  "POST"
+                                       :headers #js {"Content-Type" "application/json"}
+                                       :body    (js/JSON.stringify #js {:invite invite})}))]
     (if (.-ok response)
       (js->clj (await (.json response)) :keywordize-keys true)
-      (throw (ex-info "Recovery token redemption failed" {:status (.-status response)})))))
+      (throw (ex-info "Provision failed" {:status (.-status response)})))))

--- a/src/client/adapters/progress_store.cljs
+++ b/src/client/adapters/progress_store.cljs
@@ -79,10 +79,9 @@
     (nil? (:started-at lesson-state)) (assoc :started-at (now-iso clock))))
 
 
-(defn ^:async find-word-by-normalized-value
-  [dbs normalized]
-  (let [{docs :docs} (await (find-all dbs "vocab"))]
-    (first (filter #(= normalized (vocabulary/normalize-value (:value %))) docs))))
+(defn ^:async find-word-by-value
+  [dbs value]
+  (await (dbs/get dbs "vocab" (vocabulary/vocab-id value))))
 
 
 (defn ^:async get-word

--- a/src/client/adapters/progress_store.cljs
+++ b/src/client/adapters/progress_store.cljs
@@ -1,5 +1,6 @@
 (ns adapters.progress-store
   (:require
+   [adapters.data-export :as data-export]
    [clojure.core :as clojure]
    [db.pouch :as dbs]
    [domain.lesson :as lesson]
@@ -171,3 +172,13 @@
   [dbs]
   (when-let [lesson-state (await (get-lesson dbs))]
     (await (dbs/remove dbs lesson-state))))
+
+
+(defn export-data!
+  [dbs]
+  (data-export/export-data! dbs))
+
+
+(defn import-data!
+  [dbs payload]
+  (data-export/import-data! dbs payload))

--- a/src/client/application.cljs
+++ b/src/client/application.cljs
@@ -1,7 +1,7 @@
 (ns application
   (:require
    ["qrcode" :as QRCode]
-   [adapters.identity :as identity-api]
+   [adapters.identity :as identity]
    [install-guide.view :as install-guide]
    [lambdaisland.glogi :as log]
    [nexus.registry :as nxr]
@@ -9,8 +9,7 @@
    [pages.home.view :as pages.home.view]
    [pages.lesson.view :as pages.lesson.view]
    [pages.words.view :as pages.words.view]
-   [replicant.dom :as r]
-   [sync :as sync]))
+   [replicant.dom :as r]))
 
 
 ;;
@@ -52,6 +51,13 @@
   (fn reload-page [state]
     (when-let [load-effect (:page/load state)]
       [load-effect])))
+
+
+(nxr/register-effect! :effect/load-account
+  (fn load-account [{:keys [capabilities dispatch]} _]
+    (dispatch
+     [[:effect/save
+       {:app/account-id (get-in capabilities [:capabilities/sync :sync/account-id])}]])))
 
 
 (nxr/register-effect! :effect/show-modal
@@ -220,17 +226,25 @@
     [[:effect/save {:app/pairing nil}]]))
 
 
+(defn- account-key-url
+  "The QR/recovery URL a device opens to adopt this account. The token rides in
+   the fragment, which browsers never send to the server, keeping it out of
+   access logs and Referer headers (ADR-0006)."
+  [{:keys [token]}]
+  (str (.. js/window -location -origin) "/#key=" token))
+
+
 (nxr/register-effect! :effect/create-recovery-link
   (fn ^:async create-recovery-link
     [_ _]
     (try
-      (let [{:keys [token]} (await (identity-api/recovery-token!))
-            url (str (.. js/window -location -origin) "/?recover=" token)]
-        (if (exists? js/navigator.share)
-          (await (js/navigator.share #js {:title "Sprecha: восстановление доступа" :url url}))
-          (do
-            (await (.. js/navigator -clipboard (writeText url)))
-            (js/alert "Ссылка скопирована в буфер обмена"))))
+      (when-let [identity (await (identity/load-identity!))]
+        (let [url (account-key-url identity)]
+          (if (exists? js/navigator.share)
+            (await (js/navigator.share #js {:title "Sprecha: восстановление доступа" :url url}))
+            (do
+              (await (.. js/navigator -clipboard (writeText url)))
+              (js/alert "Ссылка скопирована в буфер обмена")))))
       (catch js/Error err
         (log/error :effect/create-recovery-link {:error (str err)})))))
 
@@ -239,8 +253,8 @@
   (fn ^:async open-pairing
     [{:keys [dispatch]} _]
     (try
-      (when-let [{:keys [id secret]} (await (sync/load-identity!))]
-        (let [pair-url (str (.. js/window -location -origin) "/?id=" id "&secret=" secret)
+      (when-let [identity (await (identity/load-identity!))]
+        (let [pair-url (account-key-url identity)
               qr-url   (await (.toDataURL QRCode pair-url))]
           (dispatch [[:action/show-pairing-dialog {:qr-url qr-url :pair-url pair-url}]])))
       (catch js/Error err
@@ -289,25 +303,52 @@
       :stroke-linecap "round"}]]])
 
 
+(defn- install-icon
+  []
+  [:svg.app-shell__icon
+   {:aria-hidden    "true"
+    :fill           "none"
+    :stroke         "currentColor"
+    :stroke-linecap "round"
+    :stroke-linejoin "round"
+    :stroke-width   "1.8"
+    :viewBox        "0 0 24 24"}
+   [:path {:d "M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"}]
+   [:polyline {:points "7 10 12 15 17 10"}]
+   [:line {:x1 "12" :y1 "15" :x2 "12" :y2 "3"}]])
+
+
+(defn- sync-icon
+  []
+  [:svg.app-shell__icon
+   {:aria-hidden    "true"
+    :fill           "none"
+    :stroke         "currentColor"
+    :stroke-linecap "round"
+    :stroke-linejoin "round"
+    :stroke-width   "1.8"
+    :viewBox        "0 0 24 24"}
+   [:polyline {:points "23 4 23 10 17 10"}]
+   [:polyline {:points "1 20 1 14 7 14"}]
+   [:path {:d "M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"}]])
+
+
 (defn- sync-menu-dialog
   [state]
   [:dialog.sync-menu-dialog.modal
    {:replicant/on-mount [[:action/open-dialog]]
     :on {:close [[:action/close-sync-menu]]}}
    [:div.sync-menu-dialog__content
-    (when (:pwa/install-available? state)
-      [:button.sync-menu-dialog__item
-       {:type "button"
-        :on   {:click [[:action/pwa-install-requested]]}}
-       "Установить приложение"])
-    [:button.sync-menu-dialog__item
-     {:type "button"
-      :on   {:click [[:effect/open-pairing]]}}
-     "Подключить устройство"]
-    [:button.sync-menu-dialog__item
-     {:type "button"
-      :on   {:click [[:effect/create-recovery-link]]}}
-     "Ссылка восстановления"]
+    (when (:app/account-id state)
+      (list
+       [:button.sync-menu-dialog__item
+        {:type "button"
+         :on   {:click [[:effect/open-pairing]]}}
+        "Подключить устройство"]
+       [:button.sync-menu-dialog__item
+        {:type "button"
+         :on   {:click [[:effect/create-recovery-link]]}}
+        "Ссылка восстановления"]))
     [:button.sync-menu-dialog__item.sync-menu-dialog__item--cancel
      {:type "button"
       :on   {:click [[:action/close-sync-menu]]}}
@@ -333,15 +374,28 @@
   [state]
   (list
    [:a.app-shell__logo {:href "/home"} "Sprecha"]
-   (case (:page/current state)
-     :page/home        (collections-icon)
-     :page/collections (close-icon)
-     nil)
-   [:button.app-shell__menu-button
-    {:type  "button"
-     :title "Меню"
-     :on    {:click [[:action/open-sync-menu]]}}
-    "⋮"]
+   [:div.app-shell__actions
+    ;; Install stands on its own — it is not a sync action, and it is offered
+    ;; before any account exists.
+    (when (:pwa/install-available? state)
+      [:button.app-shell__icon-button
+       {:type       "button"
+        :title      "Установить приложение"
+        :aria-label "Установить приложение"
+        :on         {:click [[:action/pwa-install-requested]]}}
+       (install-icon)])
+    ;; Sync actions are invite-gated (ADR-0006): no account, no entry point.
+    (when (:app/account-id state)
+      [:button.app-shell__icon-button
+       {:type       "button"
+        :title      "Синхронизация"
+        :aria-label "Синхронизация"
+        :on         {:click [[:action/open-sync-menu]]}}
+       (sync-icon)])
+    (case (:page/current state)
+      :page/home        (collections-icon)
+      :page/collections (close-icon)
+      nil)]
    (install-guide/render state)
    (when (:app/sync-menu-open? state)
      (sync-menu-dialog state))

--- a/src/client/application.cljs
+++ b/src/client/application.cljs
@@ -41,6 +41,19 @@
       (navigate! page))))
 
 
+(nxr/register-effect! :effect/sync-pull
+  (fn sync-pull [{:keys [capabilities dispatch]} _]
+    (when-let [pull! (get-in capabilities [:capabilities/sync :sync/pull!])]
+      (some-> (pull!)
+              (.then #(dispatch [[:action/reload-page]]))))))
+
+
+(nxr/register-action! :action/reload-page
+  (fn reload-page [state]
+    (when-let [load-effect (:page/load state)]
+      [load-effect])))
+
+
 (nxr/register-effect! :effect/show-modal
   (fn show-modal [{:keys [dispatch-data]} _]
     (.showModal (:replicant/node dispatch-data))))
@@ -320,19 +333,21 @@
   [state]
   (list
    [:a.app-shell__logo {:href "/home"} "Sprecha"]
-   (case (:app/page state)
+   (case (:page/current state)
      :page/home        (collections-icon)
      :page/collections (close-icon)
-     (list))
+     nil)
    [:button.app-shell__menu-button
     {:type  "button"
      :title "Меню"
      :on    {:click [[:action/open-sync-menu]]}}
     "⋮"]
    (install-guide/render state)
-   (when (:app/sync-menu-open? state) (sync-menu-dialog state))
-   (when (:app/pairing state) (pairing-dialog (:app/pairing state)))
-   (case (:app/page state)
+   (when (:app/sync-menu-open? state)
+     (sync-menu-dialog state))
+   (when (:app/pairing state)
+     (pairing-dialog (:app/pairing state)))
+   (case (:page/current state)
      :page/collections (pages.collections.view/page state)
      :page/home        (pages.home.view/page state)
      :page/lesson      (pages.lesson.view/page state)
@@ -353,10 +368,10 @@
      :controllers [{:start #(dispatch [[:effect/load-home]])}]}]
    ["/words"
     {:name        :page/words
-     :controllers [{:start #(dispatch [[:effect/load-words]])}]}]
+     :controllers [{:start #(dispatch [[:effect/load-words] [:effect/sync-pull]])}]}]
    ["/lesson"
     {:name        :page/lesson
-     :controllers [{:start #(dispatch [[:effect/load-lesson]])}]}]
+     :controllers [{:start #(dispatch [[:effect/load-lesson] [:effect/sync-pull]])}]}]
    ["/collections"
     {:name        :page/collections
-     :controllers [{:start #(dispatch [[:effect/load-collections]])}]}]])
+     :controllers [{:start #(dispatch [[:effect/load-collections] [:effect/sync-pull]])}]}]])

--- a/src/client/application.cljs
+++ b/src/client/application.cljs
@@ -1,12 +1,16 @@
 (ns application
   (:require
+   ["qrcode" :as QRCode]
+   [adapters.identity :as identity-api]
    [install-guide.view :as install-guide]
+   [lambdaisland.glogi :as log]
    [nexus.registry :as nxr]
    [pages.collections.view :as pages.collections.view]
    [pages.home.view :as pages.home.view]
    [pages.lesson.view :as pages.lesson.view]
    [pages.words.view :as pages.words.view]
-   [replicant.dom :as r]))
+   [replicant.dom :as r]
+   [sync :as sync]))
 
 
 ;;
@@ -181,6 +185,55 @@
       [[:effect/request-submit]])))
 
 
+(nxr/register-action! :action/open-sync-menu
+  (fn open-sync-menu [_]
+    [[:effect/save {:app/sync-menu-open? true}]]))
+
+
+(nxr/register-action! :action/close-sync-menu
+  (fn close-sync-menu [_]
+    [[:effect/save {:app/sync-menu-open? false}]]))
+
+
+(nxr/register-action! :action/show-pairing-dialog
+  (fn show-pairing-dialog [_ pairing]
+    [[:effect/save
+      {:app/sync-menu-open? false
+       :app/pairing pairing}]]))
+
+
+(nxr/register-action! :action/close-pairing-dialog
+  (fn close-pairing-dialog [_]
+    [[:effect/save {:app/pairing nil}]]))
+
+
+(nxr/register-effect! :effect/create-recovery-link
+  (fn ^:async create-recovery-link
+    [_ _]
+    (try
+      (let [{:keys [token]} (await (identity-api/recovery-token!))
+            url (str (.. js/window -location -origin) "/?recover=" token)]
+        (if (exists? js/navigator.share)
+          (await (js/navigator.share #js {:title "Sprecha: восстановление доступа" :url url}))
+          (do
+            (await (.. js/navigator -clipboard (writeText url)))
+            (js/alert "Ссылка скопирована в буфер обмена"))))
+      (catch js/Error err
+        (log/error :effect/create-recovery-link {:error (str err)})))))
+
+
+(nxr/register-effect! :effect/open-pairing
+  (fn ^:async open-pairing
+    [{:keys [dispatch]} _]
+    (try
+      (when-let [{:keys [id secret]} (await (sync/load-identity!))]
+        (let [pair-url (str (.. js/window -location -origin) "/?id=" id "&secret=" secret)
+              qr-url   (await (.toDataURL QRCode pair-url))]
+          (dispatch [[:action/show-pairing-dialog {:qr-url qr-url :pair-url pair-url}]])))
+      (catch js/Error err
+        (log/error :effect/open-pairing {:error (str err)})))))
+
+
 ;;
 ;; Render
 ;;
@@ -223,6 +276,46 @@
       :stroke-linecap "round"}]]])
 
 
+(defn- sync-menu-dialog
+  [state]
+  [:dialog.sync-menu-dialog.modal
+   {:replicant/on-mount [[:action/open-dialog]]
+    :on {:close [[:action/close-sync-menu]]}}
+   [:div.sync-menu-dialog__content
+    (when (:pwa/install-available? state)
+      [:button.sync-menu-dialog__item
+       {:type "button"
+        :on   {:click [[:action/pwa-install-requested]]}}
+       "Установить приложение"])
+    [:button.sync-menu-dialog__item
+     {:type "button"
+      :on   {:click [[:effect/open-pairing]]}}
+     "Подключить устройство"]
+    [:button.sync-menu-dialog__item
+     {:type "button"
+      :on   {:click [[:effect/create-recovery-link]]}}
+     "Ссылка восстановления"]
+    [:button.sync-menu-dialog__item.sync-menu-dialog__item--cancel
+     {:type "button"
+      :on   {:click [[:action/close-sync-menu]]}}
+     "Отмена"]]])
+
+
+(defn- pairing-dialog
+  [{:keys [qr-url pair-url]}]
+  [:dialog.pairing-dialog.modal
+   {:replicant/on-mount [[:action/open-dialog]]
+    :on {:close [[:action/close-pairing-dialog]]}}
+   [:div.pairing-dialog__content
+    [:h2.pairing-dialog__title "Подключить устройство"]
+    [:p.pairing-dialog__hint "Отсканируйте QR-код на новом устройстве"]
+    [:img.pairing-dialog__qr {:src qr-url :alt "QR-код для подключения устройства"}]
+    [:button.pairing-dialog__close
+     {:type "button"
+      :on   {:click [[:action/close-pairing-dialog]]}}
+     "Закрыть"]]])
+
+
 (defn- render
   [state]
   (list
@@ -231,7 +324,14 @@
      :page/home        (collections-icon)
      :page/collections (close-icon)
      (list))
+   [:button.app-shell__menu-button
+    {:type  "button"
+     :title "Меню"
+     :on    {:click [[:action/open-sync-menu]]}}
+    "⋮"]
    (install-guide/render state)
+   (when (:app/sync-menu-open? state) (sync-menu-dialog state))
+   (when (:app/pairing state) (pairing-dialog (:app/pairing state)))
    (case (:app/page state)
      :page/collections (pages.collections.view/page state)
      :page/home        (pages.home.view/page state)

--- a/src/client/application.cljs
+++ b/src/client/application.cljs
@@ -2,6 +2,7 @@
   (:require
    ["qrcode" :as QRCode]
    [adapters.identity :as identity]
+   [application.presenter :as presenter]
    [install-guide.view :as install-guide]
    [lambdaisland.glogi :as log]
    [nexus.registry :as nxr]
@@ -347,13 +348,13 @@
 
 
 (defn- sync-menu-dialog
-  [state]
+  [{:keys [show-account-actions?]}]
   [:dialog.sync-menu-dialog.modal
    {:replicant/on-mount [[:action/open-dialog]]
     :on {:click [[:action/dismiss-on-backdrop [:event/self-click?]]]
          :close [[:action/close-sync-menu]]}}
    [:div.sync-menu-dialog__content
-    (when (:app/account-id state)
+    (when show-account-actions?
       (list
        [:button.sync-menu-dialog__item
         {:type "button"
@@ -387,41 +388,42 @@
 
 (defn- render
   [state]
-  (list
-   [:a.app-shell__logo {:href "/home"} "Sprecha"]
-   [:div.app-shell__actions
-    ;; Install stands on its own — it is not a sync action, and it is offered
-    ;; before any account exists.
-    (when (:pwa/install-available? state)
-      [:button.app-shell__icon-button
-       {:type       "button"
-        :title      "Установить приложение"
-        :aria-label "Установить приложение"
-        :on         {:click [[:action/pwa-install-requested]]}}
-       (install-icon)])
-    ;; Sync actions are invite-gated (ADR-0006): no account, no entry point.
-    (when (:app/account-id state)
-      [:button.app-shell__icon-button
-       {:type       "button"
-        :title      "Синхронизация"
-        :aria-label "Синхронизация"
-        :on         {:click [[:action/open-sync-menu]]}}
-       (sync-icon)])
-    (case (:page/current state)
-      :page/home        (collections-icon)
-      :page/collections (close-icon)
-      nil)]
-   (install-guide/render state)
-   (when (:app/sync-menu-open? state)
-     (sync-menu-dialog state))
-   (when (:app/pairing state)
-     (pairing-dialog (:app/pairing state)))
-   (case (:page/current state)
-     :page/collections (pages.collections.view/page state)
-     :page/home        (pages.home.view/page state)
-     :page/lesson      (pages.lesson.view/page state)
-     :page/words       (pages.words.view/page state)
-     [:div.app-loading "Загружаем..."])))
+  (let [{:keys [menu-open? page pairing show-install? show-sync?]}
+        (presenter/shell-props state)]
+    (list
+     [:a.app-shell__logo {:href "/home"} "Sprecha"]
+     [:div.app-shell__actions
+      ;; Install stands on its own — it is not a sync action, and it is offered
+      ;; before any account exists.
+      (when show-install?
+        [:button.app-shell__icon-button
+         {:type       "button"
+          :title      "Установить приложение"
+          :aria-label "Установить приложение"
+          :on         {:click [[:action/pwa-install-requested]]}}
+         (install-icon)])
+      (when show-sync?
+        [:button.app-shell__icon-button
+         {:type       "button"
+          :title      "Синхронизация"
+          :aria-label "Синхронизация"
+          :on         {:click [[:action/open-sync-menu]]}}
+         (sync-icon)])
+      (case page
+        :page/home        (collections-icon)
+        :page/collections (close-icon)
+        nil)]
+     (install-guide/render state)
+     (when menu-open?
+       (sync-menu-dialog (presenter/sync-menu-props state)))
+     (when pairing
+       (pairing-dialog pairing))
+     (case page
+       :page/collections (pages.collections.view/page state)
+       :page/home        (pages.home.view/page state)
+       :page/lesson      (pages.lesson.view/page state)
+       :page/words       (pages.words.view/page state)
+       [:div.app-loading "Загружаем..."]))))
 
 
 (defn render!

--- a/src/client/application.cljs
+++ b/src/client/application.cljs
@@ -65,6 +65,11 @@
     (.showModal (:replicant/node dispatch-data))))
 
 
+(nxr/register-effect! :effect/close-modal
+  (fn close-modal [{:keys [dispatch-data]} _]
+    (.close (:replicant/node dispatch-data))))
+
+
 (nxr/register-effect! :effect/focus-child
   (fn focus-child [{:keys [dispatch-data]} _ selector]
     (some-> (.querySelector (:replicant/node dispatch-data) selector) .focus)))
@@ -145,6 +150,14 @@
 (nxr/register-action! :action/open-dialog
   (fn open-dialog [_]
     [[:effect/show-modal]]))
+
+
+(nxr/register-action! :action/dismiss-on-backdrop
+  (fn dismiss-on-backdrop [_ backdrop?]
+    ;; A native modal renders its backdrop as part of the dialog element, so a
+    ;; click that lands on the element itself came from outside the content.
+    (when backdrop?
+      [[:effect/close-modal]])))
 
 
 (nxr/register-action! :action/move-cursor-to-end
@@ -337,7 +350,8 @@
   [state]
   [:dialog.sync-menu-dialog.modal
    {:replicant/on-mount [[:action/open-dialog]]
-    :on {:close [[:action/close-sync-menu]]}}
+    :on {:click [[:action/dismiss-on-backdrop [:event/self-click?]]]
+         :close [[:action/close-sync-menu]]}}
    [:div.sync-menu-dialog__content
     (when (:app/account-id state)
       (list
@@ -359,7 +373,8 @@
   [{:keys [qr-url pair-url]}]
   [:dialog.pairing-dialog.modal
    {:replicant/on-mount [[:action/open-dialog]]
-    :on {:close [[:action/close-pairing-dialog]]}}
+    :on {:click [[:action/dismiss-on-backdrop [:event/self-click?]]]
+         :close [[:action/close-pairing-dialog]]}}
    [:div.pairing-dialog__content
     [:h2.pairing-dialog__title "Подключить устройство"]
     [:p.pairing-dialog__hint "Отсканируйте QR-код на новом устройстве"]

--- a/src/client/application/presenter.cljs
+++ b/src/client/application/presenter.cljs
@@ -1,0 +1,22 @@
+(ns application.presenter)
+
+
+(defn shell-props
+  "What the shell shows, in its own terms rather than the state's.
+
+   `:show-sync?` is where the invite gate becomes visible (ADR-0006): sync has
+   no entry point until an account exists, and an account exists only once an
+   invite has been redeemed."
+  [state]
+  {:menu-open?    (boolean (:app/sync-menu-open? state))
+   :page          (:page/current state)
+   :pairing       (:app/pairing state)
+   :show-install? (boolean (:pwa/install-available? state))
+   :show-sync?    (some? (:app/account-id state))})
+
+
+(defn sync-menu-props
+  "The menu offers account actions only to a device that has an account; the
+   way out is always there."
+  [state]
+  {:show-account-actions? (some? (:app/account-id state))})

--- a/src/client/db/pouch.cljs
+++ b/src/client/db/pouch.cljs
@@ -2,7 +2,8 @@
   (:refer-clojure :exclude [get find remove])
   (:require
    [db :as db]
-   [db-migrations :as db-migrations]))
+   [db-migrations :as db-migrations]
+   [lambdaisland.glogi :as log]))
 
 
 (defn- user-db
@@ -29,6 +30,41 @@
   "Returns the database instance for a given doc type string."
   [dbs doc-type]
   (some-> doc-type doc-type->db dbs))
+
+
+(def ^:private db->remote-name
+  "Which databases have a copy on the server, and what that copy is called
+   there. device-db is absent on purpose: it holds what belongs to this device
+   alone and has nowhere to replicate to."
+  {:user/db #(str "userdb-" %)})
+
+
+(defn on-change
+  "Calls f after every local write to db-key. Returns a function that stops
+   watching."
+  [dbs db-key f]
+  (let [feed (.changes ^js (db-key dbs) #js {:live true :since "now"})]
+    (.on ^js feed "change" f)
+    #(.cancel ^js feed)))
+
+
+(defn sync-once!
+  "Runs one bidirectional replication pass of db-key against the account's copy
+   on the server. Resolves when the pass finishes and never rejects — a failed
+   pass resolves nil — so a caller can fire it on a trigger without guarding
+   every one."
+  [dbs db-key account-id]
+  (let [remote (str (.. js/globalThis -location -origin)
+                    "/db/"
+                    ((db->remote-name db-key) account-id))]
+    (js/Promise.
+     (fn [resolve _reject]
+       (doto (db/sync (db-key dbs) {:live false :remote-url remote})
+         (.on "complete" (fn [_] (resolve true)))
+         (.on "error"
+              (fn [err]
+                (log/warn :db/sync-failed {:db db-key :error (str err)})
+                (resolve nil))))))))
 
 
 (defn insert

--- a/src/client/domain/vocabulary.cljs
+++ b/src/client/domain/vocabulary.cljs
@@ -24,11 +24,17 @@
           (remove #(seen (:value %)) new-translations))))
 
 
+(defn vocab-id
+  [value]
+  (str "vocab:" (normalize-value value)))
+
+
 (defn new-word
   [value translations]
-  {:type        "vocab"
-   :value       value
-   :translation translations})
+  {:_id         (vocab-id value)
+   :translation translations
+   :type        "vocab"
+   :value       value})
 
 
 (defn new-review

--- a/src/client/install_guide/view.cljs
+++ b/src/client/install_guide/view.cljs
@@ -49,34 +49,26 @@
 
 (defn render
   [state]
-  (list
-   [:button.app-shell__install-button
-    {:type       "button"
-     :aria-label "Install app"
-     ;; disabling Install button, until designing proper UI/UX for installation.
-     :hidden     true #_(not (:pwa/install-available? state))
-     :on         {:click [[:action/pwa-install-requested]]}}
-    "установить"]
-   [:div#app-install-guide.app-install-guide
-    {:hidden (not (:pwa/show-guide? state))
-     :on     {:click [[:action/dismiss-install-guide-backdrop [:event/self-click?]]]}}
-    [:div.app-install-guide__card
-     [:div.app-install-guide__header
-      [:h3 "Install Sprecha"]
-      [:button.app-install-guide__close
-       {:aria-label "Close"
-        :on {:click [[:action/dismiss-install-guide]]}}
-       "×"]]
-     [:div.app-install-guide__steps
-      [:div.app-install-guide__step
-       [:span.app-install-guide__step-number "1"]
-       [:span.app-install-guide__step-icon (share-svg)]
-       [:span.app-install-guide__step-text "Tap " [:strong "Share"] " in the toolbar"]]
-      [:div.app-install-guide__step
-       [:span.app-install-guide__step-number "2"]
-       [:span.app-install-guide__step-icon (add-square-svg)]
-       [:span.app-install-guide__step-text "Tap " [:strong "Add to Home Screen"]]]
-      [:div.app-install-guide__step
-       [:span.app-install-guide__step-number "3"]
-       [:span.app-install-guide__step-icon (checkmark-svg)]
-       [:span.app-install-guide__step-text "Tap " [:strong "Add"] " to confirm"]]]]]))
+  [:div#app-install-guide.app-install-guide
+   {:hidden (not (:pwa/show-guide? state))
+    :on     {:click [[:action/dismiss-install-guide-backdrop [:event/self-click?]]]}}
+   [:div.app-install-guide__card
+    [:div.app-install-guide__header
+     [:h3 "Install Sprecha"]
+     [:button.app-install-guide__close
+      {:aria-label "Close"
+       :on {:click [[:action/dismiss-install-guide]]}}
+      "×"]]
+    [:div.app-install-guide__steps
+     [:div.app-install-guide__step
+      [:span.app-install-guide__step-number "1"]
+      [:span.app-install-guide__step-icon (share-svg)]
+      [:span.app-install-guide__step-text "Tap " [:strong "Share"] " in the toolbar"]]
+     [:div.app-install-guide__step
+      [:span.app-install-guide__step-number "2"]
+      [:span.app-install-guide__step-icon (add-square-svg)]
+      [:span.app-install-guide__step-text "Tap " [:strong "Add to Home Screen"]]]
+     [:div.app-install-guide__step
+      [:span.app-install-guide__step-number "3"]
+      [:span.app-install-guide__step-icon (checkmark-svg)]
+      [:span.app-install-guide__step-text "Tap " [:strong "Add"] " to confirm"]]]]])

--- a/src/client/main.cljs
+++ b/src/client/main.cljs
@@ -38,94 +38,107 @@
     (action-log/inspect))
 
   (system/start!
-   {:app/store           {:start (fn [_] (atom {:page/current :page/loading}))}
+   {:app/store          {:start (fn [_] (atom {:page/current :page/loading}))}
+
+    ;; Ask the browser to exempt our storage (device-db, the durable home of the
+    ;; account token) from automatic eviction. The auth cookie is rebuilt from
+    ;; device-db each boot, so protecting device-db is what protects sign-in.
+    :storage/persistent {:start (fn [_]
+                                  (when (some-> js/navigator .-storage .-persist)
+                                    (.then (js/navigator.storage.persist)
+                                           #(log/info :storage/persisted {:granted %})))
+                                  nil)}
 
     :worker/service-worker {:start
                             #(when (js-in "serviceWorker" js/navigator)
                                (js/navigator.serviceWorker.register "/js/app/sw.js" #js {:scope "/"}))}
 
-    :document/listeners  {:start
-                          (fn [_]
-                            (js/window.addEventListener "pageshow" application/sync-virtual-keyboard!)
-                            application/sync-virtual-keyboard!)}
+    :document/listeners {:start
+                         (fn [_]
+                           (js/window.addEventListener "pageshow" application/sync-virtual-keyboard!)
+                           application/sync-virtual-keyboard!)}
 
-    :db/sqlite           {:start sqlite/init!}
-    :identity/recovery   {:start sync/check-incoming-auth!}
+    :db/sqlite          {:start sqlite/init!}
+    :identity/incoming  {:start sync/check-incoming-auth!}
 
-    :db/pouch            {:after [:identity/recovery]
-                          :start pouch/init!}
+    :db/pouch           {:after [:identity/incoming]
+                         :start pouch/init!}
 
-    :sync/identity       {:requires {:db :db/pouch}
-                          :start    sync/start!}
+    :sync/identity      {:requires {:db :db/pouch}
+                         :start    sync/start!}
 
-    :port/clock          {:start clock/start!}
+    :port/clock         {:start clock/start!}
 
-    :worker/task-runner  {:requires {:db    :db/pouch
-                                     :clock :port/clock}
-                          :start    task-queue/start!
-                          :stop     task-queue/stop!}
+    :worker/task-runner {:requires {:db    :db/pouch
+                                    :clock :port/clock}
+                         :start    task-queue/start!
+                         :stop     task-queue/stop!}
 
-    :port/dictionary     {:requires {:db :db/sqlite}
-                          :start    dictionary/start!}
+    :port/dictionary    {:requires {:db :db/sqlite}
+                         :start    dictionary/start!}
 
     :port/progress-store {:requires {:db    :db/pouch
                                      :clock :port/clock}
                           :start    progress-store/start!}
 
-    :port/examples       {:requires {:clock :port/clock
-                                     :db    :db/pouch}
-                          :start    examples/start!}
+    :port/examples      {:requires {:clock :port/clock
+                                    :db    :db/pouch}
+                         :start    examples/start!}
 
-    :port/navigation     {:start navigation/start!}
+    :port/navigation    {:start navigation/start!}
 
-    :port/collections    {:requires {:clock :port/clock
-                                     :db    :db/pouch}
-                          :start    collections/start!}
+    :port/collections   {:requires {:clock :port/clock
+                                    :db    :db/pouch}
+                         :start    collections/start!}
 
-    :app/capabilities    {:requires {:capabilities/sync :sync/identity
-                                     :collections       :port/collections
-                                     :dictionary        :port/dictionary
-                                     :examples          :port/examples
-                                     :navigation        :port/navigation
-                                     :progress-store    :port/progress-store}
-                          :start    identity}
+    :app/capabilities   {:requires {:capabilities/sync :sync/identity
+                                    :collections       :port/collections
+                                    :dictionary        :port/dictionary
+                                    :examples          :port/examples
+                                    :navigation        :port/navigation
+                                    :progress-store    :port/progress-store}
+                         :start    identity}
 
-    :app/render          {:requires {:capabilities :app/capabilities
-                                     :store        :app/store}
-                          :start    (fn [{:keys [store] :as system}]
-                                      (let [dispatch (fn [dispatch-data actions]
-                                                       (nxr/dispatch system dispatch-data actions))]
-                                        (nxr/register-system->state! #(-> % :store deref))
-                                        (r/set-dispatch! dispatch)
-                                        (add-watch store ::render #(application/render! %4))
-                                        {:dispatch #(dispatch {} %)}))}
+    :app/render         {:requires {:capabilities :app/capabilities
+                                    :store        :app/store}
+                         :start    (fn [{:keys [store] :as system}]
+                                     (let [dispatch (fn [dispatch-data actions]
+                                                      (nxr/dispatch system dispatch-data actions))]
+                                       (nxr/register-system->state! #(-> % :store deref))
+                                       (r/set-dispatch! dispatch)
+                                       (add-watch store ::render #(application/render! %4))
+                                       {:dispatch #(dispatch {} %)}))}
 
-    :pwa/init            {:requires {:render :app/render}
-                          :start    (fn [{:keys [render]}]
-                                      (let [dispatch (:dispatch render)]
-                                        (dispatch [[:effect/pwa-init]])))}
+    :pwa/init           {:requires {:render :app/render}
+                         :start    (fn [{:keys [render]}]
+                                     (let [dispatch (:dispatch render)]
+                                       (dispatch [[:effect/pwa-init]])))}
 
-    :app/sync            {:requires {:render :app/render}
-                          :start    (fn [{:keys [render]}]
-                                      (let [dispatch (:dispatch render)]
-                                        (js/window.addEventListener
-                                         "online"
-                                         #(dispatch [[:effect/sync-pull]]))))}
+    :app/sync           {:requires {:render :app/render}
+                         :start    (fn [{:keys [render]}]
+                                     (let [dispatch (:dispatch render)]
+                                       (dispatch [[:effect/load-account]])
+                                       (js/window.addEventListener
+                                        "online"
+                                        #(dispatch [[:effect/sync-pull]]))))}
 
-    :app/router          {:requires {:render :app/render}
-                          :after    [:worker/service-worker
-                                     :document/listeners]
-                          :start    (fn [{:keys [render]}]
-                                      (let [dispatch    (:dispatch render)
-                                            controllers (atom nil)]
-                                        (rfe/start!
-                                         (rf/router
-                                          (application/routes dispatch))
-                                         (fn [match _history]
-                                           (if match
-                                             (reset! controllers (rfc/apply-controllers @controllers match))
-                                             (rfe/navigate :page/home)))
-                                         {:use-fragment false})))}}))
+    :app/router         {:requires {:render :app/render}
+                         :after    [:worker/service-worker
+                                    :document/listeners]
+                         :start    (fn [{:keys [render]}]
+                                     (let [dispatch    (:dispatch render)
+                                           controllers (atom nil)]
+                                       (rfe/start!
+                                        (rf/router
+                                         (application/routes dispatch))
+                                        (fn [match _history]
+                                          (if match
+                                            (reset! controllers (rfc/apply-controllers @controllers match))
+                                            ;; A path with no route is a redirect, not a visit: replace the
+                                            ;; entry rather than pushing one. That also drops the fragment,
+                                            ;; taking an incoming credential out of the address bar.
+                                            (rfe/replace-state :page/home)))
+                                        {:use-fragment false})))}}))
 
 
 (defn ^:async ^:export start

--- a/src/client/main.cljs
+++ b/src/client/main.cljs
@@ -65,7 +65,8 @@
                          :start pouch/init!}
 
     :sync/identity      {:requires {:db :db/pouch}
-                         :start    sync/start!}
+                         :start    sync/start!
+                         :stop     sync/stop!}
 
     :port/clock         {:start clock/start!}
 

--- a/src/client/main.cljs
+++ b/src/client/main.cljs
@@ -28,7 +28,8 @@
    [reitit.frontend.controllers :as rfc]
    [reitit.frontend.easy :as rfe]
    [replicant.dom :as r]
-   [runtime.system :as system]))
+   [runtime.system :as system]
+   [sync]))
 
 
 (defn ^:async init
@@ -49,7 +50,14 @@
                             application/sync-virtual-keyboard!)}
 
     :db/sqlite           {:start sqlite/init!}
-    :db/pouch            {:start pouch/init!}
+    :identity/recovery   {:start sync/check-incoming-auth!}
+
+    :db/pouch            {:after [:identity/recovery]
+                          :start pouch/init!}
+
+    :sync/identity       {:requires {:db :db/pouch}
+                          :start    sync/start!
+                          :stop     sync/stop!}
 
     :port/clock          {:start clock/start!}
 

--- a/src/client/main.cljs
+++ b/src/client/main.cljs
@@ -38,7 +38,7 @@
     (action-log/inspect))
 
   (system/start!
-   {:app/store           {:start (fn [_] (atom {:app/page :page/loading}))}
+   {:app/store           {:start (fn [_] (atom {:page/current :page/loading}))}
 
     :worker/service-worker {:start
                             #(when (js-in "serviceWorker" js/navigator)
@@ -56,8 +56,7 @@
                           :start pouch/init!}
 
     :sync/identity       {:requires {:db :db/pouch}
-                          :start    sync/start!
-                          :stop     sync/stop!}
+                          :start    sync/start!}
 
     :port/clock          {:start clock/start!}
 
@@ -83,11 +82,12 @@
                                      :db    :db/pouch}
                           :start    collections/start!}
 
-    :app/capabilities    {:requires {:collections    :port/collections
-                                     :dictionary     :port/dictionary
-                                     :examples       :port/examples
-                                     :navigation     :port/navigation
-                                     :progress-store :port/progress-store}
+    :app/capabilities    {:requires {:capabilities/sync :sync/identity
+                                     :collections       :port/collections
+                                     :dictionary        :port/dictionary
+                                     :examples          :port/examples
+                                     :navigation        :port/navigation
+                                     :progress-store    :port/progress-store}
                           :start    identity}
 
     :app/render          {:requires {:capabilities :app/capabilities
@@ -104,6 +104,13 @@
                           :start    (fn [{:keys [render]}]
                                       (let [dispatch (:dispatch render)]
                                         (dispatch [[:effect/pwa-init]])))}
+
+    :app/sync            {:requires {:render :app/render}
+                          :start    (fn [{:keys [render]}]
+                                      (let [dispatch (:dispatch render)]
+                                        (js/window.addEventListener
+                                         "online"
+                                         #(dispatch [[:effect/sync-pull]]))))}
 
     :app/router          {:requires {:render :app/render}
                           :after    [:worker/service-worker

--- a/src/client/pages/collections/actions.cljs
+++ b/src/client/pages/collections/actions.cljs
@@ -6,7 +6,8 @@
 (nxr/register-action! :action/show-collections
   (fn show-collections [_ {:keys [active-id items main]}]
     [[:effect/save
-      {:app/page :page/collections
+      {:page/current :page/collections
+       :page/load [:effect/load-collections]
        :collections/active-id active-id
        :collections/editing-id nil
        :collections/items items

--- a/src/client/pages/collections/effects.cljs
+++ b/src/client/pages/collections/effects.cljs
@@ -82,13 +82,13 @@
         (log/error :effect/prompt-create-collection {:error (str err)})))))
 
 
-(nxr/register-effect! :effect/delete-collection!
+(nxr/register-effect! :effect/delete-collection
   (fn ^:async delete-collection!
     [{:keys [capabilities dispatch]} _ {:keys [id]}]
     (try
       (await (collections/delete! capabilities id))
       (catch js/Error err
-        (log/error :effect/delete-collection! {:error (str err)}))
+        (log/error :effect/delete-collection {:error (str err)}))
       (finally
        (dispatch [[:effect/load-collections]])))))
 

--- a/src/client/pages/collections/view.cljs
+++ b/src/client/pages/collections/view.cljs
@@ -75,7 +75,7 @@
        :tabindex   (when-not editing? "-1")
        :on         {:pointerdown [[:effect/stop-propagation]]
                     :click       [[:effect/stop-propagation]
-                                  [:effect/delete-collection! {:id coll-id}]]}}
+                                  [:effect/delete-collection {:id coll-id}]]}}
       (close-icon)]
      (card-preview item)]))
 

--- a/src/client/pages/home/actions.cljs
+++ b/src/client/pages/home/actions.cljs
@@ -15,7 +15,8 @@
 (nxr/register-action! :action/show-home
   (fn show-home [_ {:keys [active-id active-name total]}]
     [[:effect/save
-      {:app/page            :page/home
+      {:page/current        :page/home
+       :page/load           nil
        :home/active-coll-id active-id
        :home/active-coll-name active-name
        :home/add-error      nil

--- a/src/client/pages/lesson/actions.cljs
+++ b/src/client/pages/lesson/actions.cljs
@@ -6,7 +6,8 @@
 (nxr/register-action! :action/show-lesson
   (fn show-lesson [_ {:keys [lesson-state error]}]
     [[:effect/save
-      {:app/page      :page/lesson
+      {:page/current  :page/lesson
+       :page/load     nil
        :lesson/empty? (boolean error)
        :lesson/state  (when-not error lesson-state)}]]))
 

--- a/src/client/pages/words/actions.cljs
+++ b/src/client/pages/words/actions.cljs
@@ -37,3 +37,13 @@
 (nxr/register-action! :action/remove-word
   (fn remove-word [state {:keys [id value]}]
     [[:effect/delete-word {:id id :value value :search (:words/search state)}]]))
+
+
+(nxr/register-action! :action/open-more-menu
+  (fn open-more-menu [_]
+    [[:effect/save {:words/menu-open? true}]]))
+
+
+(nxr/register-action! :action/close-more-menu
+  (fn close-more-menu [_]
+    [[:effect/save {:words/menu-open? false}]]))

--- a/src/client/pages/words/actions.cljs
+++ b/src/client/pages/words/actions.cljs
@@ -38,13 +38,3 @@
 (nxr/register-action! :action/remove-word
   (fn remove-word [state {:keys [id value]}]
     [[:effect/delete-word {:id id :value value :search (:words/search state)}]]))
-
-
-(nxr/register-action! :action/open-more-menu
-  (fn open-more-menu [_]
-    [[:effect/save {:words/menu-open? true}]]))
-
-
-(nxr/register-action! :action/close-more-menu
-  (fn close-more-menu [_]
-    [[:effect/save {:words/menu-open? false}]]))

--- a/src/client/pages/words/actions.cljs
+++ b/src/client/pages/words/actions.cljs
@@ -7,7 +7,8 @@
 (nxr/register-action! :action/show-words
   (fn show-words [_ {:keys [words total search]}]
     [[:effect/save
-      {:app/page      :page/words
+      {:page/current  :page/words
+       :page/load     [:effect/load-words]
        :words/items   (presenter/word-list-props words)
        :words/total   total
        :words/search  search

--- a/src/client/pages/words/effects.cljs
+++ b/src/client/pages/words/effects.cljs
@@ -64,3 +64,39 @@
             (dispatch [[:action/show-words {:words words :total total :search search}]]))
           (catch js/Error err
             (log/error :effect/delete-word {:error (str err)})))))))
+
+
+(nxr/register-effect! :effect/export-data
+  (fn ^:async export-data
+    [{:keys [capabilities]} _]
+    (try
+      (let [data (await (vocabulary/export! capabilities))
+            json (js/JSON.stringify (clj->js data) nil 2)
+            blob (js/Blob. #js [json] #js {:type "application/json"})
+            url  (js/URL.createObjectURL blob)
+            a    (doto (js/document.createElement "a")
+                   (aset "href" url)
+                   (aset "download"
+                         (str "sprecha-"
+                              (.slice (.toISOString (js/Date.)) 0 10)
+                              ".json")))]
+        (.click a)
+        (js/URL.revokeObjectURL url))
+      (catch js/Error err
+        (log/error :effect/export-data {:error (str err)})))))
+
+
+(nxr/register-effect! :effect/import-file
+  (fn ^:async import-file
+    [{:keys [capabilities dispatch dispatch-data]} _]
+    (let [file (some-> dispatch-data :replicant/dom-event .-target .-files (aget 0))]
+      (when file
+        (try
+          (let [text    (await (.text file))
+                payload (js->clj (js/JSON.parse text) :keywordize-keys true)]
+            (await (vocabulary/import! capabilities payload))
+            (let [{:keys [words total]} (await (vocabulary/list capabilities {:order :asc}))]
+              (dispatch [[:action/show-words {:words words :total total :search nil}]
+                         [:action/close-more-menu]])))
+          (catch js/Error err
+            (log/error :effect/import-file {:error (str err)})))))))

--- a/src/client/pages/words/effects.cljs
+++ b/src/client/pages/words/effects.cljs
@@ -64,39 +64,3 @@
             (dispatch [[:action/show-words {:words words :total total :search search}]]))
           (catch js/Error err
             (log/error :effect/delete-word {:error (str err)})))))))
-
-
-(nxr/register-effect! :effect/export-data
-  (fn ^:async export-data
-    [{:keys [capabilities]} _]
-    (try
-      (let [data (await (vocabulary/export! capabilities))
-            json (js/JSON.stringify (clj->js data) nil 2)
-            blob (js/Blob. #js [json] #js {:type "application/json"})
-            url  (js/URL.createObjectURL blob)
-            a    (doto (js/document.createElement "a")
-                   (aset "href" url)
-                   (aset "download"
-                         (str "sprecha-"
-                              (.slice (.toISOString (js/Date.)) 0 10)
-                              ".json")))]
-        (.click a)
-        (js/URL.revokeObjectURL url))
-      (catch js/Error err
-        (log/error :effect/export-data {:error (str err)})))))
-
-
-(nxr/register-effect! :effect/import-file
-  (fn ^:async import-file
-    [{:keys [capabilities dispatch dispatch-data]} _]
-    (let [file (some-> dispatch-data :replicant/dom-event .-target .-files (aget 0))]
-      (when file
-        (try
-          (let [text    (await (.text file))
-                payload (js->clj (js/JSON.parse text) :keywordize-keys true)]
-            (await (vocabulary/import! capabilities payload))
-            (let [{:keys [words total]} (await (vocabulary/list capabilities {:order :asc}))]
-              (dispatch [[:action/show-words {:words words :total total :search nil}]
-                         [:action/close-more-menu]])))
-          (catch js/Error err
-            (log/error :effect/import-file {:error (str err)})))))))

--- a/src/client/pages/words/view.cljs
+++ b/src/client/pages/words/view.cljs
@@ -65,37 +65,12 @@
       "Удалить"]]]])
 
 
-(defn- more-dialog
-  []
-  [:dialog.more-dialog.modal
-   {:replicant/on-mount [[:action/open-dialog]]
-    :on {:close [[:action/close-more-menu]]}}
-   [:div.more-dialog__content
-    [:button.more-dialog__item
-     {:type "button"
-      :on   {:click [[:effect/export-data]]}}
-     "Экспорт данных"]
-    [:label.more-dialog__item
-     {:role "button"}
-     [:input
-      {:type   "file"
-       :accept ".json,application/json"
-       :style  {:display "none"}
-       :on     {:change [[:effect/import-file]]}}]
-     "Импорт данных"]
-    [:button.more-dialog__item.more-dialog__item--cancel
-     {:type "button"
-      :on   {:click [[:action/close-more-menu]]}}
-     "Отмена"]]])
-
-
 (defn page
   [state]
-  (let [{:words/keys [items search editing menu-open?]} state]
+  (let [{:words/keys [items search editing]} state]
     [:div.vocabulary
      {:data-vk-overlay true}
      (when editing (edit-dialog editing))
-     (when menu-open? (more-dialog))
      (if (empty? items)
        [:div.vocabulary__list
         [:ul.word-list
@@ -112,12 +87,7 @@
          [:button.vocabulary__back
           {:on {:click [[:action/go-to-home]]}}
           "← Назад"]
-         [:h1.vocabulary__title "Мои слова"]
-         [:button.vocabulary__menu
-          {:type  "button"
-           :title "Дополнительно"
-           :on    {:click [[:action/open-more-menu]]}}
-          "⋮"]]
+         [:h1.vocabulary__title "Мои слова"]]
         [:form.vocabulary__search
          {:autocapitalize "none"
           :autocorrect "off"
@@ -152,4 +122,3 @@
           [:button.vocabulary__start.big-button.green-button
            {:on {:click [[:action/go-to-lesson]]}}
            "НАЧАТЬ УРОК"]]]))]))
-

--- a/src/client/pages/words/view.cljs
+++ b/src/client/pages/words/view.cljs
@@ -65,12 +65,37 @@
       "Удалить"]]]])
 
 
+(defn- more-dialog
+  []
+  [:dialog.more-dialog.modal
+   {:replicant/on-mount [[:action/open-dialog]]
+    :on {:close [[:action/close-more-menu]]}}
+   [:div.more-dialog__content
+    [:button.more-dialog__item
+     {:type "button"
+      :on   {:click [[:effect/export-data]]}}
+     "Экспорт данных"]
+    [:label.more-dialog__item
+     {:role "button"}
+     [:input
+      {:type   "file"
+       :accept ".json,application/json"
+       :style  {:display "none"}
+       :on     {:change [[:effect/import-file]]}}]
+     "Импорт данных"]
+    [:button.more-dialog__item.more-dialog__item--cancel
+     {:type "button"
+      :on   {:click [[:action/close-more-menu]]}}
+     "Отмена"]]])
+
+
 (defn page
   [state]
-  (let [{:words/keys [items search editing]} state]
+  (let [{:words/keys [items search editing menu-open?]} state]
     [:div.vocabulary
      {:data-vk-overlay true}
      (when editing (edit-dialog editing))
+     (when menu-open? (more-dialog))
      (if (empty? items)
        [:div.vocabulary__list
         [:ul.word-list
@@ -87,7 +112,12 @@
          [:button.vocabulary__back
           {:on {:click [[:action/go-to-home]]}}
           "← Назад"]
-         [:h1.vocabulary__title "Мои слова"]]
+         [:h1.vocabulary__title "Мои слова"]
+         [:button.vocabulary__menu
+          {:type  "button"
+           :title "Дополнительно"
+           :on    {:click [[:action/open-more-menu]]}}
+          "⋮"]]
         [:form.vocabulary__search
          {:autocapitalize "none"
           :autocorrect "off"
@@ -121,5 +151,5 @@
          [:div.page-footer__action
           [:button.vocabulary__start.big-button.green-button
            {:on {:click [[:action/go-to-lesson]]}}
-           "НАЧАТЬ УРОК"]]]))])
-)
+           "НАЧАТЬ УРОК"]]]))]))
+

--- a/src/client/ports/progress_store.cljs
+++ b/src/client/ports/progress_store.cljs
@@ -34,4 +34,9 @@
                                     (adapter/save-review! db clock word-id retained translation))
    :progress-store/save-word!     (fn save-word!
                                     [word]
-                                    (adapter/save-word! db clock word))})
+                                    (adapter/save-word! db clock word))
+   :progress-store/export-data!   (fn export-data! []
+                                    (adapter/export-data! db))
+   :progress-store/import-data!   (fn import-data!
+                                    [payload]
+                                    (adapter/import-data! db payload))})

--- a/src/client/ports/progress_store.cljs
+++ b/src/client/ports/progress_store.cljs
@@ -5,38 +5,38 @@
 
 (defn start!
   [{:keys [clock db]}]
-  {:progress-store/count-words    (fn count-words
-                                    []
-                                    (adapter/count-words db))
-   :progress-store/delete-word!   (fn delete-word!
-                                    [word-id]
-                                    (adapter/delete-word! db word-id))
-   :progress-store/find-word-by-normalized-value (fn find-word-by-normalized-value
-                                                   [normalized]
-                                                   (adapter/find-word-by-normalized-value db normalized))
-   :progress-store/get-lesson     (fn get-lesson
-                                    []
-                                    (adapter/get-lesson db))
-   :progress-store/get-word       (fn get-word
-                                    [word-id]
-                                    (adapter/get-word db clock word-id))
-   :progress-store/list-words     (fn list-words
-                                    [opts]
-                                    (adapter/list-words db clock opts))
-   :progress-store/remove-lesson! (fn remove-lesson!
-                                    []
-                                    (adapter/remove-lesson! db))
-   :progress-store/save-lesson!   (fn save-lesson!
-                                    [lesson-state]
-                                    (adapter/save-lesson! db clock lesson-state))
-   :progress-store/save-review!   (fn save-review!
-                                    [word-id retained translation]
-                                    (adapter/save-review! db clock word-id retained translation))
-   :progress-store/save-word!     (fn save-word!
-                                    [word]
-                                    (adapter/save-word! db clock word))
-   :progress-store/export-data!   (fn export-data! []
-                                    (adapter/export-data! db))
-   :progress-store/import-data!   (fn import-data!
-                                    [payload]
-                                    (adapter/import-data! db payload))})
+  {:progress-store/count-words        (fn count-words
+                                        []
+                                        (adapter/count-words db))
+   :progress-store/delete-word!       (fn delete-word!
+                                        [word-id]
+                                        (adapter/delete-word! db word-id))
+   :progress-store/find-word-by-value (fn find-word-by-value
+                                        [value]
+                                        (adapter/find-word-by-value db value))
+   :progress-store/get-lesson         (fn get-lesson
+                                        []
+                                        (adapter/get-lesson db))
+   :progress-store/get-word           (fn get-word
+                                        [word-id]
+                                        (adapter/get-word db clock word-id))
+   :progress-store/list-words         (fn list-words
+                                        [opts]
+                                        (adapter/list-words db clock opts))
+   :progress-store/remove-lesson!     (fn remove-lesson!
+                                        []
+                                        (adapter/remove-lesson! db))
+   :progress-store/save-lesson!       (fn save-lesson!
+                                        [lesson-state]
+                                        (adapter/save-lesson! db clock lesson-state))
+   :progress-store/save-review!       (fn save-review!
+                                        [word-id retained translation]
+                                        (adapter/save-review! db clock word-id retained translation))
+   :progress-store/save-word!         (fn save-word!
+                                        [word]
+                                        (adapter/save-word! db clock word))
+   :progress-store/export-data!       (fn export-data! []
+                                        (adapter/export-data! db))
+   :progress-store/import-data!       (fn import-data!
+                                        [payload]
+                                        (adapter/import-data! db payload))})

--- a/src/client/sync.cljs
+++ b/src/client/sync.cljs
@@ -2,6 +2,7 @@
   (:require
    [adapters.identity :as identity]
    [db :as db]
+   [db.pouch :as pouch]
    [domain.vocabulary :as domain]
    [goog.functions :as gfn]
    [lambdaisland.glogi :as log]))
@@ -75,20 +76,18 @@
 
 
 (defn ^:async sync-once!
-  "Runs one bidirectional replication pass, resolves vocab conflicts, and
-   completes when the pass finishes. Never rejects — a failed pass logs and
-   resolves nil so callers can fire it freely on triggers."
-  [user-db remote-url]
-  (js/Promise.
-   (fn [resolve _reject]
-     (doto (db/sync user-db {:live false :remote-url remote-url})
-       (.on "complete"
-            (fn [_]
-              (resolve (resolve-vocab-conflicts! user-db))))
-       (.on "error"
-            (fn [err]
-              (log/warn :sync/pass-failed {:error (str err)})
-              (resolve nil)))))))
+  "Runs one replication pass and resolves the conflicts it may have brought
+   home. Never rejects, so callers can fire it freely on triggers."
+  [dbs account-id]
+  (when (await (pouch/sync-once! dbs :user/db account-id))
+    (await (resolve-vocab-conflicts! (:user/db dbs)))))
+
+
+(defn stop!
+  "Stops pushing on local writes. A pass already in flight finishes on its own."
+  [{:sync/keys [unwatch]}]
+  (when unwatch
+    (unwatch)))
 
 
 (def ^:private push-interval-ms
@@ -102,21 +101,17 @@
    push on every local user-db change, plus a pull returned as :sync/pull!
    for the UI to call on data-page entry. Without a stored identity the device
    is local-only — no network call, inert pull (ADR-0006)."
-  [{:keys [db]}]
+  [{dbs :db}]
   (try
     (if-let [{:keys [id] :as identity} (await (identity/load-identity!))]
       (do
         (identity/use-identity! identity)
-        (let [user-db    (:user/db db)
-              remote-url (str (.. js/globalThis -location -origin) "/db/userdb-" id)
-              pull!      #(when (.-onLine js/navigator) (sync-once! user-db remote-url))]
-          (..
-           ^js user-db
-           (changes #js {:since "now" :live true})
-           (on "change" (gfn/throttle pull! push-interval-ms)))
+        (let [pull!   #(when (.-onLine js/navigator) (sync-once! dbs id))
+              unwatch (pouch/on-change dbs :user/db (gfn/throttle pull! push-interval-ms))]
           (log/info :sync/ready {:user-id id})
           {:sync/account-id id
-           :sync/pull!      pull!}))
+           :sync/pull!      pull!
+           :sync/unwatch    unwatch}))
       (do
         (log/info :sync/local-only {})
         {:sync/account-id nil

--- a/src/client/sync.cljs
+++ b/src/client/sync.cljs
@@ -3,6 +3,7 @@
    [adapters.identity :as identity-api]
    [db :as db]
    [domain.vocabulary :as domain]
+   [goog.functions :as gfn]
    [lambdaisland.glogi :as log]))
 
 
@@ -42,7 +43,7 @@
 
 
 (defn- lww-winner
-  "Returns the doc with the lexicographically higher :modified-at, or a if equal."
+  "Returns the doc with the lexicographically higher :modified-at, or b if equal."
   [a b]
   (if (pos? (compare (:modified-at a) (:modified-at b)))
     a
@@ -108,32 +109,49 @@
       (log/warn :sync/conflict-resolution-failed {:error (ex-message err)}))))
 
 
+(defn ^:async sync-once!
+  "Runs one bidirectional replication pass, resolves vocab conflicts, and
+   completes when the pass finishes. Never rejects — a failed pass logs and
+   resolves nil so callers can fire it freely on triggers."
+  [user-db remote-url]
+  (js/Promise.
+   (fn [resolve _reject]
+     (doto (db/sync user-db {:live false :remote-url remote-url})
+       (.on "complete"
+            (fn [_]
+              (resolve (resolve-vocab-conflicts! user-db))))
+       (.on "error"
+            (fn [err]
+              (log/warn :sync/pass-failed {:error (str err)})
+              (resolve nil)))))))
+
+
+(def ^:private push-interval-ms
+  "Throttle window for write-driven pushes, so a burst of writes (a lesson's
+   reviews) coalesces into periodic passes. Placeholder; tune via battery todo."
+  3000)
+
+
 (defn ^:async start!
-  "Ensures identity, authenticates, starts live PouchDB↔CouchDB replication.
-   Returns the PouchDB sync object (cancel it via stop!)."
+  "Ensures identity and authenticates, then drives replication by triggers:
+   a throttled push on every local user-db change, plus a pull returned as
+   :sync/pull! for the UI to call on data-page entry. No permanent live feed."
   [{:keys [db]}]
   (try
     (let [{:keys [id secret]} (await (ensure-identity!))]
       (await (identity-api/auth! {:id id :secret secret}))
-      (let [user-db  (:user/db db)
-            origin   (.. js/globalThis -location -origin)
-            sync-obj (db/sync user-db
-                              {:live       true
-                               :retry      true
-                               :remote-url (str origin "/db/userdb-" id)})]
-        (log/info :sync/started {:user-id id})
-        (.on sync-obj "paused" (fn [_] (resolve-vocab-conflicts! user-db)))
-        sync-obj))
+      (let [user-db    (:user/db db)
+            remote-url (str (.. js/globalThis -location -origin) "/db/userdb-" id)
+            pull!      #(when (.-onLine js/navigator) (sync-once! user-db remote-url))]
+        (..
+         ^js user-db
+         (changes #js {:since "now" :live true})
+         (on "change" (gfn/throttle pull! push-interval-ms)))
+        (log/info :sync/ready {:user-id id})
+        {:sync/pull! pull!}))
     (catch js/Error err
       (log/warn :sync/start-failed {:error (ex-message err)})
-      nil)))
-
-
-(defn stop!
-  "Cancels an active sync object."
-  [sync-obj]
-  (when sync-obj
-    (try (.cancel sync-obj) (catch :default _ nil))))
+      {:sync/pull! (constantly nil)})))
 
 
 (defn ^:async check-incoming-auth!

--- a/src/client/sync.cljs
+++ b/src/client/sync.cljs
@@ -1,0 +1,144 @@
+(ns sync
+  (:require
+   [adapters.identity :as identity-api]
+   [db :as db]
+   [lambdaisland.glogi :as log]))
+
+
+(def ^:private identity-doc-id "identity:local")
+
+
+(defn- device-db [] (db/use "device-db"))
+
+
+(defn ^:async load-identity!
+  "Returns {:id :secret} from device-db, or nil if not stored."
+  []
+  (when-let [doc (await (db/get (device-db) identity-doc-id))]
+    {:id     (:user-id doc)
+     :secret (:secret doc)}))
+
+
+(defn ^:async save-identity!
+  "Persists {:id :secret} to device-db, updating _rev if the doc already exists."
+  [{:keys [id secret]}]
+  (let [existing (await (db/get (device-db) identity-doc-id))
+        doc      (cond-> {:_id     identity-doc-id
+                          :type    "identity"
+                          :user-id id
+                          :secret  secret}
+                   existing (assoc :_rev (:_rev existing)))]
+    (await (db/insert (device-db) doc))))
+
+
+(defn ^:async ensure-identity!
+  "Returns stored identity, or claims a new one from the server and stores it."
+  []
+  (or (await (load-identity!))
+      (let [identity (await (identity-api/claim!))]
+        (await (save-identity! identity))
+        identity)))
+
+
+(defn- lww-winner
+  "Returns the doc with the lexicographically higher :modified-at, or a if equal."
+  [a b]
+  (if (pos? (compare (:modified-at a) (:modified-at b)))
+    a
+    b))
+
+
+(defn ^:async resolve-vocab-conflicts!
+  "Finds conflicted vocab docs and resolves them via LWW on :modified-at."
+  [user-db]
+  (try
+    (let [{rows :rows} (await (db/all-docs user-db {:include-docs true :conflicts true}))
+          conflicted   (filter (fn [{:keys [doc]}]
+                                 (and (= "vocab" (:type doc))
+                                      (seq (:_conflicts doc))))
+                               rows)]
+      (when (seq conflicted)
+        (log/info :sync/resolving-conflicts {:count (count conflicted)}))
+      (await
+       (js/Promise.all
+        (into-array
+         (map (fn [{:keys [doc]}]
+                ((fn ^:async f []
+                   (let [conflict-revs (:_conflicts doc)
+                         candidates    (await
+                                        (js/Promise.all
+                                         (into-array
+                                          (map #(db/get user-db (:_id doc) {:rev %})
+                                               conflict-revs))))
+                         winner        (reduce lww-winner doc (vec candidates))
+                         loser-docs    (remove #(= (:_rev %) (:_rev winner))
+                                               (cons doc (vec candidates)))]
+                     (await
+                      (js/Promise.all
+                       (into-array (map #(db/remove user-db %) loser-docs))))))))
+              conflicted)))))
+    (catch js/Error err
+      (log/warn :sync/conflict-resolution-failed {:error (ex-message err)}))))
+
+
+(defn ^:async start!
+  "Ensures identity, authenticates, starts live PouchDB↔CouchDB replication.
+   Returns the PouchDB sync object (cancel it via stop!)."
+  [{:keys [db]}]
+  (try
+    (let [{:keys [id secret]} (await (ensure-identity!))]
+      (await (identity-api/auth! {:id id :secret secret}))
+      (let [user-db  (:user/db db)
+            origin   (.. js/globalThis -location -origin)
+            sync-obj (db/sync user-db
+                              {:live       true
+                               :retry      true
+                               :remote-url (str origin "/db/userdb-" id)})]
+        (log/info :sync/started {:user-id id})
+        (.on sync-obj "paused" (fn [_] (resolve-vocab-conflicts! user-db)))
+        sync-obj))
+    (catch js/Error err
+      (log/warn :sync/start-failed {:error (ex-message err)})
+      nil)))
+
+
+(defn stop!
+  "Cancels an active sync object."
+  [sync-obj]
+  (when sync-obj
+    (try (.cancel sync-obj) (catch :default _ nil))))
+
+
+(defn ^:async check-incoming-auth!
+  "Checks URL for ?recover=TOKEN (burn-on-use) or ?id=ID&secret=SECRET (QR pair).
+   If found: saves identity, destroys user-db IndexedDB, clears URL params.
+   Must run before :db/pouch starts so the fresh PouchDB instance is empty.
+   Returns nil in all cases — called for side effects only."
+  [_]
+  (let [params  (js/URLSearchParams. (.. js/window -location -search))
+        recover (.get params "recover")
+        pair-id (.get params "id")
+        secret  (.get params "secret")]
+    (cond
+      (some? recover)
+      (try
+        (let [identity (await (identity-api/redeem! recover))]
+          (await (save-identity! identity))
+          (await (db/destroy (db/use "user-db")))
+          (js/history.replaceState nil "" "/")
+          (log/info :sync/redeemed {:user-id (:id identity)}))
+        (catch js/Error err
+          (log/warn :sync/redeem-failed {:error (ex-message err)})
+          (js/history.replaceState nil "" "/")))
+
+      (and (some? pair-id) (some? secret))
+      (try
+        (let [identity {:id (js/parseInt pair-id 10) :secret secret}]
+          (await (identity-api/auth! identity))
+          (await (save-identity! identity))
+          (await (db/destroy (db/use "user-db")))
+          (js/history.replaceState nil "" "/")
+          (log/info :sync/paired {:user-id (:id identity)}))
+        (catch js/Error err
+          (log/warn :sync/pair-failed {:error (ex-message err)})
+          (js/history.replaceState nil "" "/"))))))

--- a/src/client/sync.cljs
+++ b/src/client/sync.cljs
@@ -1,45 +1,10 @@
 (ns sync
   (:require
-   [adapters.identity :as identity-api]
+   [adapters.identity :as identity]
    [db :as db]
    [domain.vocabulary :as domain]
    [goog.functions :as gfn]
    [lambdaisland.glogi :as log]))
-
-
-(def ^:private identity-doc-id "identity:local")
-
-
-(defn- device-db [] (db/use "device-db"))
-
-
-(defn ^:async load-identity!
-  "Returns {:id :secret} from device-db, or nil if not stored."
-  []
-  (when-let [doc (await (db/get (device-db) identity-doc-id))]
-    {:id     (:user-id doc)
-     :secret (:secret doc)}))
-
-
-(defn ^:async save-identity!
-  "Persists {:id :secret} to device-db, updating _rev if the doc already exists."
-  [{:keys [id secret]}]
-  (let [existing (await (db/get (device-db) identity-doc-id))
-        doc      (cond-> {:_id     identity-doc-id
-                          :type    "identity"
-                          :user-id id
-                          :secret  secret}
-                   existing (assoc :_rev (:_rev existing)))]
-    (await (db/insert (device-db) doc))))
-
-
-(defn ^:async ensure-identity!
-  "Returns stored identity, or claims a new one from the server and stores it."
-  []
-  (or (await (load-identity!))
-      (let [identity (await (identity-api/claim!))]
-        (await (save-identity! identity))
-        identity)))
 
 
 (defn- lww-winner
@@ -133,57 +98,83 @@
 
 
 (defn ^:async start!
-  "Ensures identity and authenticates, then drives replication by triggers:
-   a throttled push on every local user-db change, plus a pull returned as
-   :sync/pull! for the UI to call on data-page entry. No permanent live feed."
+  "Drives replication by triggers when the device has an account: a throttled
+   push on every local user-db change, plus a pull returned as :sync/pull!
+   for the UI to call on data-page entry. Without a stored identity the device
+   is local-only — no network call, inert pull (ADR-0006)."
   [{:keys [db]}]
   (try
-    (let [{:keys [id secret]} (await (ensure-identity!))]
-      (await (identity-api/auth! {:id id :secret secret}))
-      (let [user-db    (:user/db db)
-            remote-url (str (.. js/globalThis -location -origin) "/db/userdb-" id)
-            pull!      #(when (.-onLine js/navigator) (sync-once! user-db remote-url))]
-        (..
-         ^js user-db
-         (changes #js {:since "now" :live true})
-         (on "change" (gfn/throttle pull! push-interval-ms)))
-        (log/info :sync/ready {:user-id id})
-        {:sync/pull! pull!}))
+    (if-let [{:keys [id] :as identity} (await (identity/load-identity!))]
+      (do
+        (identity/use-identity! identity)
+        (let [user-db    (:user/db db)
+              remote-url (str (.. js/globalThis -location -origin) "/db/userdb-" id)
+              pull!      #(when (.-onLine js/navigator) (sync-once! user-db remote-url))]
+          (..
+           ^js user-db
+           (changes #js {:since "now" :live true})
+           (on "change" (gfn/throttle pull! push-interval-ms)))
+          (log/info :sync/ready {:user-id id})
+          {:sync/account-id id
+           :sync/pull!      pull!}))
+      (do
+        (log/info :sync/local-only {})
+        {:sync/account-id nil
+         :sync/pull!      (constantly nil)}))
     (catch js/Error err
       (log/warn :sync/start-failed {:error (ex-message err)})
-      {:sync/pull! (constantly nil)})))
+      {:sync/account-id nil
+       :sync/pull!      (constantly nil)})))
+
+
+(defn- fragment-params
+  "The URL fragment as params. Credentials arrive there rather than in the
+   query string because a fragment is never part of the request: a query lands
+   in the server's access log and in Referer headers, a fragment does not."
+  []
+  (js/URLSearchParams. (.. js/window -location -hash (slice 1))))
 
 
 (defn ^:async check-incoming-auth!
-  "Checks URL for ?recover=TOKEN (burn-on-use) or ?id=ID&secret=SECRET (QR pair).
-   If found: saves identity, destroys user-db IndexedDB, clears URL params.
-   Must run before :db/pouch starts so the fresh PouchDB instance is empty.
-   Returns nil in all cases — called for side effects only."
-  [_]
-  (let [params  (js/URLSearchParams. (.. js/window -location -search))
-        recover (.get params "recover")
-        pair-id (.get params "id")
-        secret  (.get params "secret")]
-    (cond
-      (some? recover)
-      (try
-        (let [identity (await (identity-api/redeem! recover))]
-          (await (save-identity! identity))
-          (await (db/destroy (db/use "user-db")))
-          (js/history.replaceState nil "" "/")
-          (log/info :sync/redeemed {:user-id (:id identity)}))
-        (catch js/Error err
-          (log/warn :sync/redeem-failed {:error (ex-message err)})
-          (js/history.replaceState nil "" "/")))
+  "Handles an incoming credential: #key=TOKEN (QR pair, recovery, share) or
+   #invite=TOKEN (provision a new account, ADR-0006).
 
-      (and (some? pair-id) (some? secret))
+   A key is validated against the server before this device adopts it, and the
+   local user-db is destroyed only when the key turns out to belong to a
+   different account than the one stored — otherwise the local data stays and
+   merges. Must run before :db/pouch starts, so that a wipe leaves the fresh
+   PouchDB instance empty. The cookie is not written here: `start!` derives it
+   from the stored identity later in the same boot.
+
+   Returns nil — side effects only. The router drops the fragment when it
+   redirects the unmatched `/` to the home page."
+  [_]
+  (let [params (fragment-params)
+        token  (.get params "key")
+        invite (.get params "invite")]
+    (cond
+      (some? token)
       (try
-        (let [identity {:id (js/parseInt pair-id 10) :secret secret}]
-          (await (identity-api/auth! identity))
-          (await (save-identity! identity))
-          (await (db/destroy (db/use "user-db")))
-          (js/history.replaceState nil "" "/")
-          (log/info :sync/paired {:user-id (:id identity)}))
+        (if-let [account-id (await (identity/account-id! token))]
+          (do
+            (when-let [stored (await (identity/load-identity!))]
+              ;; Wiped through a throwaway handle, before :db/pouch opens its
+              ;; own: a handle that existed at destroy time never errors, it
+              ;; hangs on every later call.
+              (when (not= (:id stored) account-id)
+                (await (db/destroy (db/use "user-db")))))
+            (await (identity/save-identity! {:id account-id :token token}))
+            (log/info :sync/adopted {:user-id account-id}))
+          (log/warn :sync/invalid-key {}))
         (catch js/Error err
-          (log/warn :sync/pair-failed {:error (ex-message err)})
-          (js/history.replaceState nil "" "/"))))))
+          (log/warn :sync/adopt-failed {:error (ex-message err)})))
+
+      (some? invite)
+      (try
+        (if (await (identity/load-identity!))
+          (log/warn :sync/already-provisioned {})
+          (let [identity (await (identity/provision! invite))]
+            (await (identity/save-identity! identity))
+            (log/info :sync/provisioned {:user-id (:id identity)})))
+        (catch js/Error err
+          (log/warn :sync/provision-failed {:error (ex-message err)}))))))

--- a/src/client/sync.cljs
+++ b/src/client/sync.cljs
@@ -2,6 +2,7 @@
   (:require
    [adapters.identity :as identity-api]
    [db :as db]
+   [domain.vocabulary :as domain]
    [lambdaisland.glogi :as log]))
 
 
@@ -48,35 +49,61 @@
     b))
 
 
+(defn- all!
+  "One promise for a sequence of promises."
+  [promises]
+  (js/Promise.all (into-array promises)))
+
+
+(defn- ^:async resolve-conflict!
+  "Collapses one document's conflicting revisions into a single one. Scalar
+   fields come from the last write; translations are unioned across every
+   revision, so the same word added on two devices keeps both meanings. The
+   revisions that lost are deleted, which is what makes the conflict gone
+   rather than merely resolved on this device."
+  [user-db doc]
+  ;; A revision at a time, on purpose. The scan hands over the revision it
+  ;; serves and the ids of the ones it hides, never their contents, so they have
+  ;; to be read. `bulkGet` would read them in one call, but it is built to save
+  ;; HTTP round trips during replication: against a local database it loops over
+  ;; the same reads and assembles a grouped answer on top, and measures slower
+  ;; than the reads alone — on IndexedDB some 30 ms against 20 for 200 revisions.
+  (let [conflicting (await (all! (map #(db/get user-db (:_id doc) {:rev %})
+                                      (:_conflicts doc))))
+        revisions   (cons doc conflicting)
+        winner      (reduce lww-winner revisions)
+        translation (reduce domain/merge-translations [] (map :translation revisions))
+        losers      (remove #(= (:_rev %) (:_rev winner)) revisions)]
+    (await (db/insert user-db (assoc winner :translation translation)))
+    (await (all! (map #(db/remove user-db %) losers)))))
+
+
+(def ^:private vocabulary-with-conflicts
+  "Vocabulary ids are content-addressed under a `vocab:` prefix (ADR-0008), so
+   the words can be read as a key range rather than by scanning every review,
+   collection and example in the database. `￰` sorts past anything an id
+   can carry, which makes the range the whole prefix.
+
+   `:conflicts` is what this whole query is for, and only `all-docs`, `get` and
+   `changes` honour it — `find` accepts the option and silently answers without
+   the conflicts, which would look like a database that never conflicts."
+  {:conflicts    true
+   :endkey       "vocab:￰"
+   :include-docs true
+   :startkey     "vocab:"})
+
+
 (defn ^:async resolve-vocab-conflicts!
-  "Finds conflicted vocab docs and resolves them via LWW on :modified-at."
+  "Resolves every conflicted vocab doc a replication pass left behind."
   [user-db]
   (try
-    (let [{rows :rows} (await (db/all-docs user-db {:include-docs true :conflicts true}))
-          conflicted   (filter (fn [{:keys [doc]}]
-                                 (and (= "vocab" (:type doc))
-                                      (seq (:_conflicts doc))))
-                               rows)]
+    (let [{rows :rows} (await (db/all-docs user-db vocabulary-with-conflicts))
+          conflicted   (->> rows
+                            (map :doc)
+                            (filter #(and (-> % :type #{"vocab"}) (-> % :_conflicts seq))))]
       (when (seq conflicted)
         (log/info :sync/resolving-conflicts {:count (count conflicted)}))
-      (await
-       (js/Promise.all
-        (into-array
-         (map (fn [{:keys [doc]}]
-                ((fn ^:async f []
-                   (let [conflict-revs (:_conflicts doc)
-                         candidates    (await
-                                        (js/Promise.all
-                                         (into-array
-                                          (map #(db/get user-db (:_id doc) {:rev %})
-                                               conflict-revs))))
-                         winner        (reduce lww-winner doc (vec candidates))
-                         loser-docs    (remove #(= (:_rev %) (:_rev winner))
-                                               (cons doc (vec candidates)))]
-                     (await
-                      (js/Promise.all
-                       (into-array (map #(db/remove user-db %) loser-docs))))))))
-              conflicted)))))
+      (await (all! (map #(resolve-conflict! user-db %) conflicted))))
     (catch js/Error err
       (log/warn :sync/conflict-resolution-failed {:error (ex-message err)}))))
 

--- a/src/client/use_cases/lesson.cljs
+++ b/src/client/use_cases/lesson.cljs
@@ -126,7 +126,7 @@
 (defn ^:async token-info
   "Return token info for lesson answer annotation card."
   [capabilities dictionary-form translation]
-  (let [existing (await (vocabulary/find-duplicate-by-value capabilities dictionary-form))]
+  (let [existing (await (vocabulary/find-duplicate capabilities dictionary-form))]
     {:dictionary-form dictionary-form
      :translation translation
      :state       (token-state existing translation)}))

--- a/src/client/use_cases/vocabulary.cljs
+++ b/src/client/use_cases/vocabulary.cljs
@@ -5,9 +5,9 @@
 
 
 (defn ^:async find-duplicate
-  "Find an existing vocab doc whose normalized value matches `normalized`."
-  [{:keys [progress-store]} normalized]
-  (await ((:progress-store/find-word-by-normalized-value progress-store) normalized)))
+  "Find an existing vocab doc with the same value, or nil."
+  [{:keys [progress-store]} value]
+  (await ((:progress-store/find-word-by-value progress-store) value)))
 
 
 (defn ^:async add!
@@ -16,11 +16,10 @@
    article-stripped), merges translations and does not re-fetch examples.
    Returns {:word-id id :created? true/false}."
   [{:keys [collections examples progress-store] :as capabilities} value translation]
-  (let [parsed     (domain/parse-translations translation)
-        normalized (domain/normalize-value value)]
+  (let [parsed (domain/parse-translations translation)]
     (if (empty? parsed)
       {:error :empty-translations}
-      (let [existing (await (find-duplicate capabilities normalized))]
+      (let [existing (await (find-duplicate capabilities value))]
         (if existing
           (let [merged        (domain/merge-translations (:translation existing) parsed)
                 updated       (assoc existing :translation merged)
@@ -42,12 +41,6 @@
               (await ((:collections/add-word! collections) id collection-id)))
             ((:examples/request! examples) id collection-id collection-name)
             {:word-id id :created? true}))))))
-
-
-(defn find-duplicate-by-value
-  "Return existing vocab doc whose normalized value matches value."
-  [capabilities value]
-  (find-duplicate capabilities (domain/normalize-value value)))
 
 
 (defn ^:async get

--- a/src/client/use_cases/vocabulary.cljs
+++ b/src/client/use_cases/vocabulary.cljs
@@ -105,15 +105,3 @@
   "Creates a review document for a word and updates its retention model."
   [{:keys [progress-store]} word-id retained translation]
   ((:progress-store/save-review! progress-store) word-id retained translation))
-
-
-(defn export!
-  "Exports all vocab + reviews as a portable map."
-  [{:keys [progress-store]}]
-  ((:progress-store/export-data! progress-store)))
-
-
-(defn ^:async import!
-  "Merges a previously exported map into the local store."
-  [{:keys [progress-store]} payload]
-  (await ((:progress-store/import-data! progress-store) payload)))

--- a/src/client/use_cases/vocabulary.cljs
+++ b/src/client/use_cases/vocabulary.cljs
@@ -112,3 +112,15 @@
   "Creates a review document for a word and updates its retention model."
   [{:keys [progress-store]} word-id retained translation]
   ((:progress-store/save-review! progress-store) word-id retained translation))
+
+
+(defn export!
+  "Exports all vocab + reviews as a portable map."
+  [{:keys [progress-store]}]
+  ((:progress-store/export-data! progress-store)))
+
+
+(defn ^:async import!
+  "Merges a previously exported map into the local store."
+  [{:keys [progress-store]} payload]
+  (await ((:progress-store/import-data! progress-store) payload)))

--- a/test/backend/core_test.clj
+++ b/test/backend/core_test.clj
@@ -1,21 +1,70 @@
 (ns backend.core-test
   (:require
    [clojure.test :refer [deftest is testing]]
-   [core :as sut]))
+   [core :as sut]
+   [migrations :as migrations]
+   [next.jdbc :as jdbc]
+   [next.jdbc.result-set :as result-set])
+  (:import
+   [java.io File]))
 
 
-(deftest auth-proxy-response-returns-401-without-session
-  (testing "blank session"
-    (is (= {:status 401} (sut/auth-proxy-response nil)))
-    (is (= {:status 401} (sut/auth-proxy-response {})))))
+(set! *warn-on-reflection* true)
 
 
-(deftest auth-proxy-response-populates-proxy-headers
-  (testing "session present"
-    (let [response       (sut/auth-proxy-response {:user-id 42})
-          headers        (:headers response)
-          expected-token (sut/hmac-sign "42" sut/db-auth-secret)]
-      (is (= 200 (:status response)))
-      (is (= "42" (get headers "X-Auth-UserName")))
-      (is (= "u:42" (get headers "X-Auth-Roles")))
-      (is (= expected-token (get headers "X-Auth-Token"))))))
+(defn- migrated-db
+  []
+  (let [file (doto (File/createTempFile "core-test" ".db")
+               (.deleteOnExit))]
+    ;; SQLite wants to create the file itself.
+    (.delete file)
+    (doto {:dbtype "sqlite" :dbname (.getAbsolutePath file)}
+      (migrations/ensure-migrated!))))
+
+
+(defn- add-account!
+  [db id token]
+  (jdbc/execute! db
+    ["INSERT INTO users (id, token_sha256) VALUES (?, ?)" id (#'sut/sha256-hex token)]))
+
+
+(deftest a-token-authenticates-the-account-it-was-minted-for
+  (let [db (migrated-db)]
+    (add-account! db 1 "token-of-one")
+    (add-account! db 2 "token-of-two")
+    (testing "each token resolves to its own account"
+      (is (= 1 (#'sut/authenticated-user-id db "token-of-one")))
+      (is (= 2 (#'sut/authenticated-user-id db "token-of-two"))))
+    (testing "anything else authenticates nobody"
+      (is (nil? (#'sut/authenticated-user-id db "not-a-token")))
+      (is (nil? (#'sut/authenticated-user-id db "")))
+      (is (nil? (#'sut/authenticated-user-id db nil))))))
+
+
+(deftest the-server-keeps-no-token-it-could-leak
+  (let [db    (migrated-db)
+        token "token-of-one"]
+    (add-account! db 1 token)
+    (testing "only the hash is written"
+      (is (= [(#'sut/sha256-hex token)]
+             (map :token_sha256
+                  (jdbc/execute! db
+                    ["SELECT token_sha256 FROM users"]
+                    {:builder-fn result-set/as-unqualified-maps})))))))
+
+
+(deftest a-grant-opens-exactly-one-account
+  (let [db    (migrated-db)
+        token (sut/mint-grant! db)]
+    (testing "an unused grant burns"
+      (is (true? (#'sut/burn-grant! db token))))
+    (testing "and never burns twice"
+      (is (false? (#'sut/burn-grant! db token))))
+    (testing "a grant nobody minted does not burn"
+      (is (false? (#'sut/burn-grant! db "invented"))))))
+
+
+(deftest an-expired-grant-is-worthless
+  (let [db    (migrated-db)
+        token (sut/mint-grant! db -1)]
+    (is (false? (#'sut/burn-grant! db token)))))

--- a/test/backend/migrations_test.clj
+++ b/test/backend/migrations_test.clj
@@ -110,7 +110,7 @@
       ;; statement of a file is what proves nothing was silently truncated.
       (let [tables (table-names db)]
         (is (contains? tables "reviews") "last table of the baseline")
-        (is (contains? tables "recovery_tokens") "last table of the file")))))
+        (is (contains? tables "grants") "last table of the identity migration")))))
 
 
 (deftest migrating-twice-changes-nothing
@@ -130,4 +130,27 @@
     (testing "the baseline is recognised as already applied, the rest runs"
       (is (= (set (sut/migrations)) (recorded-ids db))))
     (testing "the schema ends up where a fresh database would be"
-      (is (= (table-names db) (table-names (doto (temp-db-spec) migrate!)))))))
+      (let [tables (table-names db)]
+        (is (contains? tables "grants"))
+        (is (not (contains? tables "sessions")))
+        (is (not (contains? tables "recovery_tokens")))))))
+
+
+(deftest rebuilding-a-table-keeps-what-hangs-off-it
+  (let [db (temp-db-spec)]
+    (apply-by-hand! db "001-initial-schema.sql")
+    (jdbc/execute! db ["INSERT INTO users (id, name, created_at) VALUES (7, 'legacy', 111)"])
+    (jdbc/execute! db ["INSERT INTO user_settings (user_id, settings) VALUES (7, '{}')"])
+    (migrate! db)
+    (testing "the account survives with its id and its age"
+      (is (= [{:id 7 :created_at 111 :token_sha256 nil}]
+             (jdbc/execute! db
+               ["SELECT id, created_at, token_sha256 FROM users"]
+               {:builder-fn result-set/as-unqualified-maps}))))
+    (testing "and so do its children"
+      ;; A rebuild drops the old table, which runs an implicit DELETE FROM
+      ;; wherever foreign keys are enforced — cascading these away without a
+      ;; word. Migrations get a connection of their own for that reason; this
+      ;; asserts the outcome, not the mechanism, since SQLite leaves foreign
+      ;; keys off on a fresh connection anyway.
+      (is (= 1 (count (jdbc/execute! db ["SELECT * FROM user_settings"])))))))

--- a/test/backend/migrations_test.clj
+++ b/test/backend/migrations_test.clj
@@ -1,0 +1,133 @@
+(ns backend.migrations-test
+  (:require
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is testing]]
+   [migrations :as sut]
+   [next.jdbc :as jdbc]
+   [next.jdbc.result-set :as result-set])
+  (:import
+   [java.io File FileOutputStream]
+   [java.net URL]
+   [java.util.jar JarEntry JarOutputStream]))
+
+
+(set! *warn-on-reflection* true)
+
+
+(defn- temp-db-spec
+  []
+  (let [file (doto (File/createTempFile "migrations-test" ".db")
+               (.deleteOnExit))]
+    ;; SQLite wants to create the file itself.
+    (.delete file)
+    {:dbtype "sqlite" :dbname (.getAbsolutePath file)}))
+
+
+(defn- apply-by-hand!
+  "Runs a migration the way a schema file used to be applied: without recording
+   that it ran. This is what every deployment looked like before migrations."
+  [db id]
+  (doseq [statement (#'sut/statements (#'sut/migration-sql id))]
+    (jdbc/execute! db [statement])))
+
+
+(defn- column
+  [db query]
+  (into #{}
+        (map (comp val first))
+        (jdbc/execute! db [query] {:builder-fn result-set/as-unqualified-maps})))
+
+
+(defn- migrate!
+  "Runs migrations against a database whose connections enforce foreign keys,
+   the way `on-connection` leaves them for the rest of the app. Without that,
+   SQLite's own default — foreign keys off — would hide what a table rebuild
+   really does to the rows hanging off the table."
+  [db]
+  (with-open [conn (jdbc/get-connection db)]
+    (jdbc/execute! conn ["PRAGMA foreign_keys = ON"]))
+  (sut/ensure-migrated! db))
+
+
+(defn- table-names
+  [db]
+  (column db "SELECT name FROM sqlite_master WHERE type = 'table'"))
+
+
+(defn- recorded-ids
+  [db]
+  (column db "SELECT id FROM schema_migrations"))
+
+
+(defn- jar-with
+  "A jar holding the given entry names, plus the directory entry a build writes."
+  [names]
+  (let [file (doto (File/createTempFile "migrations-test" ".jar")
+               (.delete)
+               (.deleteOnExit))]
+    (with-open [out (JarOutputStream. (FileOutputStream. file))]
+      (doseq [name (cons "migrations/" names)]
+        (.putNextEntry out (JarEntry. name))
+        (when-not (str/ends-with? name "/")
+          (.write out (.getBytes "-- statement")))
+        (.closeEntry out)))
+    file))
+
+
+(deftest every-migration-is-discovered
+  (testing "the list comes from the directory, not from a hand-written copy"
+    (is (seq (sut/migrations)))
+    (is (= (sut/migrations) (sort (sut/migrations))) "ordinal file names order the run")))
+
+
+(deftest migrations-are-found-inside-a-jar
+  ;; Production runs from an uberjar, where a resource directory cannot be
+  ;; listed: an archive is a flat list of entries with no directory to open.
+  (let [jar     (jar-with ["migrations/001-first.sql" "migrations/002-second.sql" "migrations/notes.txt"])
+        jar-url (.toString (.toURL (.toURI jar)))
+        entry   (URL. (str "jar:" jar-url "!/migrations/001-first.sql"))
+        dir     (URL. (str "jar:" jar-url "!/migrations/"))]
+    (testing "every entry under the directory is seen"
+      (is (= ["" "001-first.sql" "002-second.sql" "notes.txt"]
+             (sort (#'sut/archive-entries dir)))))
+    (testing "listing leaves the archive usable"
+      ;; A smoke check, not a proof: the JVM may hand out a JarFile it shares
+      ;; with the classloader, and closing that one would take the rest of the
+      ;; archive down with it. `archive-entries` disables caching to get its
+      ;; own copy; nothing in-process reproduces the shared case.
+      (#'sut/archive-entries dir)
+      (is (= "-- statement" (slurp entry))))))
+
+
+(deftest fresh-database-gets-the-whole-schema
+  (let [db (temp-db-spec)]
+    (migrate! db)
+    (testing "every migration is recorded"
+      (is (= (set (sut/migrations)) (recorded-ids db))))
+    (testing "every statement runs, not only the first"
+      ;; The driver executes the first statement of a multi-statement string
+      ;; and drops the rest without raising, so a table created by the last
+      ;; statement of a file is what proves nothing was silently truncated.
+      (let [tables (table-names db)]
+        (is (contains? tables "reviews") "last table of the baseline")
+        (is (contains? tables "recovery_tokens") "last table of the file")))))
+
+
+(deftest migrating-twice-changes-nothing
+  (let [db (temp-db-spec)]
+    (migrate! db)
+    (let [before (table-names db)]
+      (migrate! db)
+      (testing "a migrated database is left alone"
+        (is (= before (table-names db)))
+        (is (= (set (sut/migrations)) (recorded-ids db)))))))
+
+
+(deftest a-database-built-before-migrations-existed-is-adopted
+  (let [db (temp-db-spec)]
+    (apply-by-hand! db "001-initial-schema.sql")
+    (migrate! db)
+    (testing "the baseline is recognised as already applied, the rest runs"
+      (is (= (set (sut/migrations)) (recorded-ids db))))
+    (testing "the schema ends up where a fresh database would be"
+      (is (= (table-names db) (table-names (doto (temp-db-spec) migrate!)))))))

--- a/test/client/data_export_test.cljs
+++ b/test/client/data_export_test.cljs
@@ -1,0 +1,138 @@
+(ns client.data-export-test
+  (:require-macros
+   [client.support.test :refer [async-testing]])
+  (:require
+   [adapters.data-export :as sut]
+   [cljs.test :refer-macros [deftest is use-fixtures]]
+   [client.support.db-fixtures :as db-fixtures]
+   [db :as db]))
+
+
+(def user-db-name (db-fixtures/db-name "client.data-export-test.user"))
+
+
+(use-fixtures :each (db-fixtures/db-fixture user-db-name))
+
+
+(def ^:private seed-docs
+  [{:_id "vocab:hund" :type "vocab" :value "Hund" :translation ["собака"] :modified-at "2026-01-01"}
+   {:_id "review:1" :type "review" :word-id "vocab:hund" :retained true}
+   {:_id "collection:travel" :type "collection" :name "Travel"}
+   {:_id "example:1" :type "example" :word-id "vocab:hund" :value "Der Hund schläft"}])
+
+
+(defn- with-seeded-db
+  "Calls (f dbs) against a user-db holding one document of every type we keep."
+  [f]
+  (db-fixtures/with-test-db
+    user-db-name
+    (^:async fn
+     [db]
+     (doseq [doc seed-docs]
+       (await (db/insert db doc)))
+     (await (f {:user/db db})))))
+
+
+(defn- ^:async stored-docs
+  "Every document in the database, by id, without the revisions."
+  [dbs]
+  (let [{rows :rows} (await (db/all-docs (:user/db dbs) {:include-docs true}))]
+    (into {} (map (juxt :id (comp #(dissoc % :_rev) :doc))) rows)))
+
+
+(deftest export-carries-every-document-not-a-list-of-known-types
+  (async-testing "a collection is exported like anything else"
+    (await
+     (with-seeded-db
+      (^:async fn
+       [dbs]
+       (let [{:keys [docs schema]} (await (sut/export-data! dbs))
+             ids (set (map :_id docs))]
+         (is (= 2 schema))
+         (is (contains? ids "vocab:hund"))
+         (is (contains? ids "review:1"))
+         (is (contains? ids "collection:travel") "the type a hand-kept list forgot")
+         (is (contains? ids "example:1"))
+         (is (every? #(nil? (:_rev %)) docs) "revisions belong to a database, not to a backup")))))))
+
+
+(deftest import-restores-what-export-produced
+  (async-testing "round trip"
+    (await
+     (with-seeded-db
+      (^:async fn
+       [dbs]
+       (let [payload (await (sut/export-data! dbs))
+             before  (await (stored-docs dbs))]
+         (doseq [id (keys before)]
+           (await (db/remove (:user/db dbs) (await (db/get (:user/db dbs) id)))))
+         (await (sut/import-data! dbs payload))
+         (is (= before (await (stored-docs dbs))))))))))
+
+
+(deftest importing-the-same-payload-twice-changes-nothing
+  (async-testing "idempotent"
+    (await
+     (with-seeded-db
+      (^:async fn
+       [dbs]
+       (let [payload (await (sut/export-data! dbs))]
+         (await (sut/import-data! dbs payload))
+         (let [after-first (await (stored-docs dbs))]
+           (await (sut/import-data! dbs payload))
+           (is (= after-first (await (stored-docs dbs)))))))))))
+
+
+(deftest a-newer-vocab-wins-while-other-types-keep-what-is-there
+  (async-testing "import dispatches on type"
+    (await
+     (with-seeded-db
+      (^:async fn
+       [dbs]
+       (await (sut/import-data!
+               dbs
+               {:schema 2
+                :docs   [{:_id         "vocab:hund"
+                          :type        "vocab"
+                          :value       "Hund"
+                          :translation ["пёс"]
+                          :modified-at "2026-06-01"}
+                         {:_id "collection:travel" :type "collection" :name "Renamed"}]}))
+       (let [docs (await (stored-docs dbs))]
+         (is (= ["пёс"] (:translation (get docs "vocab:hund")))
+             "vocab takes the later revision")
+         (is (= "Travel" (:name (get docs "collection:travel")))
+             "anything else is inserted only when absent")))))))
+
+
+(deftest an-older-vocab-loses
+  (async-testing "last write wins by :modified-at, not by arrival"
+    (await
+     (with-seeded-db
+      (^:async fn
+       [dbs]
+       (await (sut/import-data!
+               dbs
+               {:schema 2
+                :docs   [{:_id         "vocab:hund"
+                          :type        "vocab"
+                          :value       "Hund"
+                          :translation ["старое"]
+                          :modified-at "2025-01-01"}]}))
+       (is (= ["собака"] (:translation (get (await (stored-docs dbs)) "vocab:hund")))))))))
+
+
+(deftest a-payload-from-the-previous-format-still-imports
+  (async-testing "schema 1 carried vocab and review under separate keys"
+    (await
+     (with-seeded-db
+      (^:async fn
+       [dbs]
+       (await (sut/import-data!
+               dbs
+               {:schema 1
+                :vocab  [{:_id "vocab:katze" :type "vocab" :value "Katze" :translation ["кошка"]}]
+                :review [{:_id "review:2" :type "review" :word-id "vocab:katze"}]}))
+       (let [docs (await (stored-docs dbs))]
+         (is (contains? docs "vocab:katze"))
+         (is (contains? docs "review:2"))))))))

--- a/test/client/domain/vocabulary_test.cljs
+++ b/test/client/domain/vocabulary_test.cljs
@@ -29,3 +29,32 @@
       (is (true? (:retained review)))
       (is (= "пёс" (-> review :translation first :value)))
       (is (= "ru" (-> review :translation first :lang))))))
+
+
+(deftest normalize-value-is-a-frozen-contract
+  (testing "lowercase, umlaut fold, punctuation to space — changing this remaps ids"
+    (is (= "gross" (sut/normalize-value "GROSS")))
+    (is (= "fussball" (sut/normalize-value "Fußball")))
+    (is (= "tuer" (sut/normalize-value "Tür")))
+    (is (= "maedchen" (sut/normalize-value "Mädchen")))
+    (is (= "der hund" (sut/normalize-value "der Hund")))))
+
+
+(deftest new-word-is-content-addressed
+  (testing "vocab _id is the content-addressed id of its value"
+    (let [value "der Hund"]
+      (is (= (sut/vocab-id value)
+             (:_id (sut/new-word value [{:lang "ru" :value "пёс"}])))))))
+
+
+(deftest vocab-id-is-case-insensitive
+  (testing "the same word yields the same id regardless of case"
+    (is (= (sut/vocab-id "der Hund") (sut/vocab-id "DER HUND")))))
+
+
+(deftest merge-translations-unions-by-value
+  (testing "keeps existing translations and adds only unseen ones (conflict union)"
+    (is (= [{:lang "ru" :value "пёс"} {:lang "ru" :value "собака"}]
+           (sut/merge-translations [{:lang "ru" :value "пёс"}]
+                                   [{:lang "ru" :value "пёс"}
+                                    {:lang "ru" :value "собака"}])))))

--- a/test/client/lesson_test.cljs
+++ b/test/client/lesson_test.cljs
@@ -257,7 +257,7 @@
     (with-test-dbs
      (^:async fn
       [dbs]
-      (await (db-seed/seed-vocabulary! (:user/db dbs) [{:_id "w" :value "die Seele" :translation "душа"}]))
+      (await (db-seed/seed-vocabulary! (:user/db dbs) [{:value "die Seele" :translation "душа"}]))
       (let [info (await (sut/token-info (test-capabilities dbs) "die Seele" "душа"))]
         (is (= :known-with-translation (:state info))))))))
 
@@ -267,7 +267,7 @@
     (with-test-dbs
      (^:async fn
       [dbs]
-      (await (db-seed/seed-vocabulary! (:user/db dbs) [{:_id "w" :value "die Bank" :translation "банк"}]))
+      (await (db-seed/seed-vocabulary! (:user/db dbs) [{:value "die Bank" :translation "банк"}]))
       (let [info (await (sut/token-info (test-capabilities dbs) "die Bank" "скамейка"))]
         (is (= :known-missing-translation (:state info))))))))
 

--- a/test/client/support/db_seed.cljs
+++ b/test/client/support/db_seed.cljs
@@ -1,45 +1,56 @@
 (ns client.support.db-seed
   (:require
    [client.support.time :as time]
-   [db :as db]))
+   [db :as db]
+   [domain.vocabulary :as vocabulary]))
+
+
+(defn- ^:async insert-all!
+  [db docs]
+  (await (js/Promise.all (into-array (map #(db/insert db %) docs)))))
+
+
+(defn- vocab-doc
+  "Vocab doc, defaulting :_id to its content-addressed id when not given."
+  [{id :_id value :value translation :translation}]
+  {:_id         (or id (vocabulary/vocab-id value))
+   :type        "vocab"
+   :value       value
+   :translation [{:lang "ru" :value translation}]
+   :created-at  time/test-now-iso
+   :modified-at time/test-now-iso})
+
+
+(defn- review-doc
+  [{id :_id}]
+  {:_id        (str "review-" id)
+   :type       "review"
+   :word-id    id
+   :retained   true
+   :created-at time/test-now-iso})
+
+
+(defn- example-doc
+  [{id :_id word-id :word-id word :word value :value translation :translation}]
+  {:_id         id
+   :type        "example"
+   :word-id     word-id
+   :word        word
+   :value       value
+   :translation translation
+   :structure   []
+   :created-at  time/test-now-iso})
 
 
 (defn ^:async seed-vocabulary!
-  "Adds vocabulary words and reviews to test db for testing."
+  "Adds vocabulary words and a passing review for each to a test db."
   [db words]
-  (await (js/Promise.all
-          (into-array (map (fn [{id :_id value :value translation :translation}]
-                             (db/insert db
-                                        {:_id         id
-                                         :type        "vocab"
-                                         :value       value
-                                         :translation [{:lang "ru" :value translation}]
-                                         :created-at  time/test-now-iso
-                                         :modified-at time/test-now-iso}))
-                           words))))
-  (await (js/Promise.all
-          (into-array (map (fn [{id :_id}]
-                             (db/insert db
-                                        {:_id        (str "review-" id)
-                                         :type       "review"
-                                         :word-id    id
-                                         :retained   true
-                                         :created-at time/test-now-iso}))
-                           words)))))
+  (let [docs (mapv vocab-doc words)]
+    (await (insert-all! db docs))
+    (await (insert-all! db (map review-doc docs)))))
 
 
 (defn ^:async seed-examples!
-  "Adds example documents to test db for testing."
+  "Adds example documents to a test db."
   [db examples]
-  (await (js/Promise.all
-          (into-array (map (fn [{id :_id word-id :word-id word :word value :value translation :translation}]
-                             (db/insert db
-                                        {:_id         id
-                                         :type        "example"
-                                         :word-id     word-id
-                                         :word        word
-                                         :value       value
-                                         :translation translation
-                                         :structure   []
-                                         :created-at  time/test-now-iso}))
-                           examples)))))
+  (await (insert-all! db (map example-doc examples))))

--- a/test/client/sync_test.cljs
+++ b/test/client/sync_test.cljs
@@ -1,0 +1,224 @@
+(ns client.sync-test
+  (:require-macros
+   [client.support.test :refer [async-testing]])
+  (:require
+   [client.support.db-fixtures :as db-fixtures]
+   [cljs.test :refer-macros [deftest is use-fixtures]]
+   [db :as db]
+   [sync :as sut]))
+
+
+(def user-db-name (db-fixtures/db-name "client.sync-test.user"))
+
+
+(use-fixtures :each (db-fixtures/db-fixture user-db-name))
+
+
+;; Revisions of one document in the same generation and without a shared parent
+;; — what replication leaves behind when the same word was written on two
+;; devices. PouchDB serves whichever leaf has the higher revision hash, so
+;; "1-bbb..." is the one a plain read returns and "1-aaa..." is the conflict.
+;;
+;; The two words below put the last write on opposite sides of that pick: on
+;; Hund the newest revision is the hidden one, on Katze it is the served one.
+;; One word alone would not pin the rule down — with two revisions, "take the
+;; newest" and "take whichever comes second" agree, and a merge that simply
+;; kept the last revision it saw would pass.
+(def ^:private written-on-the-phone
+  {:_id         "vocab:hund"
+   :_rev        "1-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+   :modified-at "2026-06-01"
+   :translation [{:lang "ru" :value "собака"}]
+   :type        "vocab"
+   :value       "Hund"})
+
+
+(def ^:private written-on-the-laptop
+  {:_id         "vocab:hund"
+   :_rev        "1-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+   :modified-at "2026-01-01"
+   :translation [{:lang "ru" :value "пёс"}]
+   :type        "vocab"
+   :value       "Hund"})
+
+
+(def ^:private katze-written-first
+  {:_id         "vocab:katze"
+   :_rev        "1-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+   :modified-at "2026-01-01"
+   :translation [{:lang "ru" :value "кот"}]
+   :type        "vocab"
+   :value       "Katze"})
+
+
+(def ^:private katze-written-last
+  {:_id         "vocab:katze"
+   :_rev        "1-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+   :modified-at "2026-06-01"
+   :translation [{:lang "ru" :value "кошка"}]
+   :type        "vocab"
+   :value       "Katze"})
+
+
+;; Conflicting leaves of a word whose id carries a character well above the
+;; ASCII range — the words are read as a key range, and an id sorting past its
+;; end would never be looked at.
+(def ^:private umlaut-written-first
+  {:_id         "vocab:überwältigend"
+   :_rev        "1-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+   :modified-at "2026-01-01"
+   :translation [{:lang "ru" :value "потрясающий"}]
+   :type        "vocab"
+   :value       "überwältigend"})
+
+
+(def ^:private umlaut-written-last
+  {:_id         "vocab:überwältigend"
+   :_rev        "1-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+   :modified-at "2026-06-01"
+   :translation [{:lang "ru" :value "ошеломительный"}]
+   :type        "vocab"
+   :value       "überwältigend"})
+
+
+(defn- leaf!
+  "Writes a revision under the `_rev` it carries instead of on top of what is
+   stored, which is how a sibling leaf — a conflict — can be made by hand."
+  [user-db doc]
+  (.bulkDocs ^js user-db (db/clj->couch [doc]) #js {:new_edits false}))
+
+
+(defn- with-conflict
+  "Calls (f user-db) against a database holding `docs` as conflicting leaves."
+  [docs f]
+  (db-fixtures/with-test-db
+    user-db-name
+    (^:async fn
+     [user-db]
+     (doseq [doc docs]
+       (await (leaf! user-db doc)))
+     (await (f user-db)))))
+
+
+(defn- ^:async conflicts-of
+  [user-db id]
+  (let [{rows :rows} (await (db/all-docs user-db {:include-docs true :conflicts true}))]
+    (:_conflicts (some #(when (= id (:id %)) (:doc %)) rows))))
+
+
+(deftest the-last-write-wins-over-the-revision-pouchdb-serves
+  (async-testing "a conflict is resolved by :modified-at, whichever leaf carries it"
+    (await
+     (with-conflict
+      [written-on-the-phone written-on-the-laptop katze-written-first katze-written-last]
+      (^:async fn
+       [user-db]
+       (is (= "2026-01-01" (:modified-at (await (db/get user-db "vocab:hund"))))
+           "before resolution the database serves the leaf with the higher hash")
+       (await (sut/resolve-vocab-conflicts! user-db))
+       (is (= "2026-06-01" (:modified-at (await (db/get user-db "vocab:hund"))))
+           "the newest revision was the hidden one")
+       (is (= "2026-06-01" (:modified-at (await (db/get user-db "vocab:katze"))))
+           "and here it was the served one"))))))
+
+
+(deftest no-translation-is-lost-to-the-losing-revision
+  (async-testing "translations are unioned across every revision"
+    (await
+     (with-conflict
+      [written-on-the-phone written-on-the-laptop]
+      (^:async fn
+       [user-db]
+       (await (sut/resolve-vocab-conflicts! user-db))
+       (is (= #{"собака" "пёс"}
+              (into #{} (map :value) (:translation (await (db/get user-db "vocab:hund")))))))))))
+
+
+(deftest the-losing-revisions-are-gone-afterwards
+  (async-testing "resolution deletes the leaves it merged, so the conflict does not come back"
+    (await
+     (with-conflict
+      [written-on-the-phone written-on-the-laptop]
+      (^:async fn
+       [user-db]
+       (is (seq (await (conflicts-of user-db "vocab:hund"))))
+       (await (sut/resolve-vocab-conflicts! user-db))
+       (is (empty? (await (conflicts-of user-db "vocab:hund")))))))))
+
+
+(deftest a-word-outside-the-ascii-range-is-still-reached
+  (async-testing "the key range covers the whole prefix, not the letters it was written with"
+    (await
+     (with-conflict
+      [umlaut-written-first umlaut-written-last]
+      (^:async fn
+       [user-db]
+       (await (sut/resolve-vocab-conflicts! user-db))
+       (is (empty? (await (conflicts-of user-db "vocab:überwältigend"))))
+       (is (= "2026-06-01"
+              (:modified-at (await (db/get user-db "vocab:überwältigend"))))))))))
+
+
+(deftest a-conflict-in-another-type-is-left-alone
+  (async-testing "only vocabulary merges — reviews are union-for-free, so a pass must not touch them"
+    (await
+     (with-conflict
+      [{:_id "review:1" :_rev "1-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" :retained true :type "review"}
+       {:_id "review:1" :_rev "1-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" :retained false :type "review"}]
+      (^:async fn
+       [user-db]
+       (await (sut/resolve-vocab-conflicts! user-db))
+       (is (seq (await (conflicts-of user-db "review:1")))))))))
+
+
+(deftest a-document-without-conflicts-is-not-rewritten
+  (async-testing "an untouched word keeps its revision, so a pass pushes nothing"
+    (await
+     (db-fixtures/with-test-db
+       user-db-name
+       (^:async fn
+        [user-db]
+        (await (db/insert user-db (dissoc written-on-the-phone :_rev)))
+        (let [before (:_rev (await (db/get user-db "vocab:hund")))]
+          (await (sut/resolve-vocab-conflicts! user-db))
+          (is (= before (:_rev (await (db/get user-db "vocab:hund")))))))))))
+
+
+(def ^:private dated
+  {:_id         "vocab:hase"
+   :_rev        "1-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+   :modified-at "2026-06-01"
+   :translation [{:lang "ru" :value "заяц"}]
+   :type        "vocab"
+   :value       "Hase"})
+
+
+(def ^:private undated
+  (-> dated
+      (assoc :_rev        "1-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+             :translation [{:lang "ru" :value "кролик"}])
+      (dissoc :modified-at)))
+
+
+(deftest a-revision-without-a-date-loses-to-one-that-has-it
+  (async-testing "an undated revision cannot be the last write"
+    (await
+     (with-conflict
+      [dated undated]
+      (^:async fn
+       [user-db]
+       (await (sut/resolve-vocab-conflicts! user-db))
+       (is (= "2026-06-01" (:modified-at (await (db/get user-db "vocab:hase"))))))))))
+
+
+(deftest neither-revision-carries-a-date
+  (async-testing "the conflict still goes away, and with both translations"
+    (await
+     (with-conflict
+      [(dissoc dated :modified-at) undated]
+      (^:async fn
+       [user-db]
+       (await (sut/resolve-vocab-conflicts! user-db))
+       (is (empty? (await (conflicts-of user-db "vocab:hase"))))
+       (is (= #{"заяц" "кролик"}
+              (into #{} (map :value) (:translation (await (db/get user-db "vocab:hase")))))))))))


### PR DESCRIPTION
Closes #146.

Two devices now converge on one account, and a launch still creates nothing on the server.

## What ships

**Identity behind an invite (ADR-0006).** The app used to claim a server account on first load — an unauthenticated endpoint minting a permanent, undeletable CouchDB database for any visitor. Now an account is born only when the user redeems a single-use invite. Identity collapses to one 160-bit bearer token whose sha256 is all the server keeps: no password, no session table, no login endpoint. The token travels in the URL fragment, which browsers never send to the server — a query string had been putting credentials straight into nginx's access log.

**Trigger-driven sync (ADR-0007).** Permanent live replication is replaced by a throttled push on local writes and a pull on entering a screen that shows synced data. Vocabulary ids are content-addressed (ADR-0008), so the same word added on two devices converges instead of duplicating; conflicts resolve by last write for scalar fields while translations are unioned across every revision.

**Server-side migrations.** The schema was a hand-applied file of `CREATE TABLE IF NOT EXISTS`, which cannot express a change to a table that already exists — the first added column would have broken every deployed database silently. Migrations now own the schema, all pending ones share a transaction, and the connection takes SQLite's exclusive lock so two processes cannot migrate at once.

Also fixed along the way: `on-connection` leaked a database connection per request, and `dev-mode?` was always true in production, which ran the reloading handler and a hardcoded secret.

## Review notes

The history is meant to be read commit by commit — each one compiles clean and has green tests on its own (verified, not assumed). Two are pure chores (Replicant bump, zprint config) and one is docs (ADR-0009, which is design only — push-notified sync is not implemented here).

Verification: 144 client tests / 331 assertions, 10 backend tests / 25 assertions, `shadow-cljs compile app node-test` with 0 warnings, both OpenSpec changes valid. The identity and sync flows were also exercised in a browser: local-first boot, provisioning through an invite, adopting a key from the same account (merge) and from a different one (wipe), an invalid key, push after a local write, pull on route entry, and both dialogs dismissing from the backdrop.

## Known gaps

- Real-time between two open devices is out of scope by design — ADR-0009 records how it closes, and the QR dialog will auto-close as part of it.
- Token rotation is not implemented; a leaked key stays valid until the account is abandoned.
- Sync conflict resolution reads one revision at a time; measured, batching it is slower locally, and the reason is recorded in the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
