### PR TITLE
GH-177 In-page measurement behind goog.DEBUG

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ app.db
 /opencode.json
 /.tmp/
 /src/client/sqlite3_cjs.js
+.claude/worktrees/

--- a/openspec/changes/archive/2026-08-05-in-page-measurement/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-05-in-page-measurement/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-with-adr
+created: 2026-08-05

--- a/openspec/changes/archive/2026-08-05-in-page-measurement/proposal.md
+++ b/openspec/changes/archive/2026-08-05-in-page-measurement/proposal.md
@@ -1,0 +1,15 @@
+# In-page measurement behind goog.DEBUG
+
+## Why
+
+Decisions were queuing up that cannot be argued without numbers — #176 rests on render counts per dispatch, #178 on renders per keystroke, #179 on transport overhead — while every measurement lived in ad-hoc scripts under /tmp, rebuilt each session.
+
+## What changes
+
+A dev-only `instrumentation` namespace counts renders (store notifications), dispatches with nesting, frames, layout shifts (input-caused ones filtered), long tasks and slow interactions, exposed as `window.__metrics()` / `window.__metricsReset()`. Installed from the render component only under `goog.DEBUG`; a release build eliminates it.
+
+## Impact
+
+- New: `src/client/instrumentation.cljs`; one guarded call in `main.cljs`.
+- Modified capability: `repo-browser-debugging`.
+- Phase 2 of #177 — protocol-level traces — rides the Playwright suite (#169).

--- a/openspec/changes/archive/2026-08-05-in-page-measurement/specs/repo-browser-debugging/spec.md
+++ b/openspec/changes/archive/2026-08-05-in-page-measurement/specs/repo-browser-debugging/spec.md
@@ -1,0 +1,12 @@
+## ADDED Requirements
+
+### Requirement: Development builds expose page metrics
+A development build SHALL expose in-page counters — renders, dispatches with nesting, frames, layout shift excluding input-caused entries, long tasks, slow interactions — readable as `window.__metrics()` and resettable as `window.__metricsReset()`. Release builds SHALL NOT contain the instrumentation.
+
+#### Scenario: Measurements distinguish known cases
+- **WHEN** a state-saving dispatch runs and then a deliberate layout shift is introduced without user input
+- **THEN** the render counter increases for the former and the layout-shift score is nonzero for the latter
+
+#### Scenario: Occluded window
+- **WHEN** the browser window is occluded or hidden
+- **THEN** frame- and paint-dependent metrics stop advancing while dispatch and long-task counters keep working — a documented property, verified in a painting environment instead

--- a/openspec/changes/archive/2026-08-05-in-page-measurement/tasks.md
+++ b/openspec/changes/archive/2026-08-05-in-page-measurement/tasks.md
@@ -1,0 +1,5 @@
+# Tasks
+
+- [x] 1. Instrumentation namespace: renders, dispatches/nesting, frames, layout shift, long tasks, slow interactions
+- [x] 2. Install under goog.DEBUG from the render component
+- [x] 3. Verify the measurements distinguish known cases (headless, where painting is guaranteed)

--- a/openspec/specs/repo-browser-debugging/spec.md
+++ b/openspec/specs/repo-browser-debugging/spec.md
@@ -34,3 +34,14 @@ When the CDP endpoint is not answering, the tooling SHALL fail fast and name the
 - **WHEN** the endpoint answers but no tab matches the environment
 - **THEN** the error names `start-local` as the way to open one
 
+### Requirement: Development builds expose page metrics
+A development build SHALL expose in-page counters — renders, dispatches with nesting, frames, layout shift excluding input-caused entries, long tasks, slow interactions — readable as `window.__metrics()` and resettable as `window.__metricsReset()`. Release builds SHALL NOT contain the instrumentation.
+
+#### Scenario: Measurements distinguish known cases
+- **WHEN** a state-saving dispatch runs and then a deliberate layout shift is introduced without user input
+- **THEN** the render counter increases for the former and the layout-shift score is nonzero for the latter
+
+#### Scenario: Occluded window
+- **WHEN** the browser window is occluded or hidden
+- **THEN** frame- and paint-dependent metrics stop advancing while dispatch and long-task counters keep working — a documented property, verified in a painting environment instead
+

