### PR TITLE
GH-217 rename safe envs to LEARNING_APP__ convention (phase 1)

### DIFF
--- a/infra/production/etc/systemd/system/learning-app-backup-db.service
+++ b/infra/production/etc/systemd/system/learning-app-backup-db.service
@@ -17,7 +17,7 @@ EnvironmentFile=-/etc/environment.d/learning-app.conf
 EnvironmentFile=-/etc/learning-app/environment
 LoadCredentialEncrypted=borg-passphrase:/etc/credstore.encrypted/borg-passphrase
 Environment=BORG_PASSPHRASE_PATH=%d/borg-passphrase
-Environment=LEARNING_APP_DB_BACKUP_PATH=/var/backups/learning-app/db.sqlite
+Environment=LEARNING_APP__DB_BACKUP_PATH=/var/backups/learning-app/db.sqlite
 
 # Security settings
 #

--- a/infra/production/usr/share/learning-app/backup.sh
+++ b/infra/production/usr/share/learning-app/backup.sh
@@ -10,8 +10,8 @@ fi
 
 export BORG_PASSPHRASE=$(cat "${BORG_PASSPHRASE_PATH}")
 
-: "${LEARNING_APP_DB_PATH:=/var/lib/learning-app/db.sqlite}"
-export LEARNING_APP_DB_PATH
+: "${LEARNING_APP__DB_PATH:=/var/lib/learning-app/db.sqlite}"
+export LEARNING_APP__DB_PATH
 
 
 # some helpers and error handling:
@@ -23,9 +23,9 @@ trap 'echo $( date ) Backup interrupted >&2; exit 2' INT TERM
 info "Starting backup"
 
 # Create local backup
-sqlite3 ${LEARNING_APP_DB_PATH} ".backup $LEARNING_APP_DB_BACKUP_PATH"
+sqlite3 ${LEARNING_APP__DB_PATH} ".backup $LEARNING_APP__DB_BACKUP_PATH"
 info "Check backup"
-sqlite3 ${LEARNING_APP_DB_BACKUP_PATH} ".selftest"
+sqlite3 ${LEARNING_APP__DB_BACKUP_PATH} ".selftest"
 
 sqlite_backup_exit=$?
 
@@ -39,7 +39,7 @@ borg create                     \
     --stats                     \
     --show-rc                   \
     ::app-{now}                 \
-    $LEARNING_APP_DB_BACKUP_PATH \
+    $LEARNING_APP__DB_BACKUP_PATH \
     /var/lib/couchdb
 
 borg_backup_exit=$?

--- a/openspec/changes/archive/2026-08-06-finish-env-naming-phase1/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-06-finish-env-naming-phase1/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-with-adr
+created: 2026-08-06

