### PR TITLE
GH-190 Harden systemd services

### DIFF
--- a/infra/production/etc/systemd/system/learning-app-backup-db.service
+++ b/infra/production/etc/systemd/system/learning-app-backup-db.service
@@ -17,5 +17,41 @@ Environment=BORG_PASSPHRASE_PATH=%d/borg-passphrase
 Environment=LEARNING_APP_DB_BACKUP_PATH=/var/backups/learning-app/db.sqlite
 
 # Security settings
+#
+# What this service actually needs: sqlite3 .backup of the app database into
+# /var/backups/learning-app, then borg over ssh to the remote repository.
+# Borg keeps its cache/config in the dbmaintainer home (/var/lib/dbmaintainer,
+# not under /home, so ProtectHome does not block it).
+#
+# No privilege gain on execve; nothing here elevates.
 NoNewPrivileges=yes
 PrivateTmp=yes
+ProtectHome=yes
+# Filesystem read-only except ReadWritePaths below. StateDirectory keeps
+# /var/lib/learning-app writable under strict — sqlite3 needs write access to
+# the source -wal/-shm files even when only reading a WAL database.
+ProtectSystem=strict
+# Local backup target plus borg cache/config/ssh state in the home directory.
+ReadWritePaths=/var/backups/learning-app /var/lib/dbmaintainer
+PrivateDevices=yes
+# Kernel interfaces read-only or unreachable.
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectControlGroups=yes
+ProtectClock=yes
+ProtectHostname=yes
+# No setuid/setgid files, namespaces, realtime, or personality changes.
+RestrictSUIDSGID=yes
+RestrictNamespaces=yes
+RestrictRealtime=yes
+LockPersonality=yes
+# ssh to the borg repository; AF_UNIX for journald and NSS lookups.
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+# Unprivileged user: zero capabilities needed.
+CapabilityBoundingSet=
+# Native-ABI syscalls only, filtered to the standard service set.
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+# MemoryDenyWriteExecute stays OFF: borg is Python with cffi — libffi closure
+# trampolines need writable+executable pages.

--- a/infra/production/etc/systemd/system/learning-app-certbot.service
+++ b/infra/production/etc/systemd/system/learning-app-certbot.service
@@ -4,3 +4,43 @@ Description=Renew Let's Encrypt certificates for Sprecha
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/certbot renew --quiet --deploy-hook "systemctl reload nginx"
+
+# Security settings
+#
+# What this service actually needs: root certbot doing ACME over HTTPS, the
+# nginx authenticator rewriting nginx config during the challenge, the deploy
+# hook installing certs into /etc/nginx/ssl (chown via install) and reloading
+# nginx over D-Bus. /var/{lib,log}/letsencrypt stay writable under "full".
+#
+# Already root; no setuid transitions involved.
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectHome=yes
+# "full" makes /usr, /boot and /etc read-only except ReadWritePaths below.
+# "strict" deliberately not used: certbot's full write surface under /var and
+# /run is not enumerable with confidence.
+ProtectSystem=full
+# certbot owns /etc/letsencrypt; the nginx plugin edits config during the
+# http-01 challenge and the deploy hook writes /etc/nginx/ssl.
+ReadWritePaths=/etc/letsencrypt /etc/nginx
+# Kernel interfaces read-only or unreachable.
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectControlGroups=yes
+ProtectClock=yes
+ProtectHostname=yes
+# No setuid/setgid files, namespaces, realtime, or personality changes.
+RestrictSUIDSGID=yes
+RestrictNamespaces=yes
+RestrictRealtime=yes
+LockPersonality=yes
+# ACME over TCP; AF_UNIX for D-Bus (systemctl reload) and journald.
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+# Native-ABI syscalls only, filtered to the standard service set.
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+# CapabilityBoundingSet deliberately not narrowed: certbot and its deploy hook
+# chown/chmod cert files as root; the minimal capability set is unverified.
+# MemoryDenyWriteExecute stays OFF: certbot is Python with cffi (cryptography)
+# — libffi closure trampolines need writable+executable pages.