--- a/src/client/instrumentation.cljs
+++ b/src/client/instrumentation.cljs
@@ -1,0 +1,109 @@
+(ns instrumentation
+  "In-page measurement for development. Answers, with numbers, what the
+   browser did: how many times the app rendered, how many dispatches ran and
+   how they nested, whether layout shifted, which tasks ran long, which
+   interactions were slow.
+
+   Installed only under goog.DEBUG — a release build eliminates the whole
+   namespace. Read from the page as `window.__metrics()`, reset with
+   `window.__metricsReset()`.
+
+   Honest limits, measured before this existed: the frame counter stops when
+   the window is occluded even though visibilityState stays \"visible\", and a
+   render here means one store notification — the browser still paints at most
+   once per frame regardless of how many happened inside it."
+  (:require
+   [nexus.registry :as nxr]))
+
+
+(defonce ^:private zero-metrics
+  {:dispatches   0
+   :frames       0
+   :layout-shift 0.0
+   :long-tasks   []
+   :nested-dispatches 0
+   :renders      0
+   :slow-interactions []})
+
+
+(defonce ^:private metrics (atom zero-metrics))
+
+
+(defonce ^:private dispatch-depth (volatile! 0))
+
+
+(defn- observe!
+  "Watches one PerformanceObserver entry type, quietly skipping the ones this
+   browser does not support."
+  [entry-type f options]
+  (try
+    (let [observer (js/PerformanceObserver.
+                    (fn [entries _]
+                      (doseq [entry (.getEntries ^js entries)]
+                        (f entry))))]
+      (.observe observer (clj->js (merge {:type entry-type :buffered true} options)))
+      observer)
+    (catch :default _ nil)))
+
+
+(defn- count-frames!
+  []
+  (js/requestAnimationFrame
+   (fn [_]
+     (swap! metrics update :frames inc)
+     (count-frames!))))
+
+
+(defn install!
+  "Wires every probe up. Takes the store so renders are counted the same way
+   they are triggered — one notification, one render."
+  [store]
+  (add-watch store ::renders (fn [_ _ _ _] (swap! metrics update :renders inc)))
+
+  (nxr/register-interceptor!
+    {:before-dispatch (fn [ctx]
+                        (swap! metrics update
+                          (if (zero? @dispatch-depth) :dispatches :nested-dispatches)
+                          inc)
+                        (vswap! dispatch-depth inc)
+                        ctx)
+     :after-dispatch  (fn [ctx]
+                        (vswap! dispatch-depth dec)
+                        ctx)})
+
+  (count-frames!)
+
+  ;; Shifts the user did not cause: hadRecentInput filters out reflows that
+  ;; follow the user's own click or keystroke, the same rule CLS scoring uses.
+  (observe! "layout-shift"
+            (fn [entry]
+              (when-not (.-hadRecentInput ^js entry)
+                (swap! metrics update :layout-shift + (.-value ^js entry))))
+            {})
+
+  (observe! "longtask"
+            (fn [entry]
+              (swap! metrics update
+                :long-tasks
+                conj
+                {:duration (.-duration ^js entry)
+                 :name     (.-name ^js entry)}))
+            {})
+
+  ;; Interactions the user would call sluggish. 100 ms is where an interface
+  ;; stops feeling instant; faster events are noise at this level.
+  (observe! "event"
+            (fn [entry]
+              (swap! metrics update
+                :slow-interactions
+                conj
+                {:duration (.-duration ^js entry)
+                 :type     (.-name ^js entry)}))
+            {:durationThreshold 100})
+
+  (set! (.-__metrics js/window) (fn [] (clj->js @metrics)))
+  (set! (.-__metricsReset js/window)
+        (fn []
+          (reset! metrics zero-metrics)
+          (vreset! dispatch-depth 0)
+          nil)))

--- a/src/client/instrumentation.cljs
+++ b/src/client/instrumentation.cljs
@@ -34,15 +34,20 @@
 
 (defn- observe!
   "Watches one PerformanceObserver entry type, quietly skipping the ones this
-   browser does not support."
+   browser does not support.
+
+   The constructor takes a callback the browser itself invokes with a batch of
+   entries whenever new ones are recorded; `.observe` only says which entry
+   type to watch. Nothing holds the observer afterwards on purpose: the
+   platform keeps a registered observer alive until `.disconnect`, and these
+   watch for the whole page lifetime."
   [entry-type f options]
   (try
-    (let [observer (js/PerformanceObserver.
-                    (fn [entries _]
-                      (doseq [entry (.getEntries ^js entries)]
-                        (f entry))))]
-      (.observe observer (clj->js (merge {:type entry-type :buffered true} options)))
-      observer)
+    (.observe (js/PerformanceObserver.
+               (fn [entries _]
+                 (doseq [entry (.getEntries ^js entries)]
+                   (f entry))))
+              (clj->js (merge {:type entry-type :buffered true} options)))
     (catch :default _ nil)))
 
 
@@ -101,6 +106,9 @@
                  :type     (.-name ^js entry)}))
             {:durationThreshold 100})
 
+  ;; The page-facing API for tests and CDP evals. Functions, not values: each
+  ;; call snapshots the atom at that moment — a value stored once would be
+  ;; frozen at install time.
   (set! (.-__metrics js/window) (fn [] (clj->js @metrics)))
   (set! (.-__metricsReset js/window)
         (fn []

--- a/src/client/main.cljs
+++ b/src/client/main.cljs
@@ -4,6 +4,7 @@
    [db.pouch :as pouch]
    [db.sqlite :as sqlite]
    [install-guide.core]
+   [instrumentation :as instrumentation]
    [lambdaisland.glogi :as log]
    [logging]
    [nexus.action-log :as action-log]
@@ -108,6 +109,8 @@
                                        (nxr/register-system->state! #(-> % :store deref))
                                        (r/set-dispatch! dispatch)
                                        (add-watch store ::render #(application/render! %4))
+                                       (when goog/DEBUG
+                                         (instrumentation/install! store))
                                        {:dispatch #(dispatch {} %)}))}
 
     :pwa/init           {:requires {:render :app/render}


### PR DESCRIPTION
Part of #177 — phase 1, the in-page half. Phase 2 (protocol-level traces) rides the Playwright suite, #169.

`window.__metrics()` in dev builds: renders, dispatches with nesting depth, frames, layout shift (input-caused entries filtered, CLS rule), long tasks, interactions over 100 ms. One guarded call in `main.cljs`; release builds eliminate the namespace.

Verified against the issue's own criterion — measurements must distinguish known cases. In headless Chrome (painting guaranteed): a saving dispatch renders exactly once; a deliberate 220 px layout shift scores 0.605; a 120 ms busy loop appears in long-tasks; 36 frames per 600 ms. Also measured and documented: an occluded window freezes frame- and paint-dependent metrics while dispatch and long-task counters keep working — relevant for anyone measuring against the visible Windows browser.

Tests: client 144 / 331, both builds 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)