--- a/openspec/changes/archive/2026-08-06-finish-env-naming-phase1/proposal.md
+++ b/openspec/changes/archive/2026-08-06-finish-env-naming-phase1/proposal.md
@@ -1,0 +1,21 @@
+# Finish LEARNING_APP__ env naming — phase 1, the safe three
+
+## Why
+
+App envs follow `LEARNING_APP__XXX` (double underscore), stated in review of #209, where `LEARNING_APP__DB_PATH` was renamed to match. Three names still use the old single form and are safe to rename in one step; the mixed convention invites the next misconfiguration.
+
+## What Changes
+
+- `LEARNING_APP_PORT` → `LEARNING_APP__PORT`: read in `src/backend/core.clj` only; nothing in infra sets it, the default covers the gap. Also renamed in `test/browser/README.md`, which sets it for the suite's own backend.
+- `LEARNING_APP_DB_BACKUP_PATH` → `LEARNING_APP__DB_BACKUP_PATH`: set in the backup unit `Environment=`, read in `backup.sh`; both ship in the same deb, so the rename is atomic within one artifact.
+- `LEARNING_APP_DB_PATH` → `LEARNING_APP__DB_PATH` in `backup.sh` (`:=` default, export, sqlite3 use) — the conf side was already renamed in #209; the script now picks up the conf value again.
+- **Out of scope**: `LEARNING_APP_DB_AUTH_SECRET`/`_PATH` — spans two deploy artifacts (unit in the deb, reader in the jar); phase 2, gated on staging rung 1 (#214).
+
+## Capabilities
+
+- **New Capabilities**: none.
+- **Modified Capabilities**: `backend-configuration` — ADDED requirement recording the naming convention.
+
+## Impact
+
+`src/backend/core.clj`, `infra/production/etc/systemd/system/learning-app-backup-db.service`, `infra/production/usr/share/learning-app/backup.sh`, `test/browser/README.md`. No behavior change when the env is unset — defaults are identical.

--- a/openspec/changes/archive/2026-08-06-finish-env-naming-phase1/specs/backend-configuration/spec.md
+++ b/openspec/changes/archive/2026-08-06-finish-env-naming-phase1/specs/backend-configuration/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Environment variables follow the LEARNING_APP__ prefix convention
+Every application environment variable SHALL be named `LEARNING_APP__XXX` — double underscore between the app prefix and the variable name. Legacy single-underscore names SHALL NOT be read; a rename that spans more than one deploy artifact SHALL ship as a dual-read transition before the old name is dropped.
+
+#### Scenario: Double-underscore name is honored
+- **WHEN** the backend starts with `LEARNING_APP__PORT=9999`
+- **THEN** it listens on 9999
+
+#### Scenario: Legacy single-underscore name is ignored
+- **WHEN** the backend starts with only `LEARNING_APP_PORT=9999` set
+- **THEN** it listens on the default port 8083
+
+#### Scenario: Backup pipeline uses the convention
+- **WHEN** the backup unit runs `backup.sh`
+- **THEN** the database and backup paths flow through `LEARNING_APP__DB_PATH` and `LEARNING_APP__DB_BACKUP_PATH`, both wired within the same deb artifact

--- a/openspec/changes/archive/2026-08-06-finish-env-naming-phase1/tasks.md
+++ b/openspec/changes/archive/2026-08-06-finish-env-naming-phase1/tasks.md
@@ -1,0 +1,14 @@
+# Tasks
+
+## 1. Renames
+
+- [x] 1.1 `LEARNING_APP_PORT` → `LEARNING_APP__PORT` in `src/backend/core.clj` and `test/browser/README.md`
+- [x] 1.2 `LEARNING_APP_DB_BACKUP_PATH` → `LEARNING_APP__DB_BACKUP_PATH` in the backup unit `Environment=` and `backup.sh`
+- [x] 1.3 `LEARNING_APP_DB_PATH` → `LEARNING_APP__DB_PATH` in `backup.sh` (default, export, sqlite3 use)
+
+## 2. Verification
+
+- [x] 2.1 `grep -rn "LEARNING_APP_[A-Z]"` over src, infra, docs, test — only the AUTH_SECRET pair (phase 2) remains
+- [x] 2.2 Backend tests stay green (22 tests / 49 assertions)
+- [x] 2.3 `LEARNING_APP__PORT=9999` → `core/port` answers 9999; legacy name ignored
+- [x] 2.4 `bash -n backup.sh`; `systemd-analyze verify` on the backup unit

--- a/openspec/specs/backend-configuration/spec.md
+++ b/openspec/specs/backend-configuration/spec.md
@@ -25,3 +25,18 @@ On startup, before opening the database, the backend SHALL move a database found
 - **WHEN** both the legacy and the target exist
 - **THEN** the target wins, nothing is deleted, and the log names both paths for the operator
 
+### Requirement: Environment variables follow the LEARNING_APP__ prefix convention
+Every application environment variable SHALL be named `LEARNING_APP__XXX` — double underscore between the app prefix and the variable name. Legacy single-underscore names SHALL NOT be read; a rename that spans more than one deploy artifact SHALL ship as a dual-read transition before the old name is dropped.
+
+#### Scenario: Double-underscore name is honored
+- **WHEN** the backend starts with `LEARNING_APP__PORT=9999`
+- **THEN** it listens on 9999
+
+#### Scenario: Legacy single-underscore name is ignored
+- **WHEN** the backend starts with only `LEARNING_APP_PORT=9999` set
+- **THEN** it listens on the default port 8083
+
+#### Scenario: Backup pipeline uses the convention
+- **WHEN** the backup unit runs `backup.sh`
+- **THEN** the database and backup paths flow through `LEARNING_APP__DB_PATH` and `LEARNING_APP__DB_BACKUP_PATH`, both wired within the same deb artifact
+

--- a/src/backend/core.clj
+++ b/src/backend/core.clj
@@ -34,7 +34,7 @@
 (set! *warn-on-reflection* true)
 
 
-(def port (or (some-> (System/getenv "LEARNING_APP_PORT") Integer/parseInt) 8083))
+(def port (or (some-> (System/getenv "LEARNING_APP__PORT") Integer/parseInt) 8083))
 
 
 (def ^:private console-log-handler-id :learning-app/console)

--- a/test/browser/README.md
+++ b/test/browser/README.md
@@ -11,7 +11,7 @@ The suite assumes a backend of its own is already listening on port 8301:
 
 ```sh
 npx shadow-cljs compile app
-LEARNING_APP_PORT=8301 LEARNING_APP__DB_PATH=$PWD/test-app.db \
+LEARNING_APP__PORT=8301 LEARNING_APP__DB_PATH=$PWD/test-app.db \
   clojure -M:dev -m core &
 ```
 


### PR DESCRIPTION
Part of #217. Phase 1 — the safe three renames to the `LEARNING_APP__XXX` double-underscore convention. Phase 2 (`LEARNING_APP_DB_AUTH_SECRET`/`_PATH`) spans two deploy artifacts and waits for staging rung 1 (#214); the issue stays open.

## Renames

- `LEARNING_APP_PORT` → `LEARNING_APP__PORT` — read in `src/backend/core.clj` only, nothing in infra sets it; also renamed in `test/browser/README.md`. Jar-only, single-step safe.
- `LEARNING_APP_DB_BACKUP_PATH` → `LEARNING_APP__DB_BACKUP_PATH` — backup unit `Environment=` + `backup.sh`, same deb, atomic within one artifact.
- `LEARNING_APP_DB_PATH` → `LEARNING_APP__DB_PATH` in `backup.sh` (`:=` default, export, sqlite3 use) — conf side already renamed in #209; the script picks up the conf value again.

## Proof

`grep -rn "LEARNING_APP_[A-Z]" src infra docs test` — only the phase-2 pair remains:

```
src/backend/core.clj:61:  (or (System/getenv "LEARNING_APP_DB_AUTH_SECRET")
src/backend/core.clj:63:      (throw (ex-info "LEARNING_APP_DB_AUTH_SECRET is required outside a source checkout" {}))))
infra/production/etc/systemd/system/learning-app-run.service:13:ExecStart=sh -c '...LEARNING_APP_DB_AUTH_SECRET.../...LEARNING_APP_DB_AUTH_SECRET_PATH...'
infra/production/etc/systemd/system/learning-app-run.service:21:Environment=LEARNING_APP_DB_AUTH_SECRET_PATH=%d/db_auth_secret
infra/production/opt/couchdb/etc/local.d/10-learning-app.ini:14:; adds a second layer; configure LEARNING_APP_DB_AUTH_SECRET in the app environment
```

- Backend tests: 22 tests, 49 assertions, 0 failures (baseline unchanged).
- `LEARNING_APP__PORT=9999` → `core/port` = 9999; legacy `LEARNING_APP_PORT=9999` ignored → 8083 default.
- `bash -n backup.sh` clean; `systemd-analyze verify` on the backup unit exits 0.
- OpenSpec: ADDED requirement on `backend-configuration`, validated strict and archived in the same commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)