### PR TITLE
GH-189 Verified atomic jar swap on deploy

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -38,7 +38,10 @@ jobs:
       - run: rm -rf resources/public/js/app
       - run: npx shadow-cljs release app
       - run: clojure -T:build uber
-      - run: cp target/learning-app.jar target/learning-app.jar.tmp
+      # Unique per-run temp name: concurrent deploys never share an upload path.
+      - run: cp target/learning-app.jar 'target/learning-app.jar.${{ github.run_id }}.tmp'
+      - id: jar
+        run: echo "sha256=$(sha256sum target/learning-app.jar | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
 
       - uses: actions/cache/save@v6.1.0
         if: ${{ always() && steps.cache-clojure.outputs.cache-hit != 'true' }}
@@ -55,16 +58,24 @@ jobs:
           username: ${{ secrets.USER }}
           key: ${{ secrets.KEY }}
           strip_components: 1 # removes '/target' segment from the source path.
-          source: 'target/learning-app.jar.tmp'
+          source: 'target/learning-app.jar.${{ github.run_id }}.tmp'
           target: '/opt/learning-app/'
           overwrite: true
 
+      # Verify the upload is complete, then rename(2) it into place: same
+      # filesystem, so the swap is atomic and the restart watch on
+      # learning-app.jar only ever sees a whole artifact.
       - uses: appleboy/ssh-action@v1.2.5
+        env:
+          JAR_TMP: /opt/learning-app/learning-app.jar.${{ github.run_id }}.tmp
+          JAR_SHA256: ${{ steps.jar.outputs.sha256 }}
         with:
           host: ${{ secrets.HOST }}
           username: ${{ secrets.USER }}
           key: ${{ secrets.KEY }}
+          envs: JAR_TMP,JAR_SHA256
           script: |
             set -euo pipefail
-            test -f /opt/learning-app/learning-app.jar.tmp
-            mv -f /opt/learning-app/learning-app.jar.tmp /opt/learning-app/learning-app.jar
+            echo "${JAR_SHA256}  ${JAR_TMP}" | sha256sum -c -
+            mv -f "${JAR_TMP}" /opt/learning-app/learning-app.jar
+            find /opt/learning-app -maxdepth 1 -name 'learning-app.jar.*.tmp' -mmin +60 -delete

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -40,6 +40,9 @@ jobs:
       - run: clojure -T:build uber
       # Unique per-run temp name: concurrent deploys never share an upload path.
       - run: cp target/learning-app.jar 'target/learning-app.jar.${{ github.run_id }}.tmp'
+      # $GITHUB_OUTPUT is a file GitHub provides per step; `key=value` lines
+      # appended to it become `steps.<id>.outputs.<key>` for later steps:
+      # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
       - id: jar
         run: echo "sha256=$(sha256sum target/learning-app.jar | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
 

--- a/openspec/changes/archive/2026-08-05-atomic-artifact-swap/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-05-atomic-artifact-swap/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-with-adr
+created: 2026-08-05

--- a/openspec/changes/archive/2026-08-05-atomic-artifact-swap/proposal.md
+++ b/openspec/changes/archive/2026-08-05-atomic-artifact-swap/proposal.md
@@ -1,0 +1,15 @@
+# Atomic artifact swap on deploy
+
+## Why
+
+The app deploy already writes aside and renames: scp-action lands `learning-app.jar.tmp` in `/opt/learning-app/`, then an ssh step `mv -f`s it over `learning-app.jar` — rename(2) on the same filesystem — and `learning-app-restart.path` (PathChanged on the live jar) restarts the service. Two torn-jar paths remain. The temp name is fixed and shared, so a second concurrent `workflow_dispatch` run uploads into the same `learning-app.jar.tmp` while the first run's `mv` grabs it half-written — the rename is atomic, but it atomically installs a torn jar and triggers the restart watch. And nothing checks the upload survived the tar-over-ssh transfer intact before the swap: `test -f` passes on a truncated file.
+
+## What changes
+
+- The upload path becomes per-run unique: `learning-app.jar.${{ github.run_id }}.tmp`, still inside `/opt/learning-app` so the rename never crosses a filesystem.
+- The build records the jar's sha256; the server-side step verifies it against the uploaded temp file and aborts before the swap on any mismatch or missing file (subsumes `test -f`).
+- After a successful swap, per-run temp files older than an hour are deleted, so aborted deploys do not accumulate uber jars in `/opt/learning-app`.
+
+## Impact
+
+Added capability: `deploy-pipeline`. Files: `.github/workflows/deploy-app.yml`. Server infra untouched; the restart mechanism (`learning-app-restart.path`) is unchanged. Proof of the full path is the next real deploy.

