### PR TITLE
GH-214 Staging rung 2: the production shape in a systemd container from the deb

### DIFF
--- a/infra/staging/Dockerfile
+++ b/infra/staging/Dockerfile
@@ -1,0 +1,74 @@
+# Staging rung 2 (ADR-0010): the production shape in a systemd container.
+#
+# Base: ubuntu:24.04 — not pure Debian. Production is an Ubuntu Hetzner box
+# (admin-setup.sh --bootstrap uses `add-apt-repository universe`), and noble is
+# the release that carries openjdk-21 and has CouchDB packages in the Apache
+# apt repository. This is the closest image to what the deb actually lands on.
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive container=docker
+
+# A hung mirror connection must fail fast and retry, not stall the build.
+RUN printf '%s\n' \
+        'Acquire::Retries "3";' \
+        'Acquire::http::Timeout "30";' \
+        'Acquire::https::Timeout "30";' \
+    > /etc/apt/apt.conf.d/80-staging-timeouts
+
+# systemd as PID 1 plus tooling for the repo setup below.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        systemd systemd-sysv dbus \
+        curl ca-certificates gnupg apt-transport-https openssl \
+    && rm -rf /var/lib/apt/lists/*
+
+# CouchDB apt repository — the same source admin-setup.sh --bootstrap adds.
+RUN curl -fsSL https://couchdb.apache.org/repo/keys.asc \
+        | gpg --dearmor -o /usr/share/keyrings/couchdb-archive-keyring.gpg \
+    && . /etc/os-release \
+    && echo "deb [signed-by=/usr/share/keyrings/couchdb-archive-keyring.gpg] https://apache.jfrog.io/artifactory/couchdb-deb/ ${VERSION_CODENAME} main" \
+        > /etc/apt/sources.list.d/couchdb.list
+
+# Preseed CouchDB: single node on localhost with a known staging admin
+# password (plaintext by design — this container never holds real secrets).
+# On the real server the operator answers these prompts during bootstrap.
+RUN printf '%s\n' \
+        'couchdb couchdb/mode select standalone' \
+        'couchdb couchdb/bindaddress string 127.0.0.1' \
+        'couchdb couchdb/cookie string learning-app-staging' \
+        'couchdb couchdb/adminpass password staging-couch-pass' \
+        'couchdb couchdb/adminpass_again password staging-couch-pass' \
+    | debconf-set-selections
+
+# Everything the infra deb Depends on, baked at image build so installing the
+# deb inside the booted container needs no network.
+RUN apt-get update \
+    && apt-get install -y \
+        nginx borgbackup certbot python3-certbot-nginx couchdb \
+        openjdk-21-jre-headless sqlite3 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Self-signed certificate where postinst expects the real one; without it
+# `nginx -t` fails the moment tmpfiles links the site in. Certbot stays
+# dry below production (ADR-0010).
+RUN mkdir -p /etc/nginx/ssl/sprecha.de \
+    && openssl req -x509 -newkey rsa:2048 -nodes -days 30 \
+        -subj "/CN=sprecha.de" \
+        -addext "subjectAltName=DNS:sprecha.de,DNS:www.sprecha.de" \
+        -keyout /etc/nginx/ssl/sprecha.de/privkey.pem \
+        -out /etc/nginx/ssl/sprecha.de/fullchain.pem \
+    && chmod 700 /etc/nginx/ssl/sprecha.de
+
+# Units that cannot work under docker (no udev, no kernel mounts) or that
+# docker already covers (resolv.conf is bind-mounted by the daemon).
+RUN systemctl mask \
+        systemd-resolved.service \
+        systemd-udevd.service \
+        systemd-udevd-kernel.socket \
+        systemd-udevd-control.socket \
+        systemd-modules-load.service \
+        sys-kernel-config.mount \
+        sys-kernel-debug.mount
+
+STOPSIGNAL SIGRTMIN+3
+CMD ["/lib/systemd/systemd"]

--- a/infra/staging/README.md
+++ b/infra/staging/README.md
@@ -1,0 +1,92 @@
+# Staging rung 2: the production shape in a systemd container
+
+ADR-0010's middle rung. `run.sh` builds `infra/production` into the same deb
+CI produces, boots a systemd container, installs the deb, delivers the app jar
+the runbook way, and runs `smoke.sh` — one PASS/FAIL line per claim that infra
+PRs used to ship as manual checklists (#199 stop behavior, #200 sandboxes,
+#209 adoption, #211 backup contents).
+
+## Run
+
+```sh
+# Prerequisite: the app jar, built as deploy-app.yml builds it
+npm ci && npx shadow-cljs release app && clojure -T:build uber
+
+bash infra/staging/run.sh
+```
+
+Environment knobs: `LEARNING_APP_STAGING_KEEP=1` leaves the container running
+for inspection; `LEARNING_APP_STAGING_CONTAINER` / `LEARNING_APP_STAGING_IMAGE`
+rename the artifacts (default prefix `learning-app-staging`). No container
+ports are published; every check goes through `docker exec`.
+
+## The systemd-in-docker incantation
+
+Three walls were hit on this daemon (docker 29.x, cgroup v2, WSL2 kernel),
+each recorded here so none is ever rediscovered (ADR-0010):
+
+1. **PID 1 boot.** The default private cgroup namespace leaves
+   `/sys/fs/cgroup` read-only and systemd dies with "Failed to create
+   /init.scope control group". Fix: `--cgroupns=host
+   -v /sys/fs/cgroup:/sys/fs/cgroup:rw --tmpfs /run --tmpfs /run/lock`.
+2. **Unit sandboxes.** `ProtectSystem`, `PrivateTmp` and the credential mount
+   die with "Failed to keep CAP_SYS_ADMIN" (status=217/USER) under docker's
+   default caps. Fix: `--cap-add=SYS_ADMIN --security-opt seccomp=unconfined
+   --security-opt apparmor=unconfined`.
+3. **Encrypted credentials.** The subtle one: everything starts, but
+   `/run/credentials/<unit>` is empty and the app dies with
+   "LEARNING_APP_DB_AUTH_SECRET is required". Docker leaves every mount
+   private and systemd-in-a-container skips its usual "remount / rshared"
+   boot step, so the staged credential tmpfs is MS_MOVEd into a mount
+   namespace nobody observes — silently. Fix: `mount --make-rshared /` inside
+   the container once systemd is up. `--privileged` does NOT fix this one.
+
+With all three in place `--privileged` is not needed anywhere, and
+`systemd-creds encrypt --with-key=host` works inside the container
+(generating `/var/lib/systemd/credential.secret` on first use), so the
+encrypted-credential flow — `systemd-creds` in postinst,
+`LoadCredentialEncrypted=` in the units — runs for real, not as a stub.
+
+## What a green run proves
+
+- The deb installs cleanly with its declared dependencies on the OS family it
+  targets (Ubuntu noble: production is an Ubuntu Hetzner box, and noble is
+  what carries openjdk-21 and CouchDB's apt packages — a pure Debian base
+  matches production less, not more).
+- postinst's credential gates behave: without an OpenRouter key the app unit
+  is not started; with borg passphrase + `BORG_REPO` the backup timer is.
+- All units become active under their production sandbox settings.
+- nginx terminates TLS and proxies; `/db/` without a cookie is 401 via
+  `auth_request`; the app's `/auth/check` refuses without a cookie.
+- Migrations run against `LEARNING_APP__DB_PATH`.
+- A legacy `/opt/learning-app/app.db` placed before the first service start is
+  adopted into `/var/lib/learning-app/db.sqlite` (#209's scenario against the
+  real unit sandbox).
+- `learning-app-backup-db.service` produces a borg archive carrying both the
+  SQLite snapshot and `/var/lib/couchdb`.
+
+## What it deliberately does not prove
+
+- **TLS reality.** The certificate is self-signed; certbot never talks to an
+  ACME server (its timer being active is all that is checked).
+- **Remote backup.** borg targets a local repository with a plaintext test
+  passphrase; ssh transport and the real repository are rung 3's job.
+- **Kernel and hardware.** The kernel is the host's (WSL2 here); nothing about
+  memory pressure, disk, or multi-day behavior transfers.
+- **CouchDB provisioning exactly as production.** The debconf answers are
+  preseeded with test values where an operator answers prompts during
+  `admin-setup.sh --bootstrap`.
+
+Real TLS, real borg, multi-day observation: rung 3, the mini-PC (#215).
+
+## Known red: adoption (a real catch, not a script bug)
+
+The first full run reported 15 PASS and 3 FAIL, all three on adoption. The
+deb's own `tmpfiles.d` line — `f /var/lib/learning-app/db.sqlite 0660 webapp
+webapp -`, shipped since GH-64 — pre-creates an empty file at the configured
+path during postinst, before the app ever starts. #209's adoption then hits
+its no-clobber branch ("target exists"), logs `legacy-database-left-behind`,
+and leaves the real data stranded at `/opt/learning-app/app.db`. The same
+empty file exists on the production server for the same reason, so this
+would have surfaced on the next real deploy as stranded accounts. The fix
+belongs to #209's scope; once it lands, this smoke goes green.

--- a/infra/staging/run.sh
+++ b/infra/staging/run.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# Staging rung 2 (ADR-0010): build the deb the way CI does, install it inside
+# a systemd container, and smoke the production shape. See README.md for what
+# this proves and what it deliberately does not.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "${HERE}/../.." && pwd)"
+
+IMAGE="${LEARNING_APP_STAGING_IMAGE:-learning-app-staging}"
+CONTAINER="${LEARNING_APP_STAGING_CONTAINER:-learning-app-staging-run}"
+KEEP="${LEARNING_APP_STAGING_KEEP:-0}"
+
+# Test-only secrets, plaintext by design: nothing in this container is real.
+COUCH_PASS="staging-couch-pass"   # must match the debconf preseed in Dockerfile
+BORG_PASS="staging-borg-pass"     # must match smoke.sh
+
+cleanup() {
+    if [ "${KEEP}" = 1 ]; then
+        echo "KEEP=1 — leaving container ${CONTAINER} running"
+    else
+        docker rm -f "${CONTAINER}" >/dev/null 2>&1 || true
+    fi
+}
+trap cleanup EXIT
+
+in_c() {
+    docker exec "${CONTAINER}" "$@"
+}
+
+encrypt_credential() {
+    # systemd-creds needs a real machine behind it; inside this container
+    # `encrypt --with-key=host` works and generates
+    # /var/lib/systemd/credential.secret on first use (no TPM2 involved).
+    local name="$1"
+    printf '%s' "$2" | docker exec -i "${CONTAINER}" \
+        systemd-creds encrypt --name="${name}" --with-key=host \
+        - "/etc/credstore.encrypted/${name}"
+}
+
+echo "== Build the infra deb (identical to infra-checks.yml) =="
+mkdir -p "${ROOT}/target"
+dpkg-deb --root-owner-group --build "${ROOT}/infra/production" \
+    "${ROOT}/target/learning-app-infra.deb"
+
+if [ ! -f "${ROOT}/target/learning-app.jar" ]; then
+    echo "ERROR: target/learning-app.jar missing. Build it the way deploy-app.yml does:" >&2
+    echo "  npm ci && npx shadow-cljs release app && clojure -T:build uber" >&2
+    exit 1
+fi
+
+echo "== Build the container image =="
+docker build -t "${IMAGE}" "${HERE}"
+
+echo "== Boot systemd =="
+# The incantation this daemon needed (docker 29.2, cgroup v2, WSL2 kernel),
+# recorded per ADR-0010 so it is never rediscovered:
+# - default private cgroupns leaves /sys/fs/cgroup read-only and PID 1 dies
+#   with "Failed to create /init.scope control group" -> host cgroupns plus a
+#   rw cgroup bind;
+# - the units' production sandboxes (ProtectSystem, PrivateTmp,
+#   LoadCredentialEncrypted's credential mount) die with "Failed to keep
+#   CAP_SYS_ADMIN" under docker's default caps/seccomp -> CAP_SYS_ADMIN plus
+#   an unconfined seccomp/apparmor profile;
+# - docker leaves every mount private and systemd-in-a-container skips its
+#   usual "remount / rshared" setup, so LoadCredentialEncrypted's staged
+#   credential mount is MS_MOVEd into a namespace nobody sees: the service
+#   runs but /run/credentials/<unit> is empty. `mount --make-rshared /`
+#   after boot (below) restores propagation. --privileged does NOT fix this
+#   one and is not needed once these three are in place.
+# No ports are published on purpose — every assertion goes through docker exec.
+docker rm -f "${CONTAINER}" >/dev/null 2>&1 || true
+docker run -d --name "${CONTAINER}" \
+    --cgroupns=host -v /sys/fs/cgroup:/sys/fs/cgroup:rw \
+    --tmpfs /run --tmpfs /run/lock \
+    --cap-add=SYS_ADMIN \
+    --security-opt seccomp=unconfined --security-opt apparmor=unconfined \
+    "${IMAGE}" >/dev/null
+
+state=""
+for _ in $(seq 1 60); do
+    state="$(docker exec "${CONTAINER}" systemctl is-system-running 2>/dev/null || true)"
+    case "${state}" in running|degraded) break ;; esac
+    sleep 1
+done
+case "${state}" in
+    running|degraded)
+        echo "systemd is up (${state})"
+        # See the incantation note above: without this, per-service encrypted
+        # credentials silently never arrive.
+        in_c mount --make-rshared /
+        ;;
+    *)
+        echo "ERROR: systemd did not come up (state: ${state:-none})" >&2
+        docker logs "${CONTAINER}" 2>&1 | tail -20 >&2
+        exit 1
+        ;;
+esac
+
+echo "== Stage inputs =="
+docker cp "${ROOT}/target/learning-app-infra.deb" "${CONTAINER}:/root/"
+docker cp "${ROOT}/target/learning-app.jar" "${CONTAINER}:/root/"
+docker cp "${HERE}/smoke.sh" "${CONTAINER}:/root/smoke.sh"
+
+echo "== Credentials the operator creates via admin-setup.sh =="
+# The OpenRouter key is withheld until after the first install so postinst's
+# gate ("no key -> do not start the app") is exercised for real.
+in_c install -d -m 700 /etc/credstore.encrypted
+encrypt_credential couchdb_admin_password "${COUCH_PASS}"
+encrypt_credential db_auth_secret "$(in_c openssl rand -hex 32)"
+encrypt_credential borg-passphrase "${BORG_PASS}"
+in_c bash -c 'install -d -m 700 /etc/learning-app
+              printf "BORG_REPO=/var/lib/dbmaintainer/borg-repo\n" > /etc/learning-app/environment
+              chmod 600 /etc/learning-app/environment'
+
+echo "== Pre-place the legacy database (#209 adoption scenario) =="
+# Before ANY service start: the pre-#201 world where the data lives at
+# /opt/learning-app/app.db and /var/lib/learning-app/db.sqlite does not hold it.
+docker exec -i "${CONTAINER}" bash -c 'mkdir -p /opt/learning-app && sqlite3 /opt/learning-app/app.db' <<'SQL'
+CREATE TABLE staging_marker(note TEXT);
+INSERT INTO staging_marker VALUES ('legacy');
+SQL
+
+echo "== Install the deb (runbook step 1) =="
+in_c bash -c 'dpkg -i /root/learning-app-infra.deb || apt-get -f install -y'
+
+if in_c systemctl is-active --quiet learning-app-run.service; then
+    echo "ERROR: learning-app-run started without an OpenRouter key — postinst gate broken" >&2
+    exit 1
+fi
+echo "postinst gate held: learning-app-run not started without OPENROUTER key"
+
+echo "== Complete the operator setup: perms, key, jar (runbook step 2) =="
+# /opt/learning-app mirrors the dictionary dir pattern: deployer writes the
+# jar, webapp (group) needs write to retire the legacy db after adoption.
+in_c bash -c 'chown deployer:webapp /opt/learning-app
+              chmod 2775 /opt/learning-app
+              chown webapp:webapp /opt/learning-app/app.db'
+encrypt_credential openrouter_api_key "staging-dummy-openrouter-key"
+# Atomic replace, exactly like the runbook — this fires learning-app-restart.path.
+in_c bash -c 'cp /root/learning-app.jar /opt/learning-app/learning-app.jar.tmp
+              mv -f /opt/learning-app/learning-app.jar.tmp /opt/learning-app/learning-app.jar'
+# Reinstall is idempotent per the runbook; with the key present postinst now
+# enables learning-app-run.
+in_c bash -c 'dpkg -i /root/learning-app-infra.deb'
+
+echo "== Wait for the app =="
+up=0
+for _ in $(seq 1 90); do
+    if in_c curl -sf -o /dev/null http://127.0.0.1:8083/; then up=1; break; fi
+    sleep 1
+done
+if [ "${up}" != 1 ]; then
+    echo "ERROR: app did not answer on 127.0.0.1:8083 within 90s" >&2
+    in_c systemctl status learning-app-run.service --no-pager >&2 || true
+    in_c journalctl -u learning-app-run.service --no-pager 2>&1 | tail -30 >&2 || true
+    exit 1
+fi
+
+echo "== Local borg repository (remote borg is out of scope here) =="
+in_c runuser -u dbmaintainer -- env \
+    BORG_REPO=/var/lib/dbmaintainer/borg-repo \
+    BORG_PASSPHRASE="${BORG_PASS}" \
+    borg init --encryption=repokey
+
+echo "== Smoke =="
+in_c bash /root/smoke.sh

--- a/infra/staging/smoke.sh
+++ b/infra/staging/smoke.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Runs INSIDE the staging container. One PASS/FAIL line per assertion,
+# nonzero exit if anything failed.
+set -u
+
+BORG_PASS="staging-borg-pass"   # must match run.sh
+BORG_REPO="/var/lib/dbmaintainer/borg-repo"
+DB="/var/lib/learning-app/db.sqlite"
+
+fails=0
+
+check() {
+    local name="$1"
+    shift
+    if "$@" >/dev/null 2>&1; then
+        echo "PASS ${name}"
+    else
+        echo "FAIL ${name}"
+        fails=$((fails + 1))
+    fi
+}
+
+http_code() {
+    curl -k -s -o /dev/null -w '%{http_code}' "$@"
+}
+
+# Units under their production sandboxes.
+for unit in nginx.service couchdb.service learning-app-run.service \
+            learning-app-restart.path learning-app-certbot.timer \
+            learning-app-backup-db.timer; do
+    check "unit active: ${unit}" systemctl is-active --quiet "${unit}"
+done
+
+# nginx answers inside the container (self-signed cert, hence -k).
+check "nginx: https:// answers 200" \
+    test "$(http_code --resolve sprecha.de:443:127.0.0.1 https://sprecha.de/)" = 200
+check "nginx: http:// redirects 301" \
+    test "$(http_code --resolve sprecha.de:80:127.0.0.1 http://sprecha.de/)" = 301
+
+# Auth boundary: no cookie means 401 — at the app and through nginx's
+# auth_request on /db/ (nginx marks /auth/check itself `internal`).
+check "app: /auth/check without cookie is 401" \
+    test "$(http_code http://127.0.0.1:8083/auth/check)" = 401
+check "nginx: /db/ without cookie is 401" \
+    test "$(http_code --resolve sprecha.de:443:127.0.0.1 https://sprecha.de/db/anything)" = 401
+
+# Migrations ran against the configured database path.
+check "migrations: schema_migrations has rows" \
+    bash -c "test \"\$(sqlite3 ${DB} 'SELECT count(*) FROM schema_migrations;')\" -ge 1"
+
+# Adoption (#209): the legacy /opt/learning-app/app.db pre-placed before the
+# first service start must have moved into the configured path.
+check "adoption: database-adopted in the journal" \
+    bash -c 'journalctl -u learning-app-run.service --no-pager | grep -q database-adopted'
+check "adoption: marker row survived the move" \
+    bash -c "test \"\$(sqlite3 ${DB} 'SELECT note FROM staging_marker;' 2>/dev/null)\" = legacy"
+check "adoption: legacy file retired" \
+    bash -c 'test ! -e /opt/learning-app/app.db'
+
+# Backup through the real unit (its sandbox included), against the local
+# borg repository run.sh initialized.
+check "backup: learning-app-backup-db.service runs clean" \
+    systemctl start learning-app-backup-db.service
+
+borg_ls() {
+    runuser -u dbmaintainer -- env \
+        BORG_REPO="${BORG_REPO}" BORG_PASSPHRASE="${BORG_PASS}" borg "$@"
+}
+archive="$(borg_ls list --short 2>/dev/null | tail -1)"
+check "backup: archive exists" test -n "${archive}"
+contents="$(borg_ls list "::${archive}" 2>/dev/null)"
+check "backup: archive carries the sqlite store" \
+    bash -c "grep -q 'db.sqlite' <<< '${contents}'"
+check "backup: archive carries the couchdb store" \
+    bash -c "grep -q 'var/lib/couchdb' <<< '${contents}'"
+
+if [ "${fails}" -gt 0 ]; then
+    echo "SMOKE: ${fails} assertion(s) failed"
+    exit 1
+fi
+echo "SMOKE: all assertions passed"

--- a/openspec/changes/archive/2026-08-06-staging-container/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-06-staging-container/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-with-adr
+created: 2026-08-06

--- a/openspec/changes/archive/2026-08-06-staging-container/proposal.md
+++ b/openspec/changes/archive/2026-08-06-staging-container/proposal.md
@@ -1,0 +1,13 @@
+# The production shape boots in a container before it boots on the server
+
+## Why
+
+Five infra PRs in one day ended their verification with "proven on the next real deploy" (#199, #200, #209, #211, plus the deploy transport), and the #168 class of bug lived for months because nothing exists between "dev from source" and production. ADR-0010 names the missing rung: a systemd container built from the actual deb, answering "does the production shape hold?" in minutes.
+
+## What changes
+
+`infra/staging/` gains a runnable rung: `run.sh` builds the deb exactly as CI does, boots a systemd container (Ubuntu noble, the deb's real target family), stages the credentials an operator would create, pre-places a legacy `app.db`, installs the deb, delivers the jar the runbook way, and runs `smoke.sh` — one PASS/FAIL line per claim those PRs previously shipped as checklists: units active under their sandboxes, nginx answering, the auth boundary, migrations, #209's adoption, #211's backup archive carrying both stores. Certbot and remote borg stay dry; the kernel is shared — rung 3 (#215) owns reality.
+
+## Impact
+
+New `infra/staging/` (Dockerfile, run.sh, smoke.sh, README.md); no production files change. New capability spec `staging-environment`. CI wiring is a separate decision per #214.

--- a/openspec/changes/archive/2026-08-06-staging-container/specs/staging-environment/spec.md
+++ b/openspec/changes/archive/2026-08-06-staging-container/specs/staging-environment/spec.md
@@ -1,0 +1,21 @@
+# staging-environment Specification
+
+## ADDED Requirements
+
+### Requirement: The packaged shape is verifiable without a server
+A staging run SHALL build the infra deb exactly as CI builds it, install it inside a systemd container, and verify the resulting shape by script: services under their production sandboxes, nginx answering, the authentication boundary, migrations against the configured database path, legacy database adoption, and a backup archive carrying both stores. Each assertion SHALL report PASS or FAIL on its own line and the run SHALL exit nonzero when any assertion fails.
+
+#### Scenario: An infra change before merge
+- **WHEN** `infra/staging/run.sh` runs against the working tree
+- **THEN** the actual deb installs in a booted systemd container and every smoke assertion reports PASS or FAIL, with a nonzero exit on any FAIL
+
+#### Scenario: A deliberately broken unit
+- **WHEN** a sandbox directive the service depends on is removed (e.g. a ReadWritePaths)
+- **THEN** the run reports the failure instead of green
+
+### Requirement: The container rung stays honest about its limits
+The staging container SHALL NOT contact production systems or real credential stores: certbot never issues, borg targets a local repository, all secrets are test-only values, and the kernel is the host's. Claims beyond the shape — real TLS, remote backup, multi-day behavior — SHALL remain with the metal rung (ADR-0010).
+
+#### Scenario: Reading a staging run's result
+- **WHEN** the smoke passes
+- **THEN** what is proven is the packaged shape — install, boot, sandboxes, data flow — and nothing about production reality

--- a/openspec/changes/archive/2026-08-06-staging-container/tasks.md
+++ b/openspec/changes/archive/2026-08-06-staging-container/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+- [x] 1. Deb built byte-for-byte the way infra-checks.yml builds it
+- [x] 2. systemd container boots on this docker daemon; incantation recorded in run.sh and README
+- [x] 3. Credentials staged via systemd-creds inside the container; OpenRouter gate exercised (postinst refuses to start the app without the key)
+- [x] 4. smoke.sh: units, nginx, auth 401, migrations, adoption journal + marker row, backup archive with both stores — PASS/FAIL per line, nonzero exit on failure
+- [x] 5. Real run; output recorded in the PR, honest reds included

--- a/openspec/specs/staging-environment/spec.md
+++ b/openspec/specs/staging-environment/spec.md
@@ -1,0 +1,23 @@
+# staging-environment Specification
+
+## Purpose
+TBD - created by archiving change staging-container. Update Purpose after archive.
+## Requirements
+### Requirement: The packaged shape is verifiable without a server
+A staging run SHALL build the infra deb exactly as CI builds it, install it inside a systemd container, and verify the resulting shape by script: services under their production sandboxes, nginx answering, the authentication boundary, migrations against the configured database path, legacy database adoption, and a backup archive carrying both stores. Each assertion SHALL report PASS or FAIL on its own line and the run SHALL exit nonzero when any assertion fails.
+
+#### Scenario: An infra change before merge
+- **WHEN** `infra/staging/run.sh` runs against the working tree
+- **THEN** the actual deb installs in a booted systemd container and every smoke assertion reports PASS or FAIL, with a nonzero exit on any FAIL
+
+#### Scenario: A deliberately broken unit
+- **WHEN** a sandbox directive the service depends on is removed (e.g. a ReadWritePaths)
+- **THEN** the run reports the failure instead of green
+
+### Requirement: The container rung stays honest about its limits
+The staging container SHALL NOT contact production systems or real credential stores: certbot never issues, borg targets a local repository, all secrets are test-only values, and the kernel is the host's. Claims beyond the shape — real TLS, remote backup, multi-day behavior — SHALL remain with the metal rung (ADR-0010).
+
+#### Scenario: Reading a staging run's result
+- **WHEN** the smoke passes
+- **THEN** what is proven is the packaged shape — install, boot, sandboxes, data flow — and nothing about production reality
+


### PR DESCRIPTION
Part of #214.

Rung 2 of ADR-0010: `infra/staging/` boots the actual deb (built byte-for-byte as `infra-checks.yml` builds it) in a systemd container and smokes the production shape. No ports published; everything asserted through `docker exec`.

## Smoke output (real run, this daemon)

```
PASS unit active: nginx.service
PASS unit active: couchdb.service
PASS unit active: learning-app-run.service
PASS unit active: learning-app-restart.path
PASS unit active: learning-app-certbot.timer
PASS unit active: learning-app-backup-db.timer
PASS nginx: https:// answers 200
PASS nginx: http:// redirects 301
PASS app: /auth/check without cookie is 401
PASS nginx: /db/ without cookie is 401
PASS migrations: schema_migrations has rows
FAIL adoption: database-adopted in the journal
FAIL adoption: marker row survived the move
FAIL adoption: legacy file retired
PASS backup: learning-app-backup-db.service runs clean
PASS backup: archive exists
PASS backup: archive carries the sqlite store
PASS backup: archive carries the couchdb store
SMOKE: 3 assertion(s) failed
```

The postinst OpenRouter gate was also exercised: without the key credential the first install refuses to start `learning-app-run`; a second (idempotent) install with the key staged enables it.

## The three FAILs are a real catch, not a script bug

`tmpfiles.d/learning-app.conf` ships `f /var/lib/learning-app/db.sqlite 0660 webapp webapp -` (GH-64 era), so postinst pre-creates an **empty** file at the configured path before the app ever starts. #209's adoption then takes its no-clobber branch and strands the legacy database. Container evidence:

```
ERROR EVENT ... core[91,9] ::legacy-database-left-behind
-rw-r--r-- webapp webapp  8192 /opt/learning-app/app.db      <- marker row still here
-rw-rw---- ...           77824 /var/lib/learning-app/db.sqlite <- fresh empty schema
```

The same empty file exists on production (created by the same tmpfiles line on every install since GH-64), so the not-yet-deployed #209 would strand the accounts on its first real deploy. Exactly the class of bug this rung exists to catch — details commented on #209. Once that lands, this smoke goes green.

## systemd-in-docker incantation (recorded per ADR-0010)

1. PID 1 dies with "Failed to create /init.scope control group" under the default private cgroupns → `--cgroupns=host -v /sys/fs/cgroup:/sys/fs/cgroup:rw --tmpfs /run --tmpfs /run/lock`.
2. Unit sandboxes die with "Failed to keep CAP_SYS_ADMIN" (status=217/USER) → `--cap-add=SYS_ADMIN --security-opt seccomp=unconfined --security-opt apparmor=unconfined`.
3. The subtle one: units start but `/run/credentials/<unit>` is silently empty — docker leaves mounts private and systemd-in-a-container skips its "remount / rshared" boot step, so the credential tmpfs is MS_MOVEd into an unobserved namespace → `mount --make-rshared /` after boot. `--privileged` does **not** fix this and is not needed at all.

`systemd-creds encrypt --with-key=host` works inside the container, so postinst's encrypted-credential flow runs for real.

## Also observed (footnotes, no action taken here)

- `learning-app-run` (User=webapp) and `learning-app-backup-db` (User=dbmaintainer) share `StateDirectory=learning-app`; every service start rechowns the whole state dir to its own user, so `db.sqlite` ownership ping-pongs between backups and app restarts. Self-heals on each start today, but it is accidental.
- `deps.edn`'s `:build` alias pins tools.build `{:git/tag "v0.10.14" :git/sha "3a3c177"}` — that sha is v0.10.13; a clean gitlibs cache fails `clojure -T:build uber` with "sha and tag point to different commits" (CI passes only via cache).
- Our postinst never restarts CouchDB, so the deb's `10-learning-app.ini` (proxy auth handlers) is not loaded until the next CouchDB restart — true on production too.

What is and is not proven by a green run is written down in `infra/staging/README.md` (certbot dry, local borg with a plaintext test passphrase, shared kernel; reality is #215's rung).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
