### PR TITLE
GH-113 CDP tooling failures name their own fix

### DIFF
--- a/.skills/learning-app-cdp/SKILL.md
+++ b/.skills/learning-app-cdp/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: learning-app-cdp
-description: Inspect or debug the learning app in a real browser through the project-specific Windows Chrome CDP workflow. Prefer this skill for browser testing, browser debugging, console inspection, network capture, DOM/runtime inspection, and service-worker-aware refreshes against https://sprecha.local or https://sprecha.de.
+description: "Inspect or debug the learning app in a real browser through the project-specific Windows Chrome CDP workflow. Prefer this skill for browser testing, browser debugging, console inspection, network capture, DOM/runtime inspection, and service-worker-aware refreshes against https://sprecha.local or https://sprecha.de. Commands: doctor, start-local/start-prod (launches Chrome with the debug port — use this when Chrome is down, never launch chrome.exe by hand), refresh-*, wait-* (--path/--selector), eval-* (--expression/--file), console-*, monitor-*, read, clear, stop."
 ---
 
 # Learning App CDP

--- a/.skills/learning-app-cdp/scripts/learning_app_cdp.sh
+++ b/.skills/learning-app-cdp/scripts/learning_app_cdp.sh
@@ -207,6 +207,14 @@ resolve_page_ws_url() {
   printf 'ws://127.0.0.1:%s/devtools/page/%s\n' "$port" "$target_id"
 }
 
