### PR TITLE
GH-168 Stamp the service worker version at build time

### DIFF
--- a/build.clj
+++ b/build.clj
@@ -1,7 +1,10 @@
 (ns build
   (:require
+   [clojure.java.io :as io]
    [clojure.string :as str]
-   [clojure.tools.build.api :as b]))
+   [clojure.tools.build.api :as b])
+  (:import
+   [java.security MessageDigest]))
 
 
 (def target-dir "target")
@@ -32,6 +35,32 @@
   (b/delete {:path "target"}))
 
 
+(defn- assets-digest
+  "sha256 over every file under `dir`, in path order.
+
+   This belongs to the build rather than to the server: it needs to walk a
+   directory, and inside a jar there is none — only a flat list of entries. The
+   server reads the answer back as a single named resource, which a jar does
+   serve."
+  [dir]
+  (let [digest (MessageDigest/getInstance "SHA-256")]
+    (doseq [^java.io.File file (sort (file-seq (io/file dir)))
+            :when (.isFile file)]
+      (with-open [stream (io/input-stream file)]
+        (let [buffer (byte-array 8192)]
+          (loop []
+            (let [n (.read stream buffer)]
+              (when (pos? n)
+                (.update digest buffer 0 n)
+                (recur)))))))
+    (subs (apply str (map #(format "%02x" (Byte/toUnsignedInt %)) (.digest digest))) 0 8)))
+
+
+(def sw-version-file
+  "Read back by `service-worker-handler` in core.clj under the same name."
+  "sw-version")
+
+
 (defn uber
   [_]
   (clean nil)
@@ -39,6 +68,11 @@
   (println "Copying resources...")
   (b/copy-dir {:src-dirs   ["resources"]
                :target-dir class-dir})
+
+  (println "Stamping the service worker version...")
+  (let [version (assets-digest (io/file class-dir "public"))]
+    (spit (io/file class-dir sw-version-file) version)
+    (println (format "Service worker version: %s" version)))
 
   (println "Compiling files...")
   (b/compile-clj {:basis      @basis

--- a/openspec/changes/archive/2026-08-04-build-time-service-worker-version/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-04-build-time-service-worker-version/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-with-adr
+created: 2026-08-04

--- a/openspec/changes/archive/2026-08-04-build-time-service-worker-version/proposal.md
+++ b/openspec/changes/archive/2026-08-04-build-time-service-worker-version/proposal.md
@@ -1,0 +1,17 @@
+# Derive the service worker version at build time
+
+## Why
+
+`SW_VERSION` was computed per request by hashing `resources/public` off the filesystem. A packaged run has no such directory — a jar is a flat list of entries — so the walk found nothing and the digest degraded to the sha256 of empty input, the same string on every release. Browsers saw an unchanged worker and kept serving a cached build indefinitely.
+
+It failed silently, and development masked it: running from source, the directory is there and the mechanism works.
+
+## What changes
+
+The version is computed where the assets are still files — during `clojure -T:build uber`, right after resources are copied — and written into the artifact as a single named resource. The server reads that name back, which is an operation a jar does serve. A source checkout keeps computing from disk, so a rebuild during development is still picked up.
+
+## Impact
+
+- `build.clj` stamps `sw-version` into the uberjar.
+- `core.clj` reads it, falling back to the on-disk digest.
+- One test guards the only thing the two sides share: the name.

--- a/openspec/changes/archive/2026-08-04-build-time-service-worker-version/specs/main-thread-runtime/spec.md
+++ b/openspec/changes/archive/2026-08-04-build-time-service-worker-version/specs/main-thread-runtime/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Service Worker version is derived from the built assets
+The served worker SHALL carry a version derived from the contents of the static assets it caches, computed while those assets are still files and stored in the artifact. The server SHALL NOT enumerate a directory at request time to obtain it.
+
+#### Scenario: A release changes an asset
+- **WHEN** a build runs after any file under `public/` changed
+- **THEN** the version served with the worker differs from the previous build's
+- **AND** browsers treat the worker as changed and install it
+
+#### Scenario: A release changes nothing
+- **WHEN** a build runs with the assets unchanged
+- **THEN** the version is the same as before, and browsers keep the installed worker
+
+#### Scenario: Running from source
+- **WHEN** the server runs from a source checkout, where no version was stamped
+- **THEN** it computes the version from the assets on disk, so a rebuild during development is picked up

--- a/openspec/changes/archive/2026-08-04-build-time-service-worker-version/tasks.md
+++ b/openspec/changes/archive/2026-08-04-build-time-service-worker-version/tasks.md
@@ -1,0 +1,6 @@
+# Tasks
+
+- [x] 1. Compute the assets digest in `build.clj` and write it into the class directory
+- [x] 2. Read the stamped version in `core.clj`, falling back to the on-disk digest
+- [x] 3. Guard the shared resource name with a test
+- [x] 4. Verify the packaged jar serves the stamped version and that it changes with the assets

--- a/openspec/specs/main-thread-runtime/spec.md
+++ b/openspec/specs/main-thread-runtime/spec.md
@@ -89,3 +89,19 @@ The system SHALL keep the Service Worker limited to static asset caching, naviga
 - **WHEN** the SW installs
 - **THEN** it precaches the static assets listed in its manifest
 
+### Requirement: Service Worker version is derived from the built assets
+The served worker SHALL carry a version derived from the contents of the static assets it caches, computed while those assets are still files and stored in the artifact. The server SHALL NOT enumerate a directory at request time to obtain it.
+
+#### Scenario: A release changes an asset
+- **WHEN** a build runs after any file under `public/` changed
+- **THEN** the version served with the worker differs from the previous build's
+- **AND** browsers treat the worker as changed and install it
+
+#### Scenario: A release changes nothing
+- **WHEN** a build runs with the assets unchanged
+- **THEN** the version is the same as before, and browsers keep the installed worker
+
+#### Scenario: Running from source
+- **WHEN** the server runs from a source checkout, where no version was stamped
+- **THEN** it computes the version from the assets on disk, so a rebuild during development is picked up
+

--- a/src/backend/core.clj
+++ b/src/backend/core.clj
@@ -280,7 +280,16 @@
 ;;
 
 
+(def ^:private sw-version-resource
+  "Where the build leaves the service worker version. The name is repeated in
+   build.clj, which writes it — the one thing the two sides must agree on."
+  "sw-version")
+
+
 (defn- public-dir-hash
+  "Digest of the assets as they sit on disk. Only a source checkout can answer
+   this: walking a directory is exactly what a packaged run cannot do, since a
+   jar holds a flat list of entries and `resources/public` is not a path there."
   []
   (let [digest (MessageDigest/getInstance "SHA-256")
         dir    (io/file "resources/public")]
@@ -296,11 +305,22 @@
     (subs (apply str (map #(format "%02x" (Byte/toUnsignedInt %)) (.digest digest))) 0 8)))
 
 
+(defn- service-worker-version
+  "What tells a browser that the worker changed. The build writes it into the
+   artifact, where the assets were still files; a source checkout computes it
+   from disk on every request, so a rebuild during development is picked up."
+  []
+  (if-let [built (io/resource sw-version-resource)]
+    (str/trim (slurp built))
+    (public-dir-hash)))
+
+
 (defn service-worker-handler
   [request]
   (when (= (:uri request) "/js/app/sw.js")
     (when-let [res (io/resource "public/js/sw.js")]
-      (-> (response/response (str "const SW_VERSION=\"" (public-dir-hash) "\";\n" (slurp res)))
+      (-> (response/response
+           (str "const SW_VERSION=\"" (service-worker-version) "\";\n" (slurp res)))
           (response/content-type "text/javascript")
           (response/header "Service-Worker-Allowed" "/")))))
 

--- a/test/backend/core_test.clj
+++ b/test/backend/core_test.clj
@@ -1,5 +1,6 @@
 (ns backend.core-test
   (:require
+   [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [core :as sut]
    [migrations :as migrations]
@@ -68,3 +69,10 @@
   (let [db    (migrated-db)
         token (sut/mint-grant! db -1)]
     (is (false? (#'sut/burn-grant! db token)))))
+
+
+(deftest the-build-and-the-server-agree-on-where-the-version-lives
+  (testing "the name is the only thing the two sides share, and nothing else checks it"
+    (is (str/includes? (slurp "build.clj")
+                       (str "\"" @#'sut/sw-version-resource "\""))
+        "build.clj writes the service worker version under a different name than core.clj reads")))


### PR DESCRIPTION
Closes #168.

`SW_VERSION` hashed `resources/public` per request. Production runs `java -jar` from a directory holding only the jar, so the walk found nothing, the digest degraded to the empty-input sha256, and every release shipped the same string — browsers kept serving a cached build. Development hid it: from source the directory exists.

The digest is now taken during `clojure -T:build uber` and written into the artifact as one named resource; the server reads it by name, which a jar serves fine. Source runs still compute from disk.

Verification:

- jar serves `SW_VERSION="a9b61548"`; changing one CSS file → `097a56fb`; revert → back
- from source: no stamped resource, on-disk digest answers with the same value
- backend 11 tests / 26 assertions; the new test fails if the resource name drifts between `build.clj` and `core.clj`

This is what blocked every fix from reaching installed apps, including #170.

🤖 Generated with [Claude Code](https://claude.com/claude-code)