--- a/infra/production/etc/systemd/system/learning-app-dictionary-import.service
+++ b/infra/production/etc/systemd/system/learning-app-dictionary-import.service
@@ -18,9 +18,44 @@ Environment=COUCHDB_USER=admin
 Environment=COUCHDB_PASS_PATH=%d/couchdb_admin_password
 
 # Security settings
+#
+# What this service actually needs: JVM as user webapp, reads dump files from
+# the working directory (gunzip staging goes to private /tmp), pushes documents
+# to CouchDB on 127.0.0.1:5984, reads the decrypted credential from %d.
+#
+# No privilege gain on execve; nothing here elevates.
 NoNewPrivileges=yes
+# import.sh stages gunzipped dumps in /tmp; keep it private.
 PrivateTmp=yes
+# No /home access needed.
 ProtectHome=yes
+# Filesystem read-only except the drop directory below.
+ProtectSystem=strict
+# The deployer/webapp drop directory stays writable, matching its 2770 mode.
+ReadWritePaths=/var/lib/learning-app/dictionary
+# Only pseudo-devices; urandom/null suffice for the JVM.
+PrivateDevices=yes
+# Kernel interfaces read-only or unreachable.
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectControlGroups=yes
+ProtectClock=yes
+ProtectHostname=yes
+# No setuid/setgid files, namespaces, realtime, or personality changes.
+RestrictSUIDSGID=yes
+RestrictNamespaces=yes
+RestrictRealtime=yes
+LockPersonality=yes
+# TCP to CouchDB; AF_UNIX for journald and NSS lookups.
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+# Unprivileged user: zero capabilities needed.
+CapabilityBoundingSet=
+# Native-ABI syscalls only, filtered to the standard service set.
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+# MemoryDenyWriteExecute stays OFF: the HotSpot JIT maps writable+executable
+# pages for compiled code; enabling it kills the JVM at startup.
 
 [Install]
 WantedBy=multi-user.target

--- a/infra/production/etc/systemd/system/learning-app-restart.service
+++ b/infra/production/etc/systemd/system/learning-app-restart.service
@@ -4,3 +4,36 @@ Description=Learning App Restart
 [Service]
 Type=oneshot
 ExecStart=systemctl restart learning-app-run
+
+# Security settings
+#
+# What this service actually needs: one systemctl call to PID 1 over D-Bus.
+# Root uid passes the manage-units polkit check without any capabilities,
+# so this unit can be locked down almost completely.
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectHome=yes
+# Writes nothing anywhere.
+ProtectSystem=strict
+PrivateDevices=yes
+# Kernel interfaces read-only or unreachable.
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectControlGroups=yes
+ProtectClock=yes
+ProtectHostname=yes
+# No setuid/setgid files, namespaces, realtime, or personality changes.
+RestrictSUIDSGID=yes
+RestrictNamespaces=yes
+RestrictRealtime=yes
+LockPersonality=yes
+# systemctl is a plain C binary, no JIT — W^X can be enforced here.
+MemoryDenyWriteExecute=yes
+# D-Bus and journald only.
+RestrictAddressFamilies=AF_UNIX
+# uid 0 alone satisfies polkit; no capabilities needed.
+CapabilityBoundingSet=
+# Native-ABI syscalls only, filtered to the standard service set.
+SystemCallArchitectures=native
+SystemCallFilter=@system-service

--- a/infra/production/etc/systemd/system/learning-app-run.service
+++ b/infra/production/etc/systemd/system/learning-app-run.service
@@ -21,9 +21,50 @@ LoadCredentialEncrypted=db_auth_secret:/etc/credstore.encrypted/db_auth_secret
 Environment=LEARNING_APP_DB_AUTH_SECRET_PATH=%d/db_auth_secret
 
 # Security settings
+#
+# What this service actually needs: JVM as user webapp, listens on
+# localhost:8083, outbound HTTP to CouchDB 127.0.0.1:5984 and HTTPS to
+# OpenRouter, writes SQLite app.db (+ -wal/-shm) in the working directory,
+# reads decrypted credentials from %d. Everything else is locked down.
+# Note: systemd comments must be full lines; inline comments break parsing.
+#
+# No privilege gain on execve; nothing here elevates.
 NoNewPrivileges=yes
