### PR TITLE
GH-188 Graceful shutdown of the backend on SIGTERM

### DIFF
--- a/openspec/changes/archive/2026-08-05-graceful-backend-shutdown/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-05-graceful-backend-shutdown/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-with-adr
+created: 2026-08-05

--- a/openspec/changes/archive/2026-08-05-graceful-backend-shutdown/proposal.md
+++ b/openspec/changes/archive/2026-08-05-graceful-backend-shutdown/proposal.md
@@ -1,0 +1,15 @@
+# Graceful shutdown of the backend
+
+## Why
+
+systemd stop sends SIGTERM and the JVM dies mid-request: the listening socket vanishes without draining, in-flight responses are cut, and whatever SQLite connection a request held is severed instead of closed. Nothing in the process knew shutdown existed.
+
+## What changes
+
+- A JVM shutdown hook stops the http-kit server via `server-stop!` with a drain timeout: the listening socket closes first, in-flight requests get up to 5 s to finish. Draining is also what closes SQLite — connections are per-request (`with-open` in `on-connection`), so the last response closes the last one.
+- The hook is registered once per JVM (`defonce`), so the dev reload path cannot register a duplicate; `restart-server!` now delegates to `stop-server!`, which owns the drain timeout.
+- A test proves the drain: an in-flight request finishes with 200 while `stop-server!` runs, the socket refuses afterwards, the handle is released.
+
+## Impact
+
+New capability: `backend-operations`. Files: `src/backend/core.clj`, `test/backend/core_test.clj`.

--- a/openspec/changes/archive/2026-08-05-graceful-backend-shutdown/specs/backend-operations/spec.md
+++ b/openspec/changes/archive/2026-08-05-graceful-backend-shutdown/specs/backend-operations/spec.md
@@ -1,0 +1,24 @@
+# backend-operations
+
+## ADDED Requirements
+
+### Requirement: SIGTERM stops the backend gracefully
+On SIGTERM the backend SHALL stop accepting connections first, then let in-flight requests finish within a bounded drain timeout before the JVM exits. Per-request SQLite connections close as their requests complete — draining is the cleanup.
+
+#### Scenario: systemd stops the service
+
+- **WHEN** the process receives SIGTERM while requests are in flight
+- **THEN** the listening socket closes, the in-flight requests complete with their responses, and only then does the process exit
+
+#### Scenario: shutdown with nothing in flight
+
+- **WHEN** the process receives SIGTERM while idle
+- **THEN** it stops promptly and logs that the server stopped
+
+### Requirement: The shutdown hook is registered exactly once
+The JVM shutdown hook SHALL be registered once per process, surviving the dev namespace-reload path without duplication, and SHALL NOT interfere with `restart-server!` during development.
+
+#### Scenario: dev reload does not duplicate the hook
+
+- **WHEN** the backend namespace is reloaded or the server is restarted in development
+- **THEN** exactly one shutdown hook remains registered

--- a/openspec/changes/archive/2026-08-05-graceful-backend-shutdown/tasks.md
+++ b/openspec/changes/archive/2026-08-05-graceful-backend-shutdown/tasks.md
@@ -1,0 +1,6 @@
+# Tasks
+
+- [x] 1. Drain timeout in `stop-server!`; `restart-server!` delegates to it
+- [x] 2. `defonce`-guarded JVM shutdown hook calling `stop-server!`
+- [x] 3. Test: stopping the server drains an in-flight request, then the socket refuses
+- [x] 4. Live proof: SIGTERM on a free port logs "Server stopped", process exits, port closed

--- a/openspec/specs/backend-operations/spec.md
+++ b/openspec/specs/backend-operations/spec.md
@@ -1,0 +1,26 @@
+# backend-operations Specification
+
+## Purpose
+TBD - created by archiving change graceful-backend-shutdown. Update Purpose after archive.
+## Requirements
+### Requirement: SIGTERM stops the backend gracefully
+On SIGTERM the backend SHALL stop accepting connections first, then let in-flight requests finish within a bounded drain timeout before the JVM exits. Per-request SQLite connections close as their requests complete — draining is the cleanup.
+
+#### Scenario: systemd stops the service
+
+- **WHEN** the process receives SIGTERM while requests are in flight
+- **THEN** the listening socket closes, the in-flight requests complete with their responses, and only then does the process exit
+
+#### Scenario: shutdown with nothing in flight
+
+- **WHEN** the process receives SIGTERM while idle
+- **THEN** it stops promptly and logs that the server stopped
+
+### Requirement: The shutdown hook is registered exactly once
+The JVM shutdown hook SHALL be registered once per process, surviving the dev namespace-reload path without duplication, and SHALL NOT interfere with `restart-server!` during development.
+
+#### Scenario: dev reload does not duplicate the hook
+
+- **WHEN** the backend namespace is reloaded or the server is restarted in development
+- **THEN** exactly one shutdown hook remains registered
+