--- a/openspec/changes/archive/2026-08-05-atomic-artifact-swap/specs/deploy-pipeline/spec.md
+++ b/openspec/changes/archive/2026-08-05-atomic-artifact-swap/specs/deploy-pipeline/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Live app jar is replaced only by verified atomic rename
+The deploy pipeline SHALL write the new jar to a temporary path on the same filesystem as `/opt/learning-app/learning-app.jar`, verify the upload's integrity against a checksum recorded at build time, and install it with a single rename. The live jar SHALL never be written in place, and no torn artifact SHALL ever become the live jar.
+
+#### Scenario: Successful deploy
+- **WHEN** the uploaded temp jar's sha256 matches the build's recorded checksum
+- **THEN** the jar is installed via `mv -f` (rename(2), same filesystem) over the live path
+- **AND** the restart watch on the live jar observes only the completed artifact
+
+#### Scenario: Upload is torn or missing
+- **WHEN** the temp jar is absent or its sha256 does not match the recorded checksum
+- **THEN** the deploy fails before the rename
+- **AND** the live jar and running service are untouched
+
+#### Scenario: Two deploys run concurrently
+- **WHEN** two workflow runs upload at the same time
+- **THEN** each run uses its own run-id-suffixed temp path
+- **AND** neither run can rename the other's partial upload into place
+
+### Requirement: Aborted deploys do not accumulate artifacts
+The deploy pipeline SHALL remove leftover temp jars in `/opt/learning-app` after a successful swap, without touching uploads recent enough to belong to an in-flight run.
+
+#### Scenario: A previous run died between upload and swap
+- **WHEN** a later deploy succeeds and a stale temp jar older than one hour exists
+- **THEN** the stale temp jar is deleted
+- **AND** temp jars younger than one hour are left alone

--- a/openspec/changes/archive/2026-08-05-atomic-artifact-swap/tasks.md
+++ b/openspec/changes/archive/2026-08-05-atomic-artifact-swap/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+- [x] 1. Per-run unique temp upload path inside /opt/learning-app
+- [x] 2. sha256 recorded at build, verified on the server before the rename
+- [x] 3. Stale temp cleanup after a successful swap
+- [x] 4. Validate workflow YAML; dry-run the server-side script against a simulated /opt/learning-app (happy path, torn upload, missing upload)
+- [ ] 5. Watch the next real deploy: checksum line `OK` in the ssh step, service restarts once on a whole jar

