### PR TITLE
GH-218 Boot-time telemetry visible under the dev alias

### DIFF
--- a/src/backend/core.clj
+++ b/src/backend/core.clj
@@ -95,18 +95,15 @@
               target-wal (io/file (str (.getPath target) "-wal"))
               tmp        (io/file (str (.getPath target) ".adopting"))]
           (some-> (.getParentFile target) .mkdirs)
-          (let [replace ^"[Ljava.nio.file.CopyOption;"
-                        (into-array
-                         java.nio.file.CopyOption
-                         [java.nio.file.StandardCopyOption/REPLACE_EXISTING])
-                atomic  ^"[Ljava.nio.file.CopyOption;"
-                        (into-array
-                         java.nio.file.CopyOption
-                         [java.nio.file.StandardCopyOption/ATOMIC_MOVE])]
-            (when (.exists legacy-wal)
-              (java.nio.file.Files/copy (.toPath legacy-wal) (.toPath target-wal) replace))
-            (java.nio.file.Files/copy (.toPath legacy) (.toPath tmp) replace)
-            (java.nio.file.Files/move (.toPath tmp) (.toPath target) atomic))
+          ;; io/copy and File.renameTo instead of the NIO varargs API: the
+          ;; same semantics — overwriting copy, atomic same-directory rename
+          ;; via rename(2) — without the array-class type hints.
+          (when (.exists legacy-wal)
+            (io/copy legacy-wal target-wal))
+          (io/copy legacy tmp)
+          (when-not (.renameTo tmp target)
+            (throw (ex-info "Atomic rename failed during adoption"
+                            {:target (.getPath target) :tmp (.getPath tmp)})))
           (doseq [suffix ["" "-wal" "-shm"]]
             (.delete (io/file (str (.getPath legacy) suffix))))
           (t/event! ::database-adopted

--- a/src/backend/core.clj
+++ b/src/backend/core.clj
@@ -95,19 +95,18 @@
               target-wal (io/file (str (.getPath target) "-wal"))
               tmp        (io/file (str (.getPath target) ".adopting"))]
           (some-> (.getParentFile target) .mkdirs)
-          (when (.exists legacy-wal)
-            (java.nio.file.Files/copy (.toPath legacy-wal)
-                                      (.toPath target-wal)
-                                      (into-array java.nio.file.CopyOption
-                                                  [java.nio.file.StandardCopyOption/REPLACE_EXISTING])))
-          (java.nio.file.Files/copy (.toPath legacy)
-                                    (.toPath tmp)
-                                    (into-array java.nio.file.CopyOption
-                                                [java.nio.file.StandardCopyOption/REPLACE_EXISTING]))
-          (java.nio.file.Files/move (.toPath tmp)
-                                    (.toPath target)
-                                    (into-array java.nio.file.CopyOption
-                                                [java.nio.file.StandardCopyOption/ATOMIC_MOVE]))
+          (let [replace ^"[Ljava.nio.file.CopyOption;"
+                        (into-array
+                         java.nio.file.CopyOption
+                         [java.nio.file.StandardCopyOption/REPLACE_EXISTING])
+                atomic  ^"[Ljava.nio.file.CopyOption;"
+                        (into-array
+                         java.nio.file.CopyOption
+                         [java.nio.file.StandardCopyOption/ATOMIC_MOVE])]
+            (when (.exists legacy-wal)
+              (java.nio.file.Files/copy (.toPath legacy-wal) (.toPath target-wal) replace))
+            (java.nio.file.Files/copy (.toPath legacy) (.toPath tmp) replace)
+            (java.nio.file.Files/move (.toPath tmp) (.toPath target) atomic))
           (doseq [suffix ["" "-wal" "-shm"]]
             (.delete (io/file (str (.getPath legacy) suffix))))
           (t/event! ::database-adopted
@@ -611,6 +610,10 @@
 (defn -main
   []
   (let [url (str "http://localhost:" port "/")]
+    ;; Logging first: adoption, migrations and the reconciliation report all
+    ;; speak before the server starts, and events without a handler are
+    ;; dropped silently (#218 — the dev alias ships none).
+    (ensure-log-handler!)
     ;; Adopt, then migrate, then serve: the app never runs against an
     ;; outdated schema or a stranded database.
     (adopt-legacy-database!)

--- a/test/backend/core_test.clj
+++ b/test/backend/core_test.clj
@@ -130,10 +130,11 @@
           (is (= [(str "u:" id)] (get-in (second @secured) [:members :roles]))))))))
 
 
-(defn- temp-dir
+(defn- ^File temp-dir
   []
   (.toFile (java.nio.file.Files/createTempDirectory
             "adopt-test"
+            ^"[Ljava.nio.file.attribute.FileAttribute;"
             (into-array java.nio.file.attribute.FileAttribute []))))
 
 

--- a/test/backend/migrations_test.clj
+++ b/test/backend/migrations_test.clj
@@ -66,7 +66,7 @@
                (.delete)
                (.deleteOnExit))]
     (with-open [out (JarOutputStream. (FileOutputStream. file))]
-      (doseq [name (cons "migrations/" names)]
+      (doseq [^String name (cons "migrations/" names)]
         (.putNextEntry out (JarEntry. name))
         (when-not (str/ends-with? name "/")
           (.write out (.getBytes "-- statement")))
@@ -83,7 +83,7 @@
 (deftest migrations-are-found-inside-a-jar
   ;; Production runs from an uberjar, where a resource directory cannot be
   ;; listed: an archive is a flat list of entries with no directory to open.
-  (let [jar     (jar-with ["migrations/001-first.sql" "migrations/002-second.sql" "migrations/notes.txt"])
+  (let [^java.io.File jar (jar-with ["migrations/001-first.sql" "migrations/002-second.sql" "migrations/notes.txt"])
         jar-url (.toString (.toURL (.toURI jar)))
         entry   (URL. (str "jar:" jar-url "!/migrations/001-first.sql"))
         dir     (URL. (str "jar:" jar-url "!/migrations/"))]


### PR DESCRIPTION
Closes #218.

Boot events (adoption, migrations, reconciliation) logged before any handler existed — under `-M:dev` telemere ships none, so they vanished. Found live: #208's report ran fine but its line never appeared. Handler now installs first in -main. Plus reflection hints (adoption code + two old ones in the jar test).

Verified on the stand: the orphan-userdbs line appears at boot, zero reflection warnings, 22 tests green. Production was unaffected — the packaged run has a default handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)