### PR TITLE
GH-205 orphan-userdb reconciliation report

### DIFF
--- a/lib/db/src/db.cljc
+++ b/lib/db/src/db.cljc
@@ -183,6 +183,20 @@
 
 
 #?(:clj
+   (defn all-dbs
+     "Returns the names of all databases on the server.
+
+      https://docs.couchdb.org/en/stable/api/server/common.html#all-dbs"
+     ([]
+      (all-dbs conn))
+     ([conn]
+      (let [response (request-sync conn {:method :get :url "_all_dbs"})]
+        (if (= (:status response) 200)
+          (:body response)
+          (raise "Could not list databases" (:body response)))))))
+
+
+#?(:clj
    (defn create
      ([dbname]
       (create conn dbname))
@@ -333,13 +347,13 @@
   ([db docname]
    (get db docname {}))
   ([db docname params]
-   #?(:clj  (p/catch
-               (with-couch-op :couch/get
-                 (request (db-conn db)
-                          {:method :get :url (str (:name db) "/" docname) :query-params (clj->couch params)}))
-               (fn [error]
-                 (when-not (not-found? error)
-                   (throw error))))
+   #?(:clj (p/catch
+             (with-couch-op :couch/get
+               (request (db-conn db)
+                        {:method :get :url (str (:name db) "/" docname) :query-params (clj->couch params)}))
+             (fn [error]
+               (when-not (not-found? error)
+                 (throw error))))
       :cljs (-> (with-couch-op :couch/get
                   (.get ^js db docname (clj->couch params)))
                 (.catch (fn [error]
@@ -387,13 +401,13 @@
    - `execution-stats` (*object*) – Execution statistics.
    - `bookmark` (*string*) – An opaque string used for paging. See the bookmark field in the request (above) for usage details."
   [db query]
-  #?(:clj  (p/catch
-              (with-couch-op :couch/find
-                (request (db-conn db)
-                         {:method :get :url (str (:name db) "/_find") :body (clj->couch query)}))
-              (fn [error]
-                (when-not (not-found? error)
-                  (throw error))))
+  #?(:clj (p/catch
+            (with-couch-op :couch/find
+              (request (db-conn db)
+                       {:method :get :url (str (:name db) "/_find") :body (clj->couch query)}))
+            (fn [error]
+              (when-not (not-found? error)
+                (throw error))))
      :cljs (-> (with-couch-op :couch/find
                  (.find ^js db (clj->couch query)))
                (.catch (fn [error]
@@ -412,10 +426,10 @@
    Any incoming `:limit`/`:skip` in `query` is ignored."
   ([db query]
    (let [base-query (dissoc query :limit :skip)]
-     #?(:clj  (p/let [{:keys [doc-count]} (info db)]
-                 (if (zero? doc-count)
-                   {:docs []}
-                   (find db (assoc base-query :limit doc-count))))
+     #?(:clj (p/let [{:keys [doc-count]} (info db)]
+               (if (zero? doc-count)
+                 {:docs []}
+                 (find db (assoc base-query :limit doc-count))))
         :cljs ((fn ^:async f []
                  (let [{:keys [doc-count]} (await (info db))]
                    (if (zero? doc-count)

--- a/openspec/changes/archive/2026-08-06-orphan-userdb-report/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-06-orphan-userdb-report/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-with-adr
+created: 2026-08-06

--- a/openspec/changes/archive/2026-08-06-orphan-userdb-report/proposal.md
+++ b/openspec/changes/archive/2026-08-06-orphan-userdb-report/proposal.md
@@ -1,0 +1,15 @@
+# Reconciliation report: orphan userdbs
+
+## Why
+
+The per-provision guard (#197) catches a recycled id at the moment of harm, but nothing checks the two stores against each other: every `userdb-N` in CouchDB should have a matching `users` row in SQLite. Orphans accumulate silently — leftovers of deleted accounts, or evidence of an `app.db` reset.
+
+## What changes
+
+A reconciliation **report**, not an auto-repair: enumerate CouchDB databases, keep the `userdb-N` names, diff `N` against `SELECT id FROM users`, log the orphans at startup and expose the same function to the REPL operator. CouchDB being down logs a warning and never blocks boot.
+
+Auto-tombstoning is forbidden by design: SQLite restored from an older backup makes every account created after that backup a live, legitimate userdb with no row — auto-deleting at that moment destroys real user data exactly when the system is most fragile. The same applies to a half-finished #201 migration. Orphans are evidence; disposal is a human decision. The opposite direction — rows without userdbs — is a different signal and out of scope.
+
+## Impact
+
+New `reconciliation` namespace, `db/all-dbs` in lib/db, one call in `-main`, four tests. No HTTP surface — the operator story is the REPL, like `mint-grant!`.

--- a/openspec/changes/archive/2026-08-06-orphan-userdb-report/specs/identity-provisioning/spec.md
+++ b/openspec/changes/archive/2026-08-06-orphan-userdb-report/specs/identity-provisioning/spec.md
@@ -1,18 +1,4 @@
-# identity-provisioning Specification
-
-## Purpose
-TBD - created by archiving change recycled-id-guard. Update Purpose after archive.
-## Requirements
-### Requirement: A recycled account id never inherits an existing userdb
-Provisioning SHALL refuse to create an account whose derived userdb already exists in CouchDB, leaving the user row unwritten and the stale userdb untouched. The refusal SHALL be observable to the operator.
-
-#### Scenario: Stale userdb from a previous owner
-- **WHEN** provisioning would assign an id whose `userdb-<id>` already exists
-- **THEN** the request fails with 503, no user row is created, and the event is logged
-
-#### Scenario: Clean id
-- **WHEN** no userdb exists for the assigned id
-- **THEN** the account is created and its userdb is secured with the account's role
+## ADDED Requirements
 
 ### Requirement: Orphan userdbs are reported, never auto-deleted
 The system SHALL report every CouchDB `userdb-N` whose account row `N` is missing from SQLite — at startup and on operator demand — and SHALL NOT delete or tombstone any userdb on its own. A restored-from-older-backup SQLite makes such userdbs live and legitimate, so disposal stays a human decision. Account rows without a userdb are a different signal and are not part of this report.
@@ -28,4 +14,3 @@ The system SHALL report every CouchDB `userdb-N` whose account row `N` is missin
 #### Scenario: CouchDB unreachable at startup
 - **WHEN** the startup report cannot enumerate CouchDB databases
 - **THEN** a warning is logged and boot continues
-

--- a/openspec/changes/archive/2026-08-06-orphan-userdb-report/tasks.md
+++ b/openspec/changes/archive/2026-08-06-orphan-userdb-report/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+- [x] 1. `db/all-dbs` in lib/db (GET /_all_dbs, admin conn)
+- [x] 2. `reconciliation/orphan-userdbs` — diff userdb names against users ids; `reconciliation/report!` — log, non-fatal on CouchDB down
+- [x] 3. Startup hook in `-main` after migrations
+- [x] 4. Tests: orphan named exactly; matched stores → empty; rows without dbs not reported; CouchDB down → nil, no throw
+- [ ] 5. Live proof on the stand: staged orphan userdb appears in the startup log and in the REPL report, nothing else does

--- a/src/backend/core.clj
+++ b/src/backend/core.clj
@@ -13,6 +13,7 @@
    [next.jdbc.prepare :as prepare]
    [next.jdbc.result-set :as result-set]
    [org.httpkit.server :as server]
+   [reconciliation :as reconciliation]
    [reitit.http :as http]
    [reitit.http.interceptors.keyword-parameters :as keyword-parameters]
    [reitit.http.interceptors.parameters :as parameters]
@@ -560,6 +561,8 @@
   (let [url (str "http://localhost:" port "/")]
     ;; Migrate before serving: the app never runs against an outdated schema.
     (migrations/ensure-migrated! db-spec)
+    ;; Report orphan userdbs; CouchDB being down logs a warning, never blocks boot.
+    (reconciliation/report! db-spec)
     (restart-server! #'ring-handler port)
     (println "Serving" url)))
 

--- a/src/backend/reconciliation.clj
+++ b/src/backend/reconciliation.clj
@@ -1,0 +1,57 @@
+(ns reconciliation
+  (:require
+   [db :as db]
+   [next.jdbc :as jdbc]
+   [next.jdbc.result-set :as result-set]
+   [taoensso.telemere :as t]))
+
+
+(set! *warn-on-reflection* true)
+
+
+(defn- userdb-account-id
+  "The account id a `userdb-N` name derives from, or nil for any other database."
+  [dbname]
+  (some-> (re-matches #"userdb-(\d+)" dbname) second parse-long))
+
+
+(defn orphan-userdbs
+  "Userdbs in CouchDB whose account row is missing from SQLite:
+   [{:id 7 :dbname \"userdb-7\"} ...], sorted by id.
+
+   A report, not a repair (#205): an orphan can be leftovers of a deleted
+   account — or a live, legitimate userdb whose row vanished because SQLite
+   was restored from an older backup. Auto-tombstoning at that moment would
+   destroy real user data, so disposal stays a human decision. Account rows
+   without a userdb are a different signal and are not reported here."
+  [db]
+  (let [account-ids (into #{}
+                          (map :id)
+                          (jdbc/execute! db
+                            ["SELECT id FROM users"]
+                            {:builder-fn result-set/as-unqualified-maps}))]
+    (->> (db/all-dbs)
+         (keep (fn [dbname]
+                 (when-some [id (userdb-account-id dbname)]
+                   (when-not (contains? account-ids id)
+                     {:id id :dbname dbname}))))
+         (sort-by :id)
+         vec)))
+
+
+(defn report!
+  "Logs the orphan-userdb report and returns it — the REPL entry point for
+   the operator, and the startup hook in `-main`. CouchDB being down must
+   not block boot: failure to enumerate logs a warning and returns nil."
+  [db]
+  (try
+    (let [orphans (orphan-userdbs db)]
+      (t/event! ::orphan-userdbs
+                {:level (if (seq orphans) :warn :info)
+                 :data  {:orphans orphans}})
+      orphans)
+    (catch Exception e
+      (t/event! ::report-skipped
+                {:level :warn
+                 :data  {:error (ex-message e)}})
+      nil)))

--- a/test/backend/reconciliation_test.clj
+++ b/test/backend/reconciliation_test.clj
@@ -1,0 +1,60 @@
+(ns backend.reconciliation-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [db :as db]
+   [migrations :as migrations]
+   [next.jdbc :as jdbc]
+   [reconciliation :as sut])
+  (:import
+   [java.io File]))
+
+
+(set! *warn-on-reflection* true)
+
+
+(defn- migrated-db
+  []
+  (let [file (doto (File/createTempFile "reconciliation-test" ".db")
+               (.deleteOnExit))]
+    ;; SQLite wants to create the file itself.
+    (.delete file)
+    (doto {:dbtype "sqlite" :dbname (.getAbsolutePath file)}
+      (migrations/ensure-migrated!))))
+
+
+(defn- add-account!
+  [db id]
+  (jdbc/execute! db
+    ["INSERT INTO users (id, token_sha256) VALUES (?, ?)" id (str "sha-" id)]))
+
+
+(deftest an-orphan-userdb-is-named-and-nothing-else
+  (let [db (migrated-db)]
+    (add-account! db 1)
+    (with-redefs [db/all-dbs (constantly ["_replicator" "_users" "userdb-1" "userdb-7"])]
+      (testing "only the userdb without an account row is reported"
+        (is (= [{:id 7 :dbname "userdb-7"}]
+               (sut/orphan-userdbs db)))))))
+
+
+(deftest matched-stores-yield-an-empty-report
+  (let [db (migrated-db)]
+    (add-account! db 1)
+    (with-redefs [db/all-dbs (constantly ["_users" "userdb-1"])]
+      (is (= [] (sut/orphan-userdbs db))))))
+
+
+(deftest an-account-row-without-a-userdb-is-not-reported
+  (testing "rows without dbs are a different signal, out of scope for #205"
+    (let [db (migrated-db)]
+      (add-account! db 1)
+      (add-account! db 2)
+      (with-redefs [db/all-dbs (constantly ["_users" "userdb-1"])]
+        (is (= [] (sut/orphan-userdbs db)))))))
+
+
+(deftest couchdb-being-down-never-raises-out-of-the-report
+  (let [db (migrated-db)]
+    (with-redefs [db/all-dbs (fn [] (throw (ex-info "Connection refused" {})))]
+      (testing "the startup path logs and continues"
+        (is (nil? (sut/report! db)))))))


### PR DESCRIPTION
Closes #205.

Reconciliation report of CouchDB `userdb-N` databases without a matching `users` row in SQLite. Report only — auto-tombstoning is forbidden (restore-from-older-backup makes orphans live, legitimate data); disposal is a human decision. Rows without userdbs are a different signal and are not reported.

- `db/all-dbs` in lib/db (GET /_all_dbs, admin conn)
- `reconciliation/orphan-userdbs` (the diff) and `reconciliation/report!` (logs via telemere, returns the list — REPL operator entry point, like `mint-grant!`)
- Startup hook in `-main` after migrations; CouchDB down → warning, boot continues
- Tests: orphan named exactly; matched stores → empty; rows without dbs not reported; CouchDB down → nil, no throw. Suite: 18 tests / 40 assertions green (baseline 14/36)

**Pending live verification** on the dev stand (not done from this worktree — shared stand untouched): stage an orphan userdb → startup log and REPL report name it and nothing else. OpenSpec task 5 tracks it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)