+# Own /tmp, invisible to and from other services.
 PrivateTmp=yes
+# No business in /home or /root.
 ProtectHome=yes
+# Whole filesystem read-only except ReadWritePaths below. StateDirectory and
+# LogsDirectory (/var/lib/learning-app, /var/log/learning-app) stay writable
+# under strict automatically.
+ProtectSystem=strict
+# SQLite app.db lives in the working directory.
+ReadWritePaths=/opt/learning-app
+# Only pseudo-devices; the JVM needs urandom/null, both provided.
+PrivateDevices=yes
+# /proc/sys and /sys read-only; no module loading; no kernel ring buffer;
+# cgroup hierarchy read-only; no clock or hostname changes.
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectControlGroups=yes
+ProtectClock=yes
+ProtectHostname=yes
+# No setuid/setgid file creation, no new namespaces, no realtime scheduling,
+# personality(2) locked.
+RestrictSUIDSGID=yes
+RestrictNamespaces=yes
+RestrictRealtime=yes
+LockPersonality=yes
+# TCP for HTTP/CouchDB/OpenRouter; AF_UNIX for journald and NSS lookups.
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+# Unprivileged user on a port >1024: zero capabilities needed.
+CapabilityBoundingSet=
+# Native-ABI syscalls only, filtered to the standard service set.
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+# MemoryDenyWriteExecute stays OFF: the HotSpot JIT maps writable+executable
+# pages for compiled code; enabling it kills the JVM at startup.
 
 [Install]
 WantedBy=multi-user.target

--- a/openspec/changes/archive/2026-08-05-harden-systemd-services/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-05-harden-systemd-services/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-with-adr
+created: 2026-08-05

--- a/openspec/changes/archive/2026-08-05-harden-systemd-services/proposal.md
+++ b/openspec/changes/archive/2026-08-05-harden-systemd-services/proposal.md
@@ -1,0 +1,16 @@
+# Learning-app systemd services run sandboxed
+
+## Why
+
+The production units carried only NoNewPrivileges/PrivateTmp/ProtectHome (some not even that). A compromised JVM, borg, or certbot process could write anywhere its user could, load kernel-adjacent interfaces, create namespaces, and use any syscall or address family. systemd ships the sandbox; the units just did not ask for it. GH-190.
+
+## What changes
+
+- All four `[Service]` units under `infra/production/etc/systemd/system/` gain a hardening block: ProtectSystem=strict/full with ReadWritePaths for exactly what each service writes, PrivateDevices, kernel-interface protections, RestrictSUIDSGID, RestrictNamespaces, RestrictRealtime, LockPersonality, RestrictAddressFamilies, CapabilityBoundingSet= where the service needs none, SystemCallArchitectures=native, SystemCallFilter=@system-service.
+- MemoryDenyWriteExecute stays off for JVM units (HotSpot JIT) and Python units (libffi closures); it is on only for learning-app-restart (plain systemctl).
+- Directives whose survival against the real workload is unverifiable from code alone are left out and listed in the PR, not guessed at.
+- Timers and the .path unit have no `[Service]` section; nothing to harden there.
+
+## Impact
+
+New spec: `production-service-hardening`. Files: `learning-app-run.service`, `learning-app-backup-db.service`, `learning-app-certbot.service`, `learning-app-restart.service`, `learning-app-dictionary-import.service`.

