### PR TITLE
GH-225 Adopt over the tmpfiles-pre-created empty target

### DIFF
--- a/src/backend/core.clj
+++ b/src/backend/core.clj
@@ -85,6 +85,11 @@
    leftover is the operator's decision."
   [^java.io.File legacy {:keys [dbname]}]
   (let [target (io/file dbname)]
+    ;; systemd-tmpfiles pre-creates the target as an empty file (#225), and an
+    ;; empty file is not data: adopting over it loses nothing, refusing over
+    ;; it strands the accounts. Only a non-empty target earns the refusal.
+    (when (and (.exists target) (zero? (.length target)))
+      (.delete target))
     (when (and (not= (.getCanonicalPath legacy) (.getCanonicalPath target))
                (.exists legacy))
       (if (.exists target)

--- a/test/backend/core_test.clj
+++ b/test/backend/core_test.clj
@@ -175,3 +175,13 @@
           db  (doto (File. dir "app.db") (spit "dev-bytes"))]
       (#'sut/adopt-database! db {:dbname (.getPath db)})
       (is (= "dev-bytes" (slurp db))))))
+
+
+(deftest an-empty-pre-created-target-does-not-block-adoption
+  (testing "systemd-tmpfiles pre-creates the target as a zero-length file (#225)"
+    (let [dir    (temp-dir)
+          legacy (doto (File. dir "app.db") (spit "real-bytes"))
+          target (doto (File. dir "db.sqlite") (spit ""))]
+      (#'sut/adopt-database! legacy {:dbname (.getPath target)})
+      (is (= "real-bytes" (slurp target)) "adopted over the empty placeholder")
+      (is (not (.exists legacy))))))


### PR DESCRIPTION
Closes #225.

The #214 container smoke caught this before any deploy: the deb's tmpfiles line pre-creates an empty `/var/lib/learning-app/db.sqlite`, #209's no-clobber check treated it as data and refused adoption — the app would start on a fresh empty schema with accounts stranded in `/opt`. Production has the same pre-created file, so current master must not deploy without this.

Fix: a zero-length target is deleted before the check; a non-empty target still refuses (rollback safety intact). New test pins it; 23 backend tests green. The reflection warnings in the run are master's, fixed by the open #221.

Re-running #224's container smoke after merge should flip its 3 FAILs to PASS — that's the end-to-end confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)