### PR TITLE
GH-169 Headless Playwright suite replacing ad-hoc CDP checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,11 @@
 
 # DB
 app.db
+test-app.db*
+
+# Playwright artifacts
+/test-results/
+/playwright-report/
 
 # Keep linter config
 !/.clj-kondo/config.edn

--- a/openspec/changes/archive/2026-08-06-headless-playwright-suite/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-06-headless-playwright-suite/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-with-adr
+created: 2026-08-06

--- a/openspec/changes/archive/2026-08-06-headless-playwright-suite/proposal.md
+++ b/openspec/changes/archive/2026-08-06-headless-playwright-suite/proposal.md
@@ -1,0 +1,15 @@
+# Headless Playwright suite
+
+## Why
+
+Browser scenarios were verified by one-off CDP scripts: CSS-class locators that break on markup changes, `setTimeout` waits that are slow or flaky, nothing re-runnable (#169). Headless Chrome already runs inside WSL, so an automated suite needs nothing from Windows.
+
+## What changes
+
+A Playwright suite (`test/browser/`, config at repo root) runs headless inside WSL against the system Chrome (`channel: "chrome"`, no browser download) and a locally started backend — never the shared dev stand. Three specs: adding a word persists it, route entry renders shell and lists, a dialog closes from a backdrop click. Role- and label-based locators with auto-waiting assertions; no sleeps, no CSS-class locators. The CDP skill stays for interactive work with the visible Windows Chrome.
+
+## Impact
+
+- New capability: `browser-test-suite`.
+- New: `playwright.config.js`, `test/browser/*.spec.js`, `test/browser/README.md`, `test:browser` npm script; `playwright` + `@playwright/test` devDependencies.
+- Out of scope: CI wiring (deferred by #169), service worker, sync/CouchDB.

--- a/openspec/changes/archive/2026-08-06-headless-playwright-suite/specs/browser-test-suite/spec.md
+++ b/openspec/changes/archive/2026-08-06-headless-playwright-suite/specs/browser-test-suite/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: Repeatable browser scenarios run headless inside WSL
+The repository SHALL provide a Playwright suite that runs headless inside WSL against the system Google Chrome (`channel: "chrome"`, no browser download) and a locally started backend. The suite SHALL NOT depend on the Windows browser, the shared dev stand, or mirrored networking.
+
+#### Scenario: Running the suite
+- **WHEN** a backend is started locally and `npx playwright test` runs
+- **THEN** the suite passes headless without any Windows-side cooperation
+- **AND** a failing test retains a trace for inspection
+
+#### Scenario: Interactive debugging still wanted
+- **WHEN** a session needs the visible Windows browser
+- **THEN** the CDP skill remains the channel for it — the suite does not replace interactive debugging
+
+### Requirement: Specs assert user-visible behavior through accessible locators
+Specs SHALL locate elements by role, label, or visible text and rely on auto-waiting assertions. Specs SHALL NOT use fixed sleeps or CSS-class locators.
+
+#### Scenario: Adding a word
+- **WHEN** a word and its translation are typed into the labeled home-form fields and submitted
+- **THEN** the word is visible in the words list and survives a full page reload
+
+#### Scenario: Route entry loads data
+- **WHEN** the words route is entered directly and home is returned to
+- **THEN** the shell and each page's list content render as visible text and roles
+
+#### Scenario: Dialog closes from the backdrop
+- **WHEN** a reachable dialog is open and its backdrop is clicked
+- **THEN** the dialog closes, while a click inside the dialog leaves it open

--- a/openspec/changes/archive/2026-08-06-headless-playwright-suite/tasks.md
+++ b/openspec/changes/archive/2026-08-06-headless-playwright-suite/tasks.md
@@ -1,0 +1,9 @@
+# Tasks
+
+- [x] 1. Playwright devDependencies; verify `channel: "chrome"` launches system Chrome headless in WSL
+- [x] 2. Config: baseURL of the locally started backend, trace retain-on-failure, testDir test/browser
+- [x] 3. Spec: adding a word persists it (visible in words list, survives reload)
+- [x] 4. Spec: route entry renders shell and lists (home ↔ words)
+- [x] 5. Spec: dialog closes on backdrop click (install guide — sync menu needs an account a fresh environment lacks)
+- [x] 6. test/browser/README.md: how to run, own-backend requirement, out of scope; `test:browser` npm script
+- [x] 7. Verify: suite green headless; node-test build 0 warnings, 0 failures

--- a/openspec/specs/browser-test-suite/spec.md
+++ b/openspec/specs/browser-test-suite/spec.md
@@ -1,0 +1,32 @@
+# browser-test-suite Specification
+
+## Purpose
+TBD - created by archiving change headless-playwright-suite. Update Purpose after archive.
+## Requirements
+### Requirement: Repeatable browser scenarios run headless inside WSL
+The repository SHALL provide a Playwright suite that runs headless inside WSL against the system Google Chrome (`channel: "chrome"`, no browser download) and a locally started backend. The suite SHALL NOT depend on the Windows browser, the shared dev stand, or mirrored networking.
+
+#### Scenario: Running the suite
+- **WHEN** a backend is started locally and `npx playwright test` runs
+- **THEN** the suite passes headless without any Windows-side cooperation
+- **AND** a failing test retains a trace for inspection
+
+#### Scenario: Interactive debugging still wanted
+- **WHEN** a session needs the visible Windows browser
+- **THEN** the CDP skill remains the channel for it — the suite does not replace interactive debugging
+
+### Requirement: Specs assert user-visible behavior through accessible locators
+Specs SHALL locate elements by role, label, or visible text and rely on auto-waiting assertions. Specs SHALL NOT use fixed sleeps or CSS-class locators.
+
+#### Scenario: Adding a word
+- **WHEN** a word and its translation are typed into the labeled home-form fields and submitted
+- **THEN** the word is visible in the words list and survives a full page reload
+
+#### Scenario: Route entry loads data
+- **WHEN** the words route is entered directly and home is returned to
+- **THEN** the shell and each page's list content render as visible text and roles
+
+#### Scenario: Dialog closes from the backdrop
+- **WHEN** a reachable dialog is open and its backdrop is clicked
+- **THEN** the dialog closes, while a click inside the dialog leaves it open
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "learning-app",
+  "name": "agent-a50136ddd22f72382",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -13,7 +13,25 @@
         "qrcode": "^1.5.4"
       },
       "devDependencies": {
+        "@playwright/test": "^1.62.1",
+        "playwright": "^1.62.1",
         "shadow-cljs": "^3.4.12"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@sqlite.org/sqlite-wasm": {
@@ -480,6 +498,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/get-caller-file": {
@@ -955,6 +988,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/pngjs": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
   "scripts": {
+    "test:browser": "playwright test",
     "fetch-sqlite": "curl -L https://sqlite.org/2026/sqlite-wasm-3530100.zip -o /tmp/sqlite-wasm.zip && unzip -j /tmp/sqlite-wasm.zip 'sqlite-wasm-3530100/jswasm/sqlite3.js' -d resources/public/js/ && unzip -j /tmp/sqlite-wasm.zip 'sqlite-wasm-3530100/jswasm/sqlite3.wasm' -d resources/public/js/"
   },
   "devDependencies": {
+    "@playwright/test": "^1.62.1",
+    "playwright": "^1.62.1",
     "shadow-cljs": "^3.4.12"
   },
   "dependencies": {

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,14 @@
+const { defineConfig } = require('@playwright/test');
+
+// Headless suite for WSL. Runs against a locally started backend
+// (see test/browser/README.md); never against the shared dev stand.
+module.exports = defineConfig({
+  testDir: './test/browser',
+  reporter: 'list',
+  use: {
+    baseURL: 'http://localhost:8301',
+    channel: 'chrome',
+    headless: true,
+    trace: 'retain-on-failure',
+  },
+});

--- a/test/browser/README.md
+++ b/test/browser/README.md
@@ -11,7 +11,7 @@ The suite assumes a backend of its own is already listening on port 8301:
 
 ```sh
 npx shadow-cljs compile app
-LEARNING_APP_PORT=8301 LEARNING_APP_DB_PATH=$PWD/test-app.db \
+LEARNING_APP_PORT=8301 LEARNING_APP__DB_PATH=$PWD/test-app.db \
   clojure -M:dev -m core &
 ```
 

--- a/test/browser/README.md
+++ b/test/browser/README.md
@@ -1,0 +1,43 @@
+# Browser suite (Playwright)
+
+Headless Playwright specs that replace the ad-hoc CDP checks (#169). They run
+inside WSL against the system Google Chrome (`channel: "chrome"`, no browser
+download) — never against the shared dev stand or the visible Windows Chrome;
+that one remains the CDP skill's territory.
+
+## Running
+
+The suite assumes a backend of its own is already listening on port 8301:
+
+```sh
+npx shadow-cljs compile app
+LEARNING_APP_PORT=8301 LEARNING_APP_DB_PATH=$PWD/test-app.db \
+  clojure -M:dev -m core &
+```
+
+Wait for `curl -s http://localhost:8301/` to answer, then:
+
+```sh
+npm run test:browser   # = npx playwright test
+```
+
+Config is `playwright.config.js` at the repo root: baseURL
+`http://localhost:8301`, `trace: "retain-on-failure"` (traces land in
+`test-results/` on failure).
+
+## Conventions
+
+- Role- and label-based locators (`getByRole`, `getByLabel`) with auto-waiting
+  assertions. No `waitForTimeout`, no CSS-class locators.
+- Each test gets a fresh browser context, so client-side storage starts empty
+  and tests are order-independent.
+
+## Out of scope
+
+- **Service worker / offline** — not asserted here.
+- **Sync / CouchDB** — the backend runs alone, no replication target exists.
+  "Push to server" therefore reduces to "the word persists across a reload".
+- **Sync-menu dialog** — it renders only for a provisioned account (invite
+  gate, ADR-0006); a fresh environment has none, so the backdrop-dismiss
+  scenario exercises the install guide instead.
+- **CI** — explicitly deferred by #169 until the suite proves its keep.

--- a/test/browser/add-word.spec.js
+++ b/test/browser/add-word.spec.js
@@ -1,0 +1,23 @@
+const { test, expect } = require('@playwright/test');
+
+test('adding a word persists it to the words list', async ({ page }) => {
+  await page.goto('/home');
+
+  await page.getByLabel('Слово (немецкий)').fill('Haus');
+  await page.getByLabel('Перевод (русский)').fill('дом');
+  await page.getByRole('button', { name: 'ДОБАВИТЬ' }).click();
+
+  // The button is hidden while the vocabulary is empty, so its appearance
+  // already proves the write landed.
+  await page.getByRole('button', { name: 'Список слов' }).click();
+  await expect(page.getByRole('heading', { name: 'Мои слова' })).toBeVisible();
+  const item = page.getByRole('listitem').filter({ hasText: 'Haus' });
+  await expect(item).toBeVisible();
+  await expect(item).toContainText('дом');
+
+  // Persistence, not just render state: the word survives a full reload.
+  await page.reload();
+  await expect(
+    page.getByRole('listitem').filter({ hasText: 'Haus' })
+  ).toBeVisible();
+});

--- a/test/browser/dialog-backdrop.spec.js
+++ b/test/browser/dialog-backdrop.spec.js
@@ -1,0 +1,31 @@
+const { test, expect } = require('@playwright/test');
+
+// The sync-menu dialog only exists once an account is provisioned, which
+// needs a burned invite grant — absent in a fresh environment. The
+// install guide is the dialog reachable without an account; an iOS user
+// agent makes the install button render and routes its click to the guide
+// instead of the native prompt.
+test.use({
+  userAgent:
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) ' +
+    'AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+});
+
+test('install guide dialog closes on a backdrop click', async ({ page }) => {
+  await page.goto('/home');
+
+  // Document why this dialog and not the sync menu: no account, no button.
+  await expect(page.getByRole('button', { name: 'Синхронизация' })).toHaveCount(0);
+
+  await page.getByRole('button', { name: 'Установить приложение' }).click();
+  const title = page.getByRole('heading', { name: 'Install Sprecha' });
+  await expect(title).toBeVisible();
+
+  // A click inside the card must not dismiss.
+  await title.click();
+  await expect(title).toBeVisible();
+
+  // A click on the backdrop (top-left corner, outside the centered card) must.
+  await page.locator('#app-install-guide').click({ position: { x: 8, y: 8 } });
+  await expect(title).toBeHidden();
+});

--- a/test/browser/routes.spec.js
+++ b/test/browser/routes.spec.js
@@ -1,0 +1,19 @@
+const { test, expect } = require('@playwright/test');
+
+test('route entry renders shell and lists', async ({ page }) => {
+  // An unknown path is a redirect, not a visit.
+  await page.goto('/');
+  await expect(page).toHaveURL(/\/home$/);
+  await expect(page.getByRole('heading', { name: 'Главная' })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Sprecha' })).toBeVisible();
+
+  // Direct entry to the words route loads its data (empty state here).
+  await page.goto('/words');
+  await expect(page.getByText('Слов пока нет')).toBeVisible();
+
+  // And back: the empty-state action returns to home.
+  await page.getByRole('button', { name: 'Добавить слово' }).click();
+  await expect(page).toHaveURL(/\/home$/);
+  await expect(page.getByRole('heading', { name: 'Главная' })).toBeVisible();
+  await expect(page.getByLabel('Слово (немецкий)')).toBeVisible();
+});


### PR DESCRIPTION
Closes #169.

## What

Playwright suite in `test/browser/`, headless inside WSL against the system Google Chrome (`channel: "chrome"` — verified to launch, no browser download) and a locally started backend (`LEARNING_APP_PORT=8301`), per the recorded decision: no mirrored networking, the CDP skill keeps the visible Windows Chrome. Config: baseURL `http://localhost:8301`, `trace: retain-on-failure`. Role/label locators and auto-waiting assertions only — no `waitForTimeout`, no CSS-class locators. `npm run test:browser` assumes the backend is already up (documented in `test/browser/README.md`).

## Honest scope notes

- **Scenario 1** (word add pushes to server) reduces to *the word persists*: visible in the words list and surviving a full reload. No CouchDB runs here, so no replication request exists to assert on.
- **Scenario 3** exercises the **install-guide dialog**, not the sync menu. The sync button (`aria-label "Синхронизация"`) renders only when `:app/account-id` exists, and provisioning requires burning an invite grant (`/api/identity/provision`, ADR-0006) — absent in a fresh environment. The spec asserts the sync button's absence to document this, then opens the install guide under an iOS user agent (the only path where the install click shows the guide rather than the native prompt), verifies an in-card click does *not* dismiss, and a backdrop click does.
- **Out of scope:** CI wiring (deferred by the issue), service worker/offline, sync/CouchDB flows.

OpenSpec: new capability `browser-test-suite`, change archived as `2026-08-06-headless-playwright-suite` in the same commit.

## Verification

```
$ npm run test:browser
Running 3 tests using 3 workers

  ✓  2 test/browser/dialog-backdrop.spec.js:14:1 › install guide dialog closes on a backdrop click (7.3s)
  ✓  3 test/browser/routes.spec.js:3:1 › route entry renders shell and lists (7.7s)
  ✓  1 test/browser/add-word.spec.js:3:1 › adding a word persists it to the words list (9.0s)

  3 passed (11.6s)
```

```
$ npx shadow-cljs compile app node-test
[:app] Build completed. (331 files, 330 compiled, 0 warnings)
[:node-test] Build completed. (118 files, 117 compiled, 0 warnings)
$ node target/node-tests.js
Ran 144 tests containing 331 assertions.
0 failures, 0 errors.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)