+require_endpoint() {
+  local port="$1"
+  bash "$LOW_LEVEL_SCRIPT" version --port "$port" >/dev/null 2>&1 ||
+    die "CDP endpoint on :${port} is not answering — Chrome is not running with the debug port.
+Fix: bash ${BASH_SOURCE[0]} start-local
+(Do not launch chrome.exe by hand: the debug port needs the separate profile start-local provides.)"
+}
+
 wait_for_page_ws_url() {
   local port="$1"
   local env_name="$2"
@@ -214,6 +222,8 @@ wait_for_page_ws_url() {
   local attempts="${4:-40}"
   local delay_sec="${5:-0.25}"
   local ws_url=""
+
+  require_endpoint "$port"
 
   for _ in $(seq 1 "$attempts"); do
     ws_url="$(resolve_page_ws_url "$port" "$env_name" "$url_substring" 2>/dev/null || true)"
@@ -378,7 +388,7 @@ runtime_eval_env() {
   parse_eval_args "$@"
   local ws_url params_json
   ws_url="$(wait_for_page_ws_url "$PORT" "$env_name" "$url_substring")"
-  [[ -n "$ws_url" ]] || die "Could not resolve page websocket URL"
+  [[ -n "$ws_url" ]] || die "Chrome is up, but no tab matches this environment — open one with: bash ${BASH_SOURCE[0]} start-local"
   params_json="$(jq -Rn --arg expr "$EXPRESSION" \
     '{expression:$expr, returnByValue:true, awaitPromise:true, userGesture:true}')"
   bash "$LOW_LEVEL_SCRIPT" send --ws-url "$ws_url" --method Runtime.evaluate --params "$params_json"
@@ -404,7 +414,7 @@ wait_for_path() {
   deadline=$((SECONDS + timeout_sec))
   while :; do
     ws_url="$(wait_for_page_ws_url "$port" "$env_name" "$url_substring")"
-    [[ -n "$ws_url" ]] || die "Could not resolve page websocket URL"
+    [[ -n "$ws_url" ]] || die "Chrome is up, but no tab matches this environment — open one with: bash ${BASH_SOURCE[0]} start-local"
     current_path="$(current_path_via_ws_url "$ws_url")"
     if [[ "$current_path" == "$expected_path" ]]; then
       return 0
@@ -465,7 +475,7 @@ monitor_env() {
   fi
   local ws_url
   ws_url="$(wait_for_page_ws_url "$PORT" "$env_name" "$url_substring")"
-  [[ -n "$ws_url" ]] || die "Could not resolve page websocket URL"
+  [[ -n "$ws_url" ]] || die "Chrome is up, but no tab matches this environment — open one with: bash ${BASH_SOURCE[0]} start-local"
 
   mkdir -p "$MONITOR_BASE_DIR"
   local buffer_path state_path buffer_path_win state_path_win
@@ -507,7 +517,7 @@ console_env() {
   parse_console_args "$@"
   local ws_url
   ws_url="$(wait_for_page_ws_url "$PORT" "$env_name" "$url_substring")"
-  [[ -n "$ws_url" ]] || die "Could not resolve page websocket URL"
+  [[ -n "$ws_url" ]] || die "Chrome is up, but no tab matches this environment — open one with: bash ${BASH_SOURCE[0]} start-local"
   (
     cd /mnt/c
     powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$POWERSHELL_CAPTURE_SCRIPT_WIN" \
@@ -526,7 +536,7 @@ refresh_env() {
   parse_refresh_args "$@"
   local ws_url saved_path current_path
   ws_url="$(wait_for_page_ws_url "$PORT" "$env_name" "$url_substring")"
-  [[ -n "$ws_url" ]] || die "Could not resolve page websocket URL"
+  [[ -n "$ws_url" ]] || die "Chrome is up, but no tab matches this environment — open one with: bash ${BASH_SOURCE[0]} start-local"
 
   bash "$LOW_LEVEL_SCRIPT" send --ws-url "$ws_url" --method ServiceWorker.enable --params '{}'
   bash "$LOW_LEVEL_SCRIPT" send --ws-url "$ws_url" --method ServiceWorker.setForceUpdateOnPageLoad --params '{"forceUpdateOnPageLoad":true}'
@@ -536,7 +546,7 @@ refresh_env() {
   [[ -n "$saved_path" ]] || return 0
 
   ws_url="$(wait_for_page_ws_url "$PORT" "$env_name" "$url_substring")"
-  [[ -n "$ws_url" ]] || die "Could not resolve page websocket URL"
+  [[ -n "$ws_url" ]] || die "Chrome is up, but no tab matches this environment — open one with: bash ${BASH_SOURCE[0]} start-local"
   current_path="$(current_path_via_ws_url "$ws_url")"
   if [[ "$current_path" != "$saved_path" ]]; then
     start_env "$env_name" "$base_url" "$url_substring" --port "$PORT" --path "$saved_path" >/dev/null
@@ -555,7 +565,7 @@ wait_env() {
 
   local ws_url expression params_json
   ws_url="$(wait_for_page_ws_url "$PORT" "$env_name" "$url_substring")"
-  [[ -n "$ws_url" ]] || die "Could not resolve page websocket URL"
+  [[ -n "$ws_url" ]] || die "Chrome is up, but no tab matches this environment — open one with: bash ${BASH_SOURCE[0]} start-local"
 
   expression="$(jq -rn --arg path "$WAIT_PATH" --arg selector "$WAIT_SELECTOR" '
     "(() => { " +
@@ -589,7 +599,7 @@ wait_env() {
 
     sleep 0.25
     ws_url="$(wait_for_page_ws_url "$PORT" "$env_name" "$url_substring")"
-    [[ -n "$ws_url" ]] || die "Could not resolve page websocket URL"
+    [[ -n "$ws_url" ]] || die "Chrome is up, but no tab matches this environment — open one with: bash ${BASH_SOURCE[0]} start-local"
   done
 }
 
@@ -714,6 +724,17 @@ doctor() {
     echo "ok  Windows Chrome is visible: $CHROME_PATH"
   else
     echo "fail Windows Chrome not found at $CHROME_PATH"
+    failures=1
+  fi
+
+  # The plumbing being healthy says nothing about the endpoint: Chrome may
+  # simply not be running with the debug port.
+  if browser=$(bash "$LOW_LEVEL_SCRIPT" version --port "$DEFAULT_PORT" 2>/dev/null | jq -r '.Browser' 2>/dev/null) && [[ -n "$browser" && "$browser" != "null" ]]; then
+    echo "ok  CDP endpoint :$DEFAULT_PORT is alive ($browser)"
+  else
+    echo "fail CDP endpoint :$DEFAULT_PORT is not answering"
+    echo "     -> run: bash ${BASH_SOURCE[0]} start-local"
+    echo "        (never launch chrome.exe by hand: the debug port needs the separate profile start-local provides)"
     failures=1
   fi
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@ Always use `:reload` when requiring namespaces to pick up changes.
 
 - For browser-runtime behavior, use real browser proof, not only code inspection.
 - Before Windows Chrome CDP, run `bash .codex/skills/learning-app-cdp/scripts/learning_app_cdp.sh doctor`.
+- Chrome down (CDP endpoint silent, evals dying)? `learning_app_cdp.sh start-local`. Never launch chrome.exe by hand: the debug port needs the separate profile start-local provides.
 - If Windows interop is broken (`cmd.exe` gives `exec format error` or `WSLInterop` is missing), ask for `wsl --shutdown`, then retry.
 - For Service Worker offline reload checks, wait until `navigator.serviceWorker.controller` is true before switching offline.
 

--- a/openspec/changes/archive/2026-08-05-cdp-actionable-failures/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-05-cdp-actionable-failures/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-with-adr
+created: 2026-08-05

--- a/openspec/changes/archive/2026-08-05-cdp-actionable-failures/proposal.md
+++ b/openspec/changes/archive/2026-08-05-cdp-actionable-failures/proposal.md
@@ -1,0 +1,16 @@
+# CDP tooling failures name their own fix
+
+## Why
+
+With Chrome down, `doctor` reported five "ok" lines (it checks interop plumbing, not the endpoint), and every eval spun 40 interop-priced retries — 1.5–2 minutes of silence — before dying with a dead-end message. An agent read "all ok", concluded the tooling could not start Chrome, and launched chrome.exe by hand, hitting the debug-port/profile trap `start-local` exists to solve. The information was in three places (SKILL.md, usage, dispatcher) and all three were skippable; the only channel that cannot be skipped is the output of the failure itself.
+
+## What changes
+
+- `doctor` probes the endpoint and, when dead, prints the fix: `start-local`.
+- Page-resolution paths preflight the endpoint once and fail in seconds, naming the fix; the "no matching tab" dead-end names it too.
+- The skill description enumerates the commands, so `start-local` is visible without opening anything.
+- AGENTS.md gains the trigger line: Chrome down → `start-local`, never launch chrome.exe by hand.
+
+## Impact
+
+Modified: `repo-browser-debugging`. Files: `learning_app_cdp.sh`, `SKILL.md`, `AGENTS.md`.

--- a/openspec/changes/archive/2026-08-05-cdp-actionable-failures/specs/repo-browser-debugging/spec.md
+++ b/openspec/changes/archive/2026-08-05-cdp-actionable-failures/specs/repo-browser-debugging/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: CDP tooling failures prescribe the fix
+When the CDP endpoint is not answering, the tooling SHALL fail fast and name the exact command that repairs the situation, rather than diagnosing transport health alone or timing out silently.
+
+#### Scenario: Doctor with Chrome down
+- **WHEN** `doctor` runs while the CDP endpoint is not answering
+- **THEN** it reports the endpoint as failed and prints the `start-local` command to run
+
+#### Scenario: Eval with Chrome down
+- **WHEN** any page-resolving command runs while the endpoint is not answering
+- **THEN** it fails within seconds — not after a multi-minute retry loop — and its error names `start-local`
+
+#### Scenario: Chrome up but no app tab
+- **WHEN** the endpoint answers but no tab matches the environment
+- **THEN** the error names `start-local` as the way to open one

--- a/openspec/changes/archive/2026-08-05-cdp-actionable-failures/tasks.md
+++ b/openspec/changes/archive/2026-08-05-cdp-actionable-failures/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+- [x] 1. Endpoint probe with prescription in `doctor`
+- [x] 2. Fast preflight in page resolution; actionable die messages
+- [x] 3. Command list in the skill description
+- [x] 4. Trigger line in AGENTS.md
+- [x] 5. Verify live: dead port fails in ~2 s with the fix named; doctor reports the endpoint; normal eval unaffected

--- a/openspec/specs/repo-browser-debugging/spec.md
+++ b/openspec/specs/repo-browser-debugging/spec.md
@@ -19,3 +19,18 @@ The project-specific CDP workflow SHALL provide a local refresh path that forces
 - **THEN** the project CDP wrapper can enable service-worker update-on-reload and reload the page
 - **AND** the workflow reduces the chance of inspecting stale service-worker-controlled assets
 
+### Requirement: CDP tooling failures prescribe the fix
+When the CDP endpoint is not answering, the tooling SHALL fail fast and name the exact command that repairs the situation, rather than diagnosing transport health alone or timing out silently.
+
+#### Scenario: Doctor with Chrome down
+- **WHEN** `doctor` runs while the CDP endpoint is not answering
+- **THEN** it reports the endpoint as failed and prints the `start-local` command to run
+
+#### Scenario: Eval with Chrome down
+- **WHEN** any page-resolving command runs while the endpoint is not answering
+- **THEN** it fails within seconds — not after a multi-minute retry loop — and its error names `start-local`
+
+#### Scenario: Chrome up but no app tab
+- **WHEN** the endpoint answers but no tab matches the environment
+- **THEN** the error names `start-local` as the way to open one
+


### PR DESCRIPTION
Part of #113 (the CDP-handling half).

With Chrome down, `doctor` said "ok" five times (plumbing only, never the endpoint) and every eval burned 40 interop-priced retries — 1.5–2 minutes of silence — before a dead-end error. The fix follows one principle: the only discoverability channel that cannot be skipped is the output of the failure itself, so failures now name the command that repairs them.

- `doctor` probes the endpoint: alive → reports the Chrome version; dead → prints `start-local`.
- Page resolution preflights once: dead endpoint fails in ~2 s with the fix named (measured, was 1.5–2 min).
- "No matching tab" also prescribes `start-local`.
- Skill description enumerates the commands; AGENTS.md gains "Chrome down → start-local, never launch chrome.exe by hand".

OpenSpec: `repo-browser-debugging` gains the requirement; change archived on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)