### PR TITLE
GH-192 Configurable database path via LEARNING_APP_DB_PATH

### DIFF
--- a/openspec/changes/archive/2026-08-05-configurable-db-path/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-05-configurable-db-path/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-with-adr
+created: 2026-08-05

--- a/openspec/changes/archive/2026-08-05-configurable-db-path/proposal.md
+++ b/openspec/changes/archive/2026-08-05-configurable-db-path/proposal.md
@@ -1,0 +1,14 @@
+# Configurable database path
+
+## Why
+
+`db-spec` in `src/backend/core.clj` hardcodes `app.db` relative to the working directory (GH-192). Any process started from another directory — a worktree, a REPL, a one-off tool — silently creates a fresh empty database wherever it happens to run, instead of failing or finding the real one. The port already reads `LEARNING_APP_PORT`; the database path deserves the same escape hatch.
+
+## What changes
+
+- `db-spec` reads `LEARNING_APP_DB_PATH`, defaulting to `app.db` — production behavior (WorkingDirectory=/opt/learning-app, so /opt/learning-app/app.db) is unchanged.
+- `db-spec` stays the single home of the value: migrations and handlers already take it as an argument; dictionary tools and tests build their own specs for their own files and are untouched.
+
+## Impact
+
+Added: `backend-configuration`. Files: `src/backend/core.clj`.

--- a/openspec/changes/archive/2026-08-05-configurable-db-path/specs/backend-configuration/spec.md
+++ b/openspec/changes/archive/2026-08-05-configurable-db-path/specs/backend-configuration/spec.md
@@ -1,0 +1,12 @@
+## ADDED Requirements
+
+### Requirement: Database path is configurable via environment
+The backend SHALL resolve its SQLite database path from `LEARNING_APP_DB_PATH`, defaulting to `app.db` relative to the working directory when the variable is unset. The resolved spec SHALL live in exactly one place, used by the server, handlers, and migrations alike.
+
+#### Scenario: Env var points elsewhere
+- **WHEN** the backend starts with `LEARNING_APP_DB_PATH=/some/path/app.db`
+- **THEN** migrations and all queries run against `/some/path/app.db`
+
+#### Scenario: Env var unset
+- **WHEN** the backend starts without `LEARNING_APP_DB_PATH`
+- **THEN** it uses `app.db` in the working directory, identical to prior behavior

--- a/openspec/changes/archive/2026-08-05-configurable-db-path/tasks.md
+++ b/openspec/changes/archive/2026-08-05-configurable-db-path/tasks.md
@@ -1,0 +1,6 @@
+# Tasks
+
+- [x] 1. `db-spec` reads `LEARNING_APP_DB_PATH` with `app.db` default
+- [x] 2. Confirm `db-spec` is the only home of the app database spec (grep migrations, tools, tests)
+- [x] 3. Backend tests green (11 tests / 26 assertions)
+- [x] 4. Prove env var: boot migrations with `LEARNING_APP_DB_PATH=/tmp/probe-192.db`, file appears at the pointed path; default spec unchanged without the var

--- a/openspec/specs/backend-configuration/spec.md
+++ b/openspec/specs/backend-configuration/spec.md
@@ -1,0 +1,16 @@
+# backend-configuration Specification
+
+## Purpose
+TBD - created by archiving change configurable-db-path. Update Purpose after archive.
+## Requirements
+### Requirement: Database path is configurable via environment
+The backend SHALL resolve its SQLite database path from `LEARNING_APP_DB_PATH`, defaulting to `app.db` relative to the working directory when the variable is unset. The resolved spec SHALL live in exactly one place, used by the server, handlers, and migrations alike.
+
+#### Scenario: Env var points elsewhere
+- **WHEN** the backend starts with `LEARNING_APP_DB_PATH=/some/path/app.db`
+- **THEN** migrations and all queries run against `/some/path/app.db`
+
+#### Scenario: Env var unset
+- **WHEN** the backend starts without `LEARNING_APP_DB_PATH`
+- **THEN** it uses `app.db` in the working directory, identical to prior behavior
+

--- a/src/backend/core.clj
+++ b/src/backend/core.clj
@@ -68,7 +68,8 @@
 
 
 (def db-spec
-  {:dbtype "sqlite" :dbname "app.db"})
+  {:dbname (or (System/getenv "LEARNING_APP_DB_PATH") "app.db")
+   :dbtype "sqlite"})
 
 
 (defmacro on-connection


### PR DESCRIPTION
Depends-on: #201

Closes #192.

## What

`db-spec` in `src/backend/core.clj` now reads `LEARNING_APP_DB_PATH`, defaulting to `app.db` — same pattern as `port` / `LEARNING_APP_PORT`.

- `db-spec` remains the single home of the app database spec: migrations and handlers take it as an argument; dictionary tools and tests build their own specs for their own files (verified by grep).
- Production unchanged: the service runs with `WorkingDirectory=/opt/learning-app` and no `LEARNING_APP_DB_PATH`, so the default resolves to `/opt/learning-app/app.db` exactly as before. Service file untouched.
- OpenSpec: new `backend-configuration` capability, change archived as `2026-08-05-configurable-db-path` in the same commit.

## Verification

Backend tests:

```
Ran 11 tests containing 26 assertions.
0 failures, 0 errors.
```

Env var proof — migrations booted against the pointed path:

```
$ rm -f /tmp/probe-192.db && LEARNING_APP_DB_PATH=/tmp/probe-192.db clj -M:dev -e "(require 'core 'migrations) ..."
db-spec: {:dbname /tmp/probe-192.db, :dbtype sqlite}
exists: true
-rw-r--r-- 1 u473t8 u473t8 77824 Aug  5 17:49 /tmp/probe-192.db
```

Default without the var:

```
default db-spec: {:dbname app.db, :dbtype sqlite}
```

Not verified: running production service with the new jar (backend-only worktree, dev stand untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)