### PR TITLE
GH-206 CouchDB joins the backup archive

### DIFF
--- a/docs/ops/runbook.md
+++ b/docs/ops/runbook.md
@@ -74,6 +74,18 @@ curl -sf http://127.0.0.1:5984/ >/dev/null
 curl -sf --resolve sprecha.de:443:127.0.0.1 https://sprecha.de/db/dictionary-db/dictionary-meta >/dev/null
 ```
 
+## Restore from backup
+
+Archives named `app-<timestamp>` carry both stores: the SQLite snapshot and
+`/var/lib/couchdb`. Restore them together, from the same archive — an account
+row and its userdb must come from one moment, or you manufacture the orphan
+states #182/#205 exist to catch. `borg list ::` to pick, `borg extract` into a
+scratch dir, then: stop services, put the sqlite file at
+`/var/lib/learning-app/db.sqlite`, the couch tree at `/var/lib/couchdb`
+(ownership `couchdb:couchdb`), start, and check `/auth/check` with a known
+token before calling it done. Older `db-*.sqlite` archives predate #206 and
+hold SQLite only.
+
 ## Manual admin steps (bootstrap + secrets + one-off ops)
 
 Run the admin setup script (idempotent, safe to re-run).

--- a/infra/production/etc/systemd/system/learning-app-backup-db.service
+++ b/infra/production/etc/systemd/system/learning-app-backup-db.service
@@ -4,6 +4,9 @@ Description=Learning App Backup DB
 [Service]
 Type=oneshot
 User=dbmaintainer
+# Read access to /var/lib/couchdb (0750 couchdb:couchdb) for the backup —
+# granted to this service only, not to the user account globally.
+SupplementaryGroups=couchdb
 WorkingDirectory=~
 LogsDirectory=learning-app
 StateDirectory=learning-app

--- a/infra/production/usr/share/learning-app/backup.sh
+++ b/infra/production/usr/share/learning-app/backup.sh
@@ -29,13 +29,18 @@ sqlite3 ${LEARNING_APP_DB_BACKUP_PATH} ".selftest"
 
 sqlite_backup_exit=$?
 
-# Create remote backup
+# Create remote backup. One archive carries both stores so a restore is
+# coherent by construction: an account row and its userdb come from the same
+# moment. CouchDB files are append-only, so a live copy is recoverable —
+# still, the archive is taken right after the sqlite snapshot to keep the
+# two as close as possible.
 borg create                     \
     --list                      \
     --stats                     \
     --show-rc                   \
-    ::db-{now}.sqlite           \
-    $LEARNING_APP_DB_BACKUP_PATH
+    ::app-{now}                 \
+    $LEARNING_APP_DB_BACKUP_PATH \
+    /var/lib/couchdb
 
 borg_backup_exit=$?
 

--- a/openspec/changes/archive/2026-08-06-couchdb-in-backups/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-06-couchdb-in-backups/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-with-adr
+created: 2026-08-06

--- a/openspec/changes/archive/2026-08-06-couchdb-in-backups/proposal.md
+++ b/openspec/changes/archive/2026-08-06-couchdb-in-backups/proposal.md
@@ -1,0 +1,13 @@
+# CouchDB joins the backup archive
+
+## Why
+
+`backup.sh` archived exactly one artifact — the SQLite snapshot — while every user's vocabulary, reviews and collections live in CouchDB userdbs with no backup at all (#206). Local-first softens this (devices can re-seed), but a user whose only device dies loses everything if the server copy is also gone.
+
+## What changes
+
+One borg archive (`app-<now>`) now carries both stores, taken back to back — a restore is coherent by construction. The backup service gains read access to `/var/lib/couchdb` via `SupplementaryGroups=couchdb`, scoped to the unit rather than the user. Runbook gains the restore procedure with the coherence rule.
+
+## Impact
+
+`backup.sh`, backup unit, runbook. Real proof is the next backup run and #191's restore drill.

--- a/openspec/changes/archive/2026-08-06-couchdb-in-backups/specs/backup-pipeline/spec.md
+++ b/openspec/changes/archive/2026-08-06-couchdb-in-backups/specs/backup-pipeline/spec.md
@@ -1,0 +1,12 @@
+## ADDED Requirements
+
+### Requirement: Both stores are backed up as one coherent archive
+Every backup run SHALL capture the SQLite database and the CouchDB data tree in a single archive, taken back to back, so a restore recovers matching account rows and userdbs. Backup SHALL read CouchDB with access scoped to the backup service.
+
+#### Scenario: A backup run
+- **WHEN** the backup timer fires
+- **THEN** one archive contains the SQLite snapshot and /var/lib/couchdb
+
+#### Scenario: A restore
+- **WHEN** an operator restores from an archive
+- **THEN** both stores come from the same moment and an existing token authenticates against its userdb

--- a/openspec/changes/archive/2026-08-06-couchdb-in-backups/tasks.md
+++ b/openspec/changes/archive/2026-08-06-couchdb-in-backups/tasks.md
@@ -1,0 +1,6 @@
+# Tasks
+
+- [x] 1. Both stores in one borg archive, sqlite snapshot first
+- [x] 2. Unit-scoped read access to /var/lib/couchdb
+- [x] 3. Restore procedure in the runbook with the coherence rule
+- [ ] 4. Real backup run shows the couch tree in `borg list`; restore drill lands with #191

--- a/openspec/specs/backup-pipeline/spec.md
+++ b/openspec/specs/backup-pipeline/spec.md
@@ -1,0 +1,16 @@
+# backup-pipeline Specification
+
+## Purpose
+TBD - created by archiving change couchdb-in-backups. Update Purpose after archive.
+## Requirements
+### Requirement: Both stores are backed up as one coherent archive
+Every backup run SHALL capture the SQLite database and the CouchDB data tree in a single archive, taken back to back, so a restore recovers matching account rows and userdbs. Backup SHALL read CouchDB with access scoped to the backup service.
+
+#### Scenario: A backup run
+- **WHEN** the backup timer fires
+- **THEN** one archive contains the SQLite snapshot and /var/lib/couchdb
+
+#### Scenario: A restore
+- **WHEN** an operator restores from an archive
+- **THEN** both stores come from the same moment and an existing token authenticates against its userdb
+


### PR DESCRIPTION
Closes #206.

`backup.sh` archived exactly one artifact — the SQLite snapshot — while every user's vocabulary, reviews and collections live in CouchDB userdbs with **no backup at all**. One borg archive (`app-<now>`) now carries both stores taken back to back, so a restore is coherent by construction: an account row and its userdb come from the same moment (the rule the runbook now spells out — restoring one store without the other manufactures the orphan states #182/#205 catch).

Access: `/var/lib/couchdb` is `0750 couchdb:couchdb`; the backup service gains `SupplementaryGroups=couchdb` — read access scoped to the unit, not granted to the `dbmaintainer` account globally. CouchDB files are append-only, so a live copy is recoverable; noted in the script.

Pairs with #209 (which makes the SQLite half real — today it snapshots the empty path). No hard gate: archiving CouchDB is valuable either way.

Verified here: bash syntax, `systemd-analyze verify` clean. Honest remainder: the next real backup run must show the couch tree in `borg list`; the restore drill is #191's deliverable. Old `db-*.sqlite` archives stay valid, SQLite-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)