--- a/openspec/changes/archive/2026-08-05-harden-systemd-services/specs/production-service-hardening/spec.md
+++ b/openspec/changes/archive/2026-08-05-harden-systemd-services/specs/production-service-hardening/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Service units are sandboxed to their observed needs
+Every learning-app unit with a `[Service]` section SHALL declare a systemd hardening block that leaves writable only the paths the service demonstrably writes, reachable only the address families it demonstrably uses, and grants no capabilities beyond what its user and task require. Directives whose compatibility with the workload cannot be established SHALL be omitted and the omission recorded, never guessed at.
+
+#### Scenario: App service keeps serving
+- **WHEN** learning-app-run starts under the hardening block
+- **THEN** it binds its port, reaches CouchDB on localhost and OpenRouter over HTTPS, writes its SQLite files, and reads its decrypted credentials
+
+#### Scenario: JIT and FFI workloads survive
+- **WHEN** a unit runs a JVM or Python-with-cffi workload
+- **THEN** MemoryDenyWriteExecute is off for that unit, with the reason recorded in the unit file
+
+#### Scenario: Directives actually parse
+- **WHEN** `systemd-analyze verify` runs against the units
+- **THEN** no directive is ignored as unparseable — in particular, no inline comments on directive lines

--- a/openspec/changes/archive/2026-08-05-harden-systemd-services/tasks.md
+++ b/openspec/changes/archive/2026-08-05-harden-systemd-services/tasks.md
@@ -1,0 +1,10 @@
+# Tasks
+
+- [x] 1. Map each unit's real write paths, network needs, and privilege needs from unit files, admin-setup.sh, backup.sh, import.sh, and backend source
+- [x] 2. Hardening block in learning-app-run.service (JVM: MDWE off, /opt/learning-app writable for SQLite)
+- [x] 3. Hardening block in learning-app-dictionary-import.service
+- [x] 4. Hardening block in learning-app-backup-db.service (WAL source needs -shm/-wal write; borg home)
+- [x] 5. Hardening block in learning-app-certbot.service (ProtectSystem=full; caps left broad — root chown)
+- [x] 6. Hardening block in learning-app-restart.service (MDWE on; AF_UNIX only)
+- [x] 7. `systemd-analyze verify` on all units — caught that inline comments are not parsed by systemd; comments moved to full lines
+- [x] 8. Staged server verification documented in the PR (security score before/after, service start, request path, migrations) — cannot run here, no production systemd

--- a/openspec/specs/production-service-hardening/spec.md
+++ b/openspec/specs/production-service-hardening/spec.md
@@ -1,0 +1,20 @@
+# production-service-hardening Specification
+
+## Purpose
+TBD - created by archiving change harden-systemd-services. Update Purpose after archive.
+## Requirements
+### Requirement: Service units are sandboxed to their observed needs
+Every learning-app unit with a `[Service]` section SHALL declare a systemd hardening block that leaves writable only the paths the service demonstrably writes, reachable only the address families it demonstrably uses, and grants no capabilities beyond what its user and task require. Directives whose compatibility with the workload cannot be established SHALL be omitted and the omission recorded, never guessed at.
+
+#### Scenario: App service keeps serving
+- **WHEN** learning-app-run starts under the hardening block
+- **THEN** it binds its port, reaches CouchDB on localhost and OpenRouter over HTTPS, writes its SQLite files, and reads its decrypted credentials
+
+#### Scenario: JIT and FFI workloads survive
+- **WHEN** a unit runs a JVM or Python-with-cffi workload
+- **THEN** MemoryDenyWriteExecute is off for that unit, with the reason recorded in the unit file
+
+#### Scenario: Directives actually parse
+- **WHEN** `systemd-analyze verify` runs against the units
+- **THEN** no directive is ignored as unparseable — in particular, no inline comments on directive lines
+


### PR DESCRIPTION
Closes #190.

## What

All four `[Service]` units under `infra/production/etc/systemd/system/` get a sandbox block sized to what each service was observed (in unit files, `admin-setup.sh`, `backup.sh`, `import.sh`, and backend source) to actually need. Timers and the `.path` unit have no `[Service]` section — nothing to harden there.

## Applied

