### PR TITLE
GH-202 Depends-on lines become a merge gate

### DIFF
--- a/.github/workflows/depends-on.yml
+++ b/.github/workflows/depends-on.yml
@@ -1,0 +1,80 @@
+# Turns `Depends-on: #N` lines in a PR body into a merge gate: the check fails
+# while any referenced issue or PR is open, and branch protection does the
+# enforcing. The companion job re-runs the check on open dependents after a
+# push to master, so they go green without a manual poke. One blind spot: an
+# issue closed *without* a push (by hand) leaves dependents red until the next
+# event — re-run manually via workflow_dispatch.
+name: Depends-on
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    # This job name is the required-check context in branch protection.
+    name: Depends-on
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: read
+      pull-requests: read
+    env:
+      # The body is attacker-controlled on a public repo: it enters through
+      # env, never through template interpolation into the script.
+      BODY: ${{ github.event.pull_request.body }}
+      REPO: ${{ github.repository }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Fail while any Depends-on reference is open
+        run: |
+          set -euo pipefail
+          refs=$(printf '%s' "$BODY" | tr -d '\r' | grep -iE '^depends-on:' | grep -oE '#[0-9]+' | tr -d '#' | sort -un) || true
+          if [ -z "${refs:-}" ]; then
+            echo "No Depends-on references — nothing gates this PR."
+            exit 0
+          fi
+          failed=0
+          for n in $refs; do
+            if ! state=$(gh api "repos/$REPO/issues/$n" --jq .state 2>/dev/null); then
+              echo "::error::Depends-on #$n does not exist — typo?"
+              failed=1
+            elif [ "$state" = "open" ]; then
+              echo "::error::Blocked by #$n — still open."
+              failed=1
+            else
+              echo "#$n is $state — satisfied."
+            fi
+          done
+          exit "$failed"
+
+  rerun-dependents:
+    name: Re-run dependents after merge
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      pull-requests: read
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+    steps:
+      - name: Re-run the check on open PRs that declare dependencies
+        run: |
+          set -euo pipefail
+          gh pr list -R "$REPO" --state open --json body,headRefName \
+            --jq '.[] | select(.body | test("(?i)^depends-on:"; "m")) | .headRefName' |
+          while read -r branch; do
+            id=$(gh run list -R "$REPO" -w "Depends-on" -b "$branch" -L 1 --json databaseId --jq '.[0].databaseId // empty')
+            if [ -n "$id" ]; then
+              gh run rerun "$id" -R "$REPO" && echo "re-ran $branch (run $id)"
+            else
+              echo "no prior run for $branch — the check fires on its next PR event"
+            fi
+          done

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,7 +12,7 @@ on:
       - 'deps.edn'
       - 'package.json'
       - 'package-lock.json'
-      - '.github/workflows/integration.yml'
+      - '.github/workflows/**'
   push:
     branches: [master]
     paths:
@@ -25,7 +25,7 @@ on:
       - 'deps.edn'
       - 'package.json'
       - 'package-lock.json'
-      - '.github/workflows/integration.yml'
+      - '.github/workflows/**'
 
 concurrency:
   group: integration-${{ github.workflow }}-${{ github.ref }}

--- a/openspec/changes/archive/2026-08-05-depends-on-merge-gate/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-05-depends-on-merge-gate/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-with-adr
+created: 2026-08-05

--- a/openspec/changes/archive/2026-08-05-depends-on-merge-gate/proposal.md
+++ b/openspec/changes/archive/2026-08-05-depends-on-merge-gate/proposal.md
@@ -1,0 +1,13 @@
+# Merge order enforced by a required check
+
+## Why
+
+Merge order between PRs was held by drafts and comments — a request, not a wall. #196 sat one click from a production identity outage while its ordering lived in a Hold comment.
+
+## What changes
+
+A `Depends-on: #N` line in a PR body becomes a merge gate: a required check fails while any referenced node is open, and branch protection disables the button. A companion job re-runs the check on dependents after each push to master. The same line is the PR-level edge of the issue DAG.
+
+## Impact
+
+New workflow `depends-on.yml`; `integration.yml` paths widened to `.github/workflows/**` so workflow-touching PRs keep reporting the required Client Tests. Rollout: merge first, then add the context to branch protection, then retrofit #196.

--- a/openspec/changes/archive/2026-08-05-depends-on-merge-gate/specs/repo-delivery-workflow/spec.md
+++ b/openspec/changes/archive/2026-08-05-depends-on-merge-gate/specs/repo-delivery-workflow/spec.md
@@ -1,0 +1,12 @@
+## ADDED Requirements
+
+### Requirement: Merge order is machine-enforced
+A PR declaring `Depends-on: #N` SHALL NOT be mergeable while any referenced issue or pull request is open; the enforcement SHALL come from branch protection, not from convention. A missing reference SHALL fail the same way, so a typo cannot silently unlock a merge.
+
+#### Scenario: The blocker is open
+- **WHEN** a PR body contains `Depends-on: #N` and node N is open
+- **THEN** the required check fails and the merge button is disabled
+
+#### Scenario: The blocker lands
+- **WHEN** a push to master closes node N
+- **THEN** the dependent's check is re-run automatically and turns green

--- a/openspec/changes/archive/2026-08-05-depends-on-merge-gate/tasks.md
+++ b/openspec/changes/archive/2026-08-05-depends-on-merge-gate/tasks.md
@@ -1,0 +1,6 @@
+# Tasks
+
+- [x] 1. Check job: parse Depends-on refs, fail on open or missing nodes
+- [x] 2. Companion job: re-run dependents after a push to master
+- [x] 3. Parser proven against live issues (open → red, closed → ok, missing → red, none → green)
+- [ ] 4. Post-merge: add "Depends-on" to required contexts, probe-PR verification, retrofit #196 and drop its draft

--- a/openspec/specs/repo-delivery-workflow/spec.md
+++ b/openspec/specs/repo-delivery-workflow/spec.md
@@ -64,3 +64,14 @@ Closeout SHALL include deleting the delivered branch locally and on the remote, 
 - **WHEN** the pull request for tracked work is merged
 - **THEN** the branch is gone from both sides and no worktree is left behind for it
 
+### Requirement: Merge order is machine-enforced
+A PR declaring `Depends-on: #N` SHALL NOT be mergeable while any referenced issue or pull request is open; the enforcement SHALL come from branch protection, not from convention. A missing reference SHALL fail the same way, so a typo cannot silently unlock a merge.
+
+#### Scenario: The blocker is open
+- **WHEN** a PR body contains `Depends-on: #N` and node N is open
+- **THEN** the required check fails and the merge button is disabled
+
+#### Scenario: The blocker lands
+- **WHEN** a push to master closes node N
+- **THEN** the dependent's check is re-run automatically and turns green
+


### PR DESCRIPTION
Closes #202.

`Depends-on: #N` in a PR body now gates the merge: the check fails while any referenced node is open — or does not exist, so a typo cannot unlock anything. A companion job re-runs open dependents after each push to master; the one blind spot (an issue closed by hand, no push) is documented in the workflow and covered by `workflow_dispatch`.

The PR body enters the script through env, never template interpolation — safe on a public repo, fork PRs run with a read-only token.

Also here: `integration.yml` paths widen to `.github/workflows/**` — the old filter listed only itself, so this very PR would have hung on the required-but-never-reporting Client Tests. The broader form of that trap (docs-only PRs vs required path-filtered checks) is filed separately.

Verified locally against live issues: no refs → green; #201 (open) → red; #168 (closed) → ok; #99999 (missing) → red.

## Rollout after merge, in order

1. Add context "Depends-on" to required status checks.
2. Probe: fire the check on an open PR, watch the button die.
3. Retrofit `Depends-on: #201` onto #196 and drop its draft — the wall holds by itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)