### PR TITLE
GH-193 shorten lesson answer reveal, verify answer-field UX items

### DIFF
--- a/openspec/changes/archive/2026-08-06-shorten-lesson-answer-reveal/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-06-shorten-lesson-answer-reveal/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-with-adr
+created: 2026-08-06

--- a/openspec/changes/archive/2026-08-06-shorten-lesson-answer-reveal/proposal.md
+++ b/openspec/changes/archive/2026-08-06-shorten-lesson-answer-reveal/proposal.md
@@ -1,0 +1,15 @@
+# Lesson answer reveal copy shortened
+
+## Why
+
+GH-193 (UI polish batch): the error footer labels the revealed correct answer «Правильный ответ:», which the owner wants shortened to «Правильно:». Three sibling checklist items turned out to be already implemented; this change pins the delivered copy and the verified answer-field behavior in the lesson spec.
+
+## What changes
+
+- `error-footer` in `pages.lesson.view` labels the correct answer «Правильно:» instead of «Правильный ответ:».
+- Verified already implemented, no code change: the lesson answer field is a `textarea` with `spellcheck="false"`, `autocorrect="off"`, `autocapitalize="none"`, `autocomplete="off"`, so spellcheck is off and long answers soft-wrap; the home add-word on-mount focus runs through `:effect/mobile-autofocus`, which is gated on `(pointer:fine)` and never fires on mobile.
+- No new tests: the repo has no view-layer tests, and a hiccup-walking test for one string literal would start a new test category for a copy tweak.
+
+## Impact
+
+Modified: `lesson`. Files: `src/client/pages/lesson/view.cljs`. Visual check pends the shared dev stand.

--- a/openspec/changes/archive/2026-08-06-shorten-lesson-answer-reveal/specs/lesson/spec.md
+++ b/openspec/changes/archive/2026-08-06-shorten-lesson-answer-reveal/specs/lesson/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Error reveal labels the correct answer with short copy
+The lesson error footer SHALL label the revealed correct answer with the header «Правильно:».
+
+#### Scenario: Wrong answer reveal
+- **WHEN** a user answers a trial incorrectly
+- **THEN** the footer shows the user's answer under «Ваш ответ:»
+- **AND** the correct answer under «Правильно:»
+
+### Requirement: Answer field suppresses text assistance and wraps long input
+The lesson answer field SHALL be a multi-line textarea with browser text assistance disabled — `spellcheck="false"`, `autocorrect="off"`, `autocapitalize="none"`, `autocomplete="off"` — so German input is not corrected against the user, and long answers SHALL wrap onto new lines inside the field.
+
+#### Scenario: Text assistance attributes present
+- **WHEN** the lesson input footer renders
+- **THEN** the answer field is a textarea with spellcheck, autocorrect, autocapitalize and autocomplete disabled
+
+#### Scenario: Long answer wraps
+- **WHEN** the typed answer exceeds the field width
+- **THEN** the text soft-wraps onto further lines within the textarea

--- a/openspec/changes/archive/2026-08-06-shorten-lesson-answer-reveal/tasks.md
+++ b/openspec/changes/archive/2026-08-06-shorten-lesson-answer-reveal/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+- [x] 1. Shorten the error-footer reveal header to «Правильно:» in `src/client/pages/lesson/view.cljs`
+- [x] 2. Verify the answer field already disables spellcheck/autocorrect/autocapitalize/autocomplete and soft-wraps as a textarea
+- [x] 3. Verify home add-word on-mount focus is already mobile-safe (`:effect/mobile-autofocus` gated on `pointer:fine`)
+- [x] 4. `npx shadow-cljs compile app node-test` 0 warnings; `node target/node-tests.js` 0 failures (baseline 158 tests / 357 assertions)
+- [ ] 5. Visual check of the shortened reveal copy — pends the shared dev stand

--- a/openspec/specs/lesson/spec.md
+++ b/openspec/specs/lesson/spec.md
@@ -115,3 +115,22 @@ The system SHALL replace the current browser history entry when a learner exits 
 - **THEN** the app navigates to the home page
 - **AND** the navigation replaces the current history entry so the cancelled lesson screen is not restored by pressing browser Back
 
+### Requirement: Error reveal labels the correct answer with short copy
+The lesson error footer SHALL label the revealed correct answer with the header «Правильно:».
+
+#### Scenario: Wrong answer reveal
+- **WHEN** a user answers a trial incorrectly
+- **THEN** the footer shows the user's answer under «Ваш ответ:»
+- **AND** the correct answer under «Правильно:»
+
+### Requirement: Answer field suppresses text assistance and wraps long input
+The lesson answer field SHALL be a multi-line textarea with browser text assistance disabled — `spellcheck="false"`, `autocorrect="off"`, `autocapitalize="none"`, `autocomplete="off"` — so German input is not corrected against the user, and long answers SHALL wrap onto new lines inside the field.
+
+#### Scenario: Text assistance attributes present
+- **WHEN** the lesson input footer renders
+- **THEN** the answer field is a textarea with spellcheck, autocorrect, autocapitalize and autocomplete disabled
+
+#### Scenario: Long answer wraps
+- **WHEN** the typed answer exceeds the field width
+- **THEN** the text soft-wraps onto further lines within the textarea
+

--- a/src/client/pages/lesson/view.cljs
+++ b/src/client/pages/lesson/view.cljs
@@ -84,7 +84,7 @@
     [:div.lesson__answer
      [:h3.lesson__answer-header "Ваш ответ:"]
      [:p.lesson__answer-body {:lang "de"} (or user-answer "")]
-     [:h3.lesson__answer-header "Правильный ответ:"]
+     [:h3.lesson__answer-header "Правильно:"]
      (answer-body props)]
     [:div.lesson__action.page-footer__action
      [:button.big-button


### PR DESCRIPTION
Part of #193.

Per-item verdicts (mechanical subset only):

- **Сократить «Правильный ответ» до «Правильно»** — done. `error-footer` in `src/client/pages/lesson/view.cljs` now says «Правильно:».
- **Отключить проверку орфографии в поле ответа** — already done. The lesson answer textarea (`#lesson-answer`) already carries `spellcheck="false"`, `autocorrect="off"`, `autocapitalize="none"`, `autocomplete="off"`, `lang="de"`; the surrounding form repeats autocapitalize/autocorrect. No code change; behavior pinned in the lesson spec.
- **Убрать автофокус на полях добавления нового слова** — already done. The home add-panel on-mount dispatches `:action/focus-word-input` → `:effect/mobile-autofocus`, which focuses only when `matchMedia("(pointer:fine)")` matches (`src/client/application.cljs`). On coarse-pointer/mobile devices nothing is focused and the keyboard never opens — exactly the draft's intent. No change.
- **Длинный текст сам переносится на новую строку поля для ответа** — already done. The answer field is a `:textarea` (`rows 4`, `resize: none`, `min-height 87px`), no `wrap="off"`, so long answers soft-wrap natively. No conversion needed.

No new tests: the suite has no view-layer tests (actions/effects/presenter/domain only), and a hiccup-walking test pinning one copy string would force a new test category for a one-word change.

OpenSpec: delta to `lesson` archived as `2026-08-06-shorten-lesson-answer-reveal` in the same commit (validated).

Proof: `npx shadow-cljs compile app node-test` and `compile app` both 0 warnings; `node target/node-tests.js` — 158 tests / 357 assertions, 0 failures (matches baseline).

Visual pass pends the stand — this branch was built in an isolated worktree, no browser/CDP touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)