--- a/openspec/specs/deploy-pipeline/spec.md
+++ b/openspec/specs/deploy-pipeline/spec.md
@@ -1,0 +1,31 @@
+# deploy-pipeline Specification
+
+## Purpose
+TBD - created by archiving change atomic-artifact-swap. Update Purpose after archive.
+## Requirements
+### Requirement: Live app jar is replaced only by verified atomic rename
+The deploy pipeline SHALL write the new jar to a temporary path on the same filesystem as `/opt/learning-app/learning-app.jar`, verify the upload's integrity against a checksum recorded at build time, and install it with a single rename. The live jar SHALL never be written in place, and no torn artifact SHALL ever become the live jar.
+
+#### Scenario: Successful deploy
+- **WHEN** the uploaded temp jar's sha256 matches the build's recorded checksum
+- **THEN** the jar is installed via `mv -f` (rename(2), same filesystem) over the live path
+- **AND** the restart watch on the live jar observes only the completed artifact
+
+#### Scenario: Upload is torn or missing
+- **WHEN** the temp jar is absent or its sha256 does not match the recorded checksum
+- **THEN** the deploy fails before the rename
+- **AND** the live jar and running service are untouched
+
+#### Scenario: Two deploys run concurrently
+- **WHEN** two workflow runs upload at the same time
+- **THEN** each run uses its own run-id-suffixed temp path
+- **AND** neither run can rename the other's partial upload into place
+
+### Requirement: Aborted deploys do not accumulate artifacts
+The deploy pipeline SHALL remove leftover temp jars in `/opt/learning-app` after a successful swap, without touching uploads recent enough to belong to an in-flight run.
+
+#### Scenario: A previous run died between upload and swap
+- **WHEN** a later deploy succeeds and a stale temp jar older than one hour exists
+- **THEN** the stale temp jar is deleted
+- **AND** temp jars younger than one hour are left alone
+


### PR DESCRIPTION
Closes #189.

## How the jar lands in /opt/learning-app today (diagnosis)

`deploy-app.yml` (manual `workflow_dispatch`) builds the uberjar, copies it to `target/learning-app.jar.tmp`, and `appleboy/scp-action` (tar-over-ssh) extracts it as `/opt/learning-app/learning-app.jar.tmp`. A follow-up `appleboy/ssh-action` step runs `test -f` then `mv -f` over `/opt/learning-app/learning-app.jar`. On the server, `learning-app-restart.path` (`PathChanged=` on the live jar) fires `learning-app-restart.service`, which restarts `learning-app-run.service`. There is no in-place copy of the live jar: the write-aside + rename core has been in place since GH-64, and `mv` within `/opt/learning-app` is rename(2) on one filesystem.

Two torn-jar paths remained:

1. **Fixed shared temp name.** Two concurrent dispatch runs both write `/opt/learning-app/learning-app.jar.tmp`. Run A's `mv -f` can grab the file while run B is still uploading it — the rename is atomic, but it atomically installs a torn jar, `PathChanged` fires, and the service restarts on it. `Restart=always` then crash-loops.
2. **No integrity gate.** `test -f` passes on a truncated upload; nothing proved the tar-over-ssh transfer delivered the artifact whole before it got swapped in.

## Change

- Upload path is per-run unique: `learning-app.jar.${{ github.run_id }}.tmp`, still inside `/opt/learning-app` so the rename never crosses filesystems.
- Build records the jar's sha256; the server-side step verifies it against the uploaded temp file (`sha256sum -c`) and aborts before the swap on mismatch or missing file (subsumes `test -f`).
- After a successful swap, leftover `learning-app.jar.*.tmp` older than an hour are deleted, so aborted runs do not accumulate uberjars.

Restart mechanism and everything else in the deploy untouched.

## Verification (honest scope)

- Workflow YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`).
- The server-side script was dry-run verbatim against a simulated `/opt/learning-app`: happy path verifies then renames then cleans a 2h-old stale temp; a torn upload fails `sha256sum -c` **before** the `mv` with the live jar untouched; a missing upload fails the step.
- **Not proven here: the real transfer path.** The proof is the next real deploy. Watch for: the ssh step printing `…learning-app.jar.<run_id>.tmp: OK` from `sha256sum -c`, exactly one service restart after the `mv`, app healthy on the new jar, and no `learning-app.jar.*.tmp` left in `/opt/learning-app` afterwards.

OpenSpec: capability `deploy-pipeline` added, change `2026-08-05-atomic-artifact-swap` archived in this commit (task 5 — watching the next real deploy — deliberately left open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