| Directive | run | dictionary-import | backup-db | certbot | restart |
|---|---|---|---|---|---|
| NoNewPrivileges | ✓ (was) | ✓ (was) | ✓ (was) | ✓ | ✓ |
| PrivateTmp | ✓ (was) | ✓ (was) | ✓ (was) | ✓ | ✓ |
| ProtectHome | ✓ (was) | ✓ (was) | ✓ | ✓ | ✓ |
| ProtectSystem | strict | strict | strict | full | strict |
| ReadWritePaths | /opt/learning-app (SQLite app.db in cwd) | /var/lib/learning-app/dictionary | /var/backups/learning-app, /var/lib/dbmaintainer (borg home) | /etc/letsencrypt, /etc/nginx | — |
| PrivateDevices | ✓ | ✓ | ✓ | — | ✓ |
| ProtectKernelTunables/Modules/Logs, ProtectControlGroups, ProtectClock, ProtectHostname | ✓ | ✓ | ✓ | ✓ | ✓ |
| RestrictSUIDSGID, RestrictNamespaces, RestrictRealtime, LockPersonality | ✓ | ✓ | ✓ | ✓ | ✓ |
| RestrictAddressFamilies | INET INET6 UNIX | INET INET6 UNIX | INET INET6 UNIX (ssh to borg repo) | INET INET6 UNIX (ACME + D-Bus) | UNIX only |
| CapabilityBoundingSet= (empty) | ✓ | ✓ | ✓ | — | ✓ |
| SystemCallArchitectures=native, SystemCallFilter=@system-service | ✓ | ✓ | ✓ | ✓ | ✓ |
| MemoryDenyWriteExecute | off | off | off | off | **on** |

StateDirectory/LogsDirectory stay writable under `ProtectSystem=strict` automatically; that covers `/var/lib/learning-app` (including the `-wal`/`-shm` write access sqlite3 needs even for a read-only `.backup` of a WAL database).

## Not applied, reason

- **MemoryDenyWriteExecute** on run/dictionary-import: HotSpot JIT maps writable+executable pages — enabling it kills the JVM. On backup-db/certbot: Python with cffi; libffi closure trampolines need W+X. Only `learning-app-restart` (plain `systemctl`) enforces it.
- **CapabilityBoundingSet** narrowing on certbot: the renewer and deploy hook chown/chmod cert files as root; the minimal capability set is unverified against a real renewal, so caps stay broad rather than guessed.
- **ProtectSystem=strict** on certbot: certbot's full write surface under `/var` and `/run` is not enumerable from code with confidence; `full` + explicit `/etc` holes is the honest bound.
- **ProtectProc/ProcSubset**: JVM container/cgroup detection reads non-pid `/proc` entries; survival unverified, left out.
- **PrivateUsers, PrivateNetwork, IPAddress{Allow,Deny}, UMask tightening**: either break declared needs (network, group-writable drop dirs) or are unverifiable here; left out.

## Verification

**Done here (WSL, systemd 255):** `systemd-analyze verify` over all eight units — passes; the only diagnostic is `/usr/bin/certbot is not executable`, an artifact of certbot not being installed in the dev environment. Verify also caught a real bug in the first draft: systemd ignores inline comments on directive lines silently — every directive would have been dropped. All comments are full lines now. The infra-checks deb build proves packaging only, not unit semantics.

**Not possible here, staged for the server (in this order):**
1. `systemd-analyze security learning-app-run` — record the exposure score **before** deploying, then after; expect a drop from ~9.6 ("UNSAFE") territory to ~4 or below.
2. Deploy, `systemctl daemon-reload`, `systemctl restart learning-app-run`, `systemctl status` clean, journal free of seccomp/EPERM kills.
3. Full request path: `curl -f https://sprecha.de/` and `curl -f https://sprecha.de/auth/check` (exercises SQLite write, CouchDB proxy-auth signing, credential reads).
4. Migration run: restart performs startup migrations against `app.db` — confirm in journal that they complete under `ProtectSystem=strict`.
5. `systemctl start learning-app-backup-db` once, check borg reaches the repo over ssh and `/var/backups/learning-app/db.sqlite` passes `.selftest`.
6. `certbot renew --dry-run` inside the unit (`systemd-run --unit=... -p ...` or a timer dry-run) before the real 03:30 window.

If any service trips seccomp or a read-only path, the journal names the syscall/path; loosen that single directive rather than reverting the block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)