--- a/src/backend/core.clj
+++ b/src/backend/core.clj
@@ -496,24 +496,44 @@
   (reset! server (server/run-server app {:port port :legacy-return-value? false})))
 
 
-#_{:clojure-lsp/ignore [:clojure-lsp/unused-public-var]}
+(def ^:private drain-timeout-ms
+  "How long a stopping server keeps serving in-flight requests after the
+   listening socket has closed."
+  5000)
 
 
 (defn stop-server!
   []
-  (when (some? @server)
-    (when-let [stopping-promise (server/server-stop! @server)]
-      @stopping-promise
+  (when-some [running @server]
+    (when-some [stopping (server/server-stop! running {:timeout drain-timeout-ms})]
+      @stopping
       (reset! server nil))))
+
+
+#_{:clj-kondo/ignore [:unused-private-var]}
+
+
+(defonce ^:private shutdown-hook
+  ;; systemd stop is SIGTERM; without this hook the JVM dies mid-request.
+  ;; Stopping the server closes the listening socket first, then drains
+  ;; in-flight requests — and draining is all the cleanup there is: SQLite
+  ;; connections are per-request (`with-open` in `on-connection`), so the last
+  ;; response closes the last one. `defonce` keeps the dev reload path from
+  ;; registering a second hook; the hook itself only ever runs at JVM
+  ;; shutdown, so it cannot fight `restart-server!`.
+  (let [hook (Thread. ^Runnable
+                      (fn []
+                        (stop-server!)
+                        (println "Server stopped"))
+                      "graceful-shutdown")]
+    (.addShutdownHook (Runtime/getRuntime) hook)
+    hook))
 
 
 (defn restart-server!
   [app port]
-  (if @server
-    (when-some [stopping-promise (server/server-stop! @server)]
-      @stopping-promise
-      (start-server! app port))
-    (start-server! app port)))
+  (stop-server!)
+  (start-server! app port))
 
 
 (defn -main

--- a/test/backend/core_test.clj
+++ b/test/backend/core_test.clj
@@ -5,7 +5,9 @@
    [core :as sut]
    [migrations :as migrations]
    [next.jdbc :as jdbc]
-   [next.jdbc.result-set :as result-set])
+   [next.jdbc.result-set :as result-set]
+   [org.httpkit.client :as client]
+   [org.httpkit.server :as server])
   (:import
    [java.io File]))
 
@@ -69,6 +71,30 @@
   (let [db    (migrated-db)
         token (sut/mint-grant! db -1)]
     (is (false? (#'sut/burn-grant! db token)))))
+
+
+(deftest stopping-the-server-drains-in-flight-requests
+  (let [in-flight (promise)
+        handler   (fn [_]
+                    (deliver in-flight true)
+                    (Thread/sleep 300)
+                    {:body "drained" :status 200})]
+    (sut/start-server! handler 0)
+    (try
+      (let [port     (server/server-port @sut/server)
+            response (future @(client/request {:method :get
+                                               :url    (str "http://localhost:" port "/")}))]
+        (is (true? (deref in-flight 2000 false)) "the request never reached the handler")
+        (sut/stop-server!)
+        (testing "the in-flight request finished with a response"
+          (is (= 200 (:status @response))))
+        (testing "the listening socket is closed"
+          (is (thrown? java.net.ConnectException
+                       (.close (java.net.Socket. "localhost" (int port))))))
+        (testing "the server handle is released"
+          (is (nil? @sut/server))))
+      (finally
+       (sut/stop-server!)))))
 
 
 (deftest the-build-and-the-server-agree-on-where-the-version-lives


### PR DESCRIPTION
Closes #188.

## Defect

systemd stop sends SIGTERM; the JVM died mid-request — listening socket vanished without draining, in-flight responses were cut, request-held SQLite connections severed.

## Mechanism

- `defonce`-guarded JVM shutdown hook calls `stop-server!` and logs "Server stopped". One hook per JVM: the dev reload path cannot register a duplicate, and the hook only runs at JVM shutdown, so it cannot fight `restart-server!`.
- `stop-server!` passes a 5 s drain timeout to http-kit `server-stop!`: socket closes first, in-flight requests finish. Draining is all the SQLite cleanup there is — connections are per-request (`with-open` in `on-connection`), stated in the hook comment.
- `restart-server!` delegates to `stop-server!` so both paths share the drain semantics.
- OpenSpec: new `backend-operations` capability, change archived as `2026-08-05-graceful-backend-shutdown`.

## Proven

- New test `stopping-the-server-drains-in-flight-requests`: request in flight when `stop-server!` runs completes with 200, socket refuses afterwards, handle released. Suite: 12 tests / 30 assertions, 0 failures (was 11/26 before this change).
- Live SIGTERM on free port 8199 (temp db in worktree, dev stand untouched): "Server stopped" logged, process exited, port closed, no stack traces.

## Not proven

- Behavior under systemd itself (unit `TimeoutStopSec` interplay, real production stop) — only a live SIGTERM on the stand can show that; the local proof used the same signal path but not systemd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)