### PR TITLE
GH-215 ADR-0010: SSH deploys and Cloudflare Tunnel for staging

### DIFF
--- a/adr/0010-staging-ladder.md
+++ b/adr/0010-staging-ladder.md
@@ -15,14 +15,14 @@ Three rungs, each with a distinct question it answers:
 
 1. **Headless in WSL** (exists — #169): does the application behave? Playwright against the suite's own backend; no nginx, no CouchDB, no stand.
 2. **Container from the deb** (#214): does the production *shape* hold? The actual `.deb` installed in a systemd container; units boot under their sandboxes, migrations and adoption run, `backup.sh` produces a coherent archive, smoke over nginx. Turns in-PR checklists into a script.
-3. **Mini PC staging** (#215): does the production *reality* hold? A self-hosted runner on home metal runs a `deploy-staging` mirror of the real deploy workflow — same transport, real systemd, multi-day observations, restore drills. Re-imaged only via `admin-setup.sh`, which thereby stays honest.
+3. **Mini PC staging** (#215): does the production *reality* hold? Home metal, deployed over SSH from the local network, exposed through a Cloudflare Tunnel — no port forwarding, no public IP, TLS at the edge, so certbot is not needed below production; access can be gated by Cloudflare Access. Real systemd, multi-day observations, restore drills. Re-imaged only via `admin-setup.sh`, which thereby stays honest.
 
-The rungs are ordered by cost of the answer: minutes, minutes-to-hours, standing infrastructure.
+Rungs 2 and 3 complement each other and carry no ordering between them (owner's decision, 2026-08-06): the container is the fast automatic check for infra PRs, the metal is the truth. Either may land first.
 
 ## Consequences
 
 - Every "pends the server" claim gains a home short of production; infra PRs stop merging on faith.
-- The public repository makes the self-hosted runner the sharpest edge: it accepts only `workflow_dispatch` deploys behind a reviewed GitHub Environment — never `pull_request` jobs. The rule precedes the runner.
+- Staging deploys go over SSH for now. If a self-hosted runner is ever added, the public repository makes it the sharpest edge: only `workflow_dispatch` deploys behind a reviewed GitHub Environment — never `pull_request` jobs. The rule precedes any runner.
 - Certbot stays dry-run below production unless a staging DNS name is ever wanted.
 - The container rung is fragile by nature (systemd-in-docker cgroup care); the incantation gets recorded, not rediscovered.
 - Production deploys gain a precondition worth writing into the delivery flow once rung 2 exists: infra changes visit staging first.


### PR DESCRIPTION
Part of #215. Records the owner's decisions: rungs 2 and 3 complement each other with no ordering; staging deploys over SSH; exposure via Cloudflare Tunnel (no port forwarding, TLS at the edge, optional Access gating). The self-hosted-runner rule stays in the ADR for the day one appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)