### PR TITLE
GH-227 align tools.build sha with tag v0.10.14

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -23,7 +23,7 @@
            :test  {:extra-paths ["test"]}
 
            :build {:deps       {org.clojure/clojure           {:mvn/version "1.12.4"}
-                                io.github.clojure/tools.build {:git/tag "v0.10.14" :git/sha "3a3c177"}}
+                                io.github.clojure/tools.build {:git/tag "v0.10.14" :git/sha "1176afd"}}
                    :ns-default build}
 
            :dictionary {:deps       {dictionary/dictionary {:local/root "tools/dictionary"}}

--- a/openspec/changes/archive/2026-08-06-fix-tools-build-coordinate/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-06-fix-tools-build-coordinate/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-with-adr
+created: 2026-08-06

--- a/openspec/changes/archive/2026-08-06-fix-tools-build-coordinate/proposal.md
+++ b/openspec/changes/archive/2026-08-06-fix-tools-build-coordinate/proposal.md
@@ -1,0 +1,13 @@
+# The :build alias resolves on a clean cache
+
+## Why
+
+`deps.edn`'s `:build` alias pins tools.build `:git/tag "v0.10.14"` with `:git/sha "3a3c177"` — the tag object sha of v0.10.13 (#227, found by the #214 container run). Machines with a warm gitlibs cache resolve by sha and work; a clean cache fails the build.
+
+## What changes
+
+Align the sha with the tag: v0.10.14's commit is `1176afd38dc39cb1880bd990d85718d4a61e194d`, so the coordinate becomes `:git/sha "1176afd"`. Audit the other tag+sha pair in the repo (cognitect-labs/test-runner v0.5.1 / `dfb30dd` in `tools/dictionary/deps.edn`) — it is consistent, no change.
+
+## Impact
+
+`deps.edn` only. Verified by `clojure -T:build uber` against a fresh `:mvn/local-repo` and a fresh `GITLIBS`.

--- a/openspec/changes/archive/2026-08-06-fix-tools-build-coordinate/specs/backend-configuration/spec.md
+++ b/openspec/changes/archive/2026-08-06-fix-tools-build-coordinate/specs/backend-configuration/spec.md
@@ -1,0 +1,14 @@
+# backend-configuration Specification
+
+## ADDED Requirements
+
+### Requirement: Git dependency coordinates are internally consistent
+Every `:git/tag` + `:git/sha` coordinate in the repository SHALL name the same commit: the sha SHALL be a prefix of the commit the tag points to. A coordinate SHALL be proven by resolving it with cold dependency caches, not only on machines whose caches already hold the commit.
+
+#### Scenario: A pinned git dependency is bumped
+- **WHEN** a `:git/tag` is changed in any `deps.edn`
+- **THEN** the paired `:git/sha` is updated to the commit that tag dereferences to, and the build resolves from a clean gitlibs and maven cache
+
+#### Scenario: Tag and sha disagree
+- **WHEN** a coordinate pins a tag with the sha of a different commit
+- **THEN** a clean-cache build fails, and the fix is aligning the sha with the tag

--- a/openspec/changes/archive/2026-08-06-fix-tools-build-coordinate/tasks.md
+++ b/openspec/changes/archive/2026-08-06-fix-tools-build-coordinate/tasks.md
@@ -1,0 +1,5 @@
+# Tasks
+
+- [x] 1. Fetch the real commit sha of tools.build tag v0.10.14 via GitHub API; fix `deps.edn`
+- [x] 2. Audit every other `:git/tag` + `:git/sha` pair in the repo the same way (only `tools/dictionary/deps.edn` test-runner v0.5.1 — consistent)
+- [x] 3. Prove resolution from cold caches: `GITLIBS=<fresh> clojure -Sdeps '{:mvn/local-repo "<fresh>"}' -T:build uber`

--- a/openspec/specs/backend-configuration/spec.md
+++ b/openspec/specs/backend-configuration/spec.md
@@ -40,3 +40,14 @@ Every application environment variable SHALL be named `LEARNING_APP__XXX` — do
 - **WHEN** the backup unit runs `backup.sh`
 - **THEN** the database and backup paths flow through `LEARNING_APP__DB_PATH` and `LEARNING_APP__DB_BACKUP_PATH`, both wired within the same deb artifact
 
+### Requirement: Git dependency coordinates are internally consistent
+Every `:git/tag` + `:git/sha` coordinate in the repository SHALL name the same commit: the sha SHALL be a prefix of the commit the tag points to. A coordinate SHALL be proven by resolving it with cold dependency caches, not only on machines whose caches already hold the commit.
+
+#### Scenario: A pinned git dependency is bumped
+- **WHEN** a `:git/tag` is changed in any `deps.edn`
+- **THEN** the paired `:git/sha` is updated to the commit that tag dereferences to, and the build resolves from a clean gitlibs and maven cache
+
+#### Scenario: Tag and sha disagree
+- **WHEN** a coordinate pins a tag with the sha of a different commit
+- **THEN** a clean-cache build fails, and the fix is aligning the sha with the tag
+


### PR DESCRIPTION
Closes #227.

`:build` pinned tools.build `:git/tag "v0.10.14"` with `:git/sha "3a3c177"` — the tag object sha of **v0.10.13**. Warm gitlibs caches resolve by sha and hide it; a clean cache fails. Tag v0.10.14 dereferences to commit `1176afd38dc39cb1880bd990d85718d4a61e194d` (gh api, annotated tag → commit), so the coordinate is now `:git/sha "1176afd"`.

Also audited the only other tag+sha pair in the repo: `tools/dictionary/deps.edn` — cognitect-labs/test-runner `v0.5.1` / `dfb30dd` → commit `dfb30dd6605cb6c0efc275e1df1736f6e90d4d73`. Consistent, untouched.

Proof (cold caches force resolution by the corrected coordinate):

```
$ GITLIBS=/tmp/fresh-gitlibs-227 clojure -Sdeps '{:mvn/local-repo "/tmp/fresh-m2-227"}' -T:build uber
Cleaning target...
Copying resources...
Stamping the service worker version...
Service worker version: 1ce88cd7
Compiling files...
Server stopped
Creating uber file...
Uber file created: target/learning-app.jar
EXIT: 0
```

OpenSpec: `2026-08-06-fix-tools-build-coordinate`, delta on `backend-configuration` (git coordinates internally consistent, proven cold-cache). Validated and archived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)