### PR TITLE
GH-182 Refuse account ids whose userdb already exists

### DIFF
--- a/openspec/changes/archive/2026-08-05-recycled-id-guard/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-05-recycled-id-guard/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-with-adr
+created: 2026-08-05

--- a/openspec/changes/archive/2026-08-05-recycled-id-guard/proposal.md
+++ b/openspec/changes/archive/2026-08-05-recycled-id-guard/proposal.md
@@ -1,0 +1,13 @@
+# Recycled account ids do not inherit userdbs
+
+## Why
+
+Account ids are `users` row ids and the CouchDB database name derives from them, but the two stores have independent lifetimes: an `app.db` reset restarts id allocation while `userdb-*` survive. Seen live (#182): a freshly provisioned account received id 1 and its first sync pass pulled 112 documents belonging to the previous owner of `userdb-1`.
+
+## What changes
+
+`create-account!` refuses an id whose userdb already exists — the row insert and the existence check share a transaction, so a refusal leaves the id unspent and the stale userdb intact as evidence. The provision route answers 503 and logs `::recycled-id-refused`. Deleting the stale userdb is the operator's call, not the code's.
+
+## Impact
+
+`create-account!`, the provision route, two tests, live verification on the dev stand. Known cost: the invite is burned before the refusal is discovered — the operator mints a new one after clearing the conflict.

--- a/openspec/changes/archive/2026-08-05-recycled-id-guard/specs/identity-provisioning/spec.md
+++ b/openspec/changes/archive/2026-08-05-recycled-id-guard/specs/identity-provisioning/spec.md
@@ -1,0 +1,12 @@
+## ADDED Requirements
+
+### Requirement: A recycled account id never inherits an existing userdb
+Provisioning SHALL refuse to create an account whose derived userdb already exists in CouchDB, leaving the user row unwritten and the stale userdb untouched. The refusal SHALL be observable to the operator.
+
+#### Scenario: Stale userdb from a previous owner
+- **WHEN** provisioning would assign an id whose `userdb-<id>` already exists
+- **THEN** the request fails with 503, no user row is created, and the event is logged
+
+#### Scenario: Clean id
+- **WHEN** no userdb exists for the assigned id
+- **THEN** the account is created and its userdb is secured with the account's role

--- a/openspec/changes/archive/2026-08-05-recycled-id-guard/tasks.md
+++ b/openspec/changes/archive/2026-08-05-recycled-id-guard/tasks.md
@@ -1,0 +1,6 @@
+# Tasks
+
+- [x] 1. Existence check inside the account transaction; refusal keeps the id unspent
+- [x] 2. Provision route: 503 + telemetry on refusal
+- [x] 3. Tests: refusal rolls back the row; a fresh id provisions and secures its userdb
+- [x] 4. Live proof on the stand: stale userdb-2 → 503, row count unchanged; cleared → 200, role-secured userdb

--- a/openspec/specs/identity-provisioning/spec.md
+++ b/openspec/specs/identity-provisioning/spec.md
@@ -1,0 +1,16 @@
+# identity-provisioning Specification
+
+## Purpose
+TBD - created by archiving change recycled-id-guard. Update Purpose after archive.
+## Requirements
+### Requirement: A recycled account id never inherits an existing userdb
+Provisioning SHALL refuse to create an account whose derived userdb already exists in CouchDB, leaving the user row unwritten and the stale userdb untouched. The refusal SHALL be observable to the operator.
+
+#### Scenario: Stale userdb from a previous owner
+- **WHEN** provisioning would assign an id whose `userdb-<id>` already exists
+- **THEN** the request fails with 503, no user row is created, and the event is logged
+
+#### Scenario: Clean id
+- **WHEN** no userdb exists for the assigned id
+- **THEN** the account is created and its userdb is secured with the account's role
+

--- a/src/backend/core.clj
+++ b/src/backend/core.clj
@@ -154,12 +154,25 @@
 (defn create-account!
   "Mints a bearer token, creates the account row holding its sha256, and its
    role-secured CouchDB userdb. Returns {:id int :token str} — the raw token
-   is the user's key, stored nowhere on the server."
+   is the user's key, stored nowhere on the server.
+
+   Refuses an id whose userdb already exists. Account ids are row ids and
+   CouchDB outlives app.db resets, so a recycled id would silently inherit —
+   and sync down — the previous owner's data (seen live, #182). Refusal keeps
+   the evidence; deleting the stale userdb is the operator's call."
   [db]
-  (let [token        (random-token)
-        {:keys [id]} (jdbc/execute-one! db
-                       ["INSERT INTO users (token_sha256) VALUES (?) RETURNING id"
-                        (sha256-hex token)])]
+  (let [token (random-token)
+        id    (jdbc/with-transaction [tx db]
+                ;; Explicit builder: the id must come back as :id no matter
+                ;; which connection options the caller carries.
+                (let [{:keys [id]} (jdbc/execute-one! tx
+                                     ["INSERT INTO users (token_sha256) VALUES (?) RETURNING id"
+                                      (sha256-hex token)]
+                                     {:builder-fn result-set/as-unqualified-maps})]
+                  (when (db/exists? (str "userdb-" id))
+                    (throw (ex-info "userdb already exists for a fresh account id"
+                                    {:type ::recycled-id :id id})))
+                  id))]
     (db/secure (db/use (str "userdb-" id)) {:members {:names [] :roles [(str "u:" id)]}})
     {:id id :token token}))
 
@@ -396,10 +409,16 @@
          (on-connection [db db-spec]
            (let [{:keys [invite]} (some-> (:body request) io/reader (cheshire/parse-stream true))]
              (if (and (utils/non-blank invite) (burn-grant! db invite))
-               (let [{:keys [id token]} (create-account! db)]
-                 {:status  200
-                  :headers {"Content-Type" "application/json"}
-                  :body    (cheshire/generate-string {:id id :token token})})
+               (try
+                 (let [{:keys [id token]} (create-account! db)]
+                   {:status  200
+                    :headers {"Content-Type" "application/json"}
+                    :body    (cheshire/generate-string {:id id :token token})})
+                 (catch clojure.lang.ExceptionInfo e
+                   (if (= ::recycled-id (:type (ex-data e)))
+                     (do (t/event! ::recycled-id-refused {:level :error :data (ex-data e)})
+                         {:status 503 :body ""})
+                     (throw e))))
                {:status 403 :body ""}))))}]
 
      ;; Adopting a key means holding a token and nothing else. The token comes

--- a/test/backend/core_test.clj
+++ b/test/backend/core_test.clj
@@ -3,6 +3,7 @@
    [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [core :as sut]
+   [db :as db]
    [migrations :as migrations]
    [next.jdbc :as jdbc]
    [next.jdbc.result-set :as result-set])
@@ -76,3 +77,28 @@
     (is (str/includes? (slurp "build.clj")
                        (str "\"" @#'sut/sw-version-resource "\""))
         "build.clj writes the service worker version under a different name than core.clj reads")))
+
+
+(deftest a-recycled-id-is-refused-not-inherited
+  (testing "a userdb left by a previous owner of the id blocks provisioning"
+    (let [db (migrated-db)]
+      (with-redefs [db/exists? (constantly true)]
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #"userdb already exists"
+                              (#'sut/create-account! db))))
+      (is (empty? (jdbc/execute! db ["SELECT id FROM users"]))
+          "the transaction rolled the row back, the id stays unspent"))))
+
+
+(deftest a-fresh-id-provisions-and-secures-its-userdb
+  (testing "the guard does not get in the way of a normal provision"
+    (let [db      (migrated-db)
+          secured (atom nil)]
+      (with-redefs [db/exists? (constantly false)
+                    db/use     (fn [name] name)
+                    db/secure  (fn [name security] (reset! secured [name security]))]
+        (let [{:keys [id token]} (#'sut/create-account! db)]
+          (is (int? id))
+          (is (= 40 (count token)))
+          (is (= (str "userdb-" id) (first @secured)))
+          (is (= [(str "u:" id)] (get-in (second @secured) [:members :roles]))))))))


### PR DESCRIPTION
Closes #182.

Account ids are `users` row ids and userdb names derive from them, but CouchDB outlives `app.db` resets — a recycled id silently inherited the previous owner's data (112 foreign documents on a fresh account, seen live). The existence check now shares a transaction with the row insert: refusal leaves the id unspent and the stale userdb intact as evidence; the route answers 503 and logs `::recycled-id-refused`. Deleting the stale userdb stays the operator's call.

Verification, all live on the stand: stale `userdb-2` → HTTP 503, `users` count unchanged, event in the log; after operator deletion → HTTP 200, id 2, `userdb-2` created with `{"roles":["u:2"]}`. Tests 13/32 green, including rollback of the refused row. Also fixed en route: the id extraction now pins its own result-set builder instead of inheriting whichever options the caller's connection carries.

Known cost, stated: the invite burns before the refusal is discovered — after clearing the conflict the operator mints a new one. Acceptable for a corruption-detection path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)