### PR TITLE
GH-228 single owner for the shared state directory

### DIFF
--- a/infra/production/etc/systemd/system/learning-app-backup-db.service
+++ b/infra/production/etc/systemd/system/learning-app-backup-db.service
@@ -8,8 +8,6 @@ User=dbmaintainer
 # granted to this service only, not to the user account globally.
 SupplementaryGroups=couchdb
 WorkingDirectory=~
-LogsDirectory=learning-app
-StateDirectory=learning-app
 ExecStart=sh -c './backup.sh'
 
 # Environment
@@ -30,12 +28,17 @@ Environment=LEARNING_APP__DB_BACKUP_PATH=/var/backups/learning-app/db.sqlite
 NoNewPrivileges=yes
 PrivateTmp=yes
 ProtectHome=yes
-# Filesystem read-only except ReadWritePaths below. StateDirectory keeps
-# /var/lib/learning-app writable under strict — sqlite3 needs write access to
-# the source -wal/-shm files even when only reading a WAL database.
+# Filesystem read-only except ReadWritePaths below.
 ProtectSystem=strict
 # Local backup target plus borg cache/config/ssh state in the home directory.
-ReadWritePaths=/var/backups/learning-app /var/lib/dbmaintainer
+# /var/lib/learning-app is deliberately ReadWritePaths, NOT StateDirectory:
+# sqlite3 needs write access to the source journal/-wal/-shm files even when
+# only reading the database, but StateDirectory would rechown the whole state
+# tree to dbmaintainer on every backup run (learning-app-run owns it as
+# webapp). The directory is group-writable for group webapp (see tmpfiles.d
+# and StateDirectoryMode in learning-app-run.service); dbmaintainer is a
+# member of that group.
+ReadWritePaths=/var/backups/learning-app /var/lib/dbmaintainer /var/lib/learning-app
 PrivateDevices=yes
 # Kernel interfaces read-only or unreachable.
 ProtectKernelTunables=yes

--- a/infra/production/etc/systemd/system/learning-app-run.service
+++ b/infra/production/etc/systemd/system/learning-app-run.service
@@ -7,7 +7,14 @@ Type=simple
 User=webapp
 WorkingDirectory=/opt/learning-app
 LogsDirectory=learning-app
+# Sole owner of the state directory: no other unit may declare
+# StateDirectory=learning-app, or systemd rechowns the tree to that unit's
+# user on its every start and ownership ping-pongs (GH-228). Setgid
+# group-writable so group webapp members (dbmaintainer, for backups) can
+# create sqlite journal/-wal/-shm files next to db.sqlite without owning the
+# directory. Matches the tmpfiles.d entry.
 StateDirectory=learning-app
+StateDirectoryMode=2770
 Restart=always
 RestartSec=10
 ExecStart=sh -c 'if [ -z "${OPENROUTER_API_KEY:-}" ] && [ -n "${OPENROUTER_API_KEY_PATH:-}" ] && [ -f "${OPENROUTER_API_KEY_PATH}" ]; then export OPENROUTER_API_KEY="$(cat "${OPENROUTER_API_KEY_PATH}")"; fi; if [ -z "${LEARNING_APP_DB_AUTH_SECRET:-}" ] && [ -n "${LEARNING_APP_DB_AUTH_SECRET_PATH:-}" ] && [ -f "${LEARNING_APP_DB_AUTH_SECRET_PATH}" ]; then export LEARNING_APP_DB_AUTH_SECRET="$(cat "${LEARNING_APP_DB_AUTH_SECRET_PATH}")"; fi; java -jar /opt/learning-app/learning-app.jar'

--- a/infra/production/etc/tmpfiles.d/learning-app.conf
+++ b/infra/production/etc/tmpfiles.d/learning-app.conf
@@ -1,6 +1,6 @@
 #Type Path                                       Mode User         Group        Age Argument
 d     /opt/learning-app/dictionary               2775 deployer     webapp       -
-d     /var/lib/learning-app/                     0750 webapp       webapp       -
+d     /var/lib/learning-app/                     2770 webapp       webapp       -
 d     /var/lib/learning-app/dictionary           2770 deployer     webapp       -
 f     /var/lib/learning-app/db.sqlite            0660 webapp       webapp       -
 d     /var/lib/dbmaintainer                      0750 dbmaintainer dbmaintainer -

--- a/openspec/changes/archive/2026-08-06-shared-state-dir-ownership/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-06-shared-state-dir-ownership/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-with-adr
+created: 2026-08-06

--- a/openspec/changes/archive/2026-08-06-shared-state-dir-ownership/proposal.md
+++ b/openspec/changes/archive/2026-08-06-shared-state-dir-ownership/proposal.md
@@ -1,0 +1,13 @@
+# One service owns the state directory
+
+## Why
+
+#224's container smoke observed that `learning-app-run` (User=webapp) and `learning-app-backup-db` (User=dbmaintainer) both declare `StateDirectory=learning-app`. systemd rechowns the whole state tree to the starting unit's user whenever the top-level ownership mismatches, so `/var/lib/learning-app` ownership ping-pongs between webapp and dbmaintainer depending on start order. It self-heals only because each start rechowns again; the deployer-owned dictionary directory gets silently rechowned too (GH-228).
+
+## What changes
+
+`learning-app-run` becomes the sole owner of `StateDirectory=learning-app` and pins `StateDirectoryMode=2770` (setgid, group-writable) so group-webapp members keep sqlite journal/-wal/-shm access without owning the tree. `learning-app-backup-db` drops its `StateDirectory` and `LogsDirectory` claims — it only needs the state path writable under `ProtectSystem=strict`, which `ReadWritePaths=/var/lib/learning-app` gives without any ownership semantics; it logs to the journal only. The tmpfiles.d entry for `/var/lib/learning-app` moves to 2770 to match.
+
+## Impact
+
+`infra/production/etc/systemd/system/learning-app-run.service`, `learning-app-backup-db.service`, `etc/tmpfiles.d/learning-app.conf`. Delta on `production-service-hardening`. Proves out in the #214 container smoke.

--- a/openspec/changes/archive/2026-08-06-shared-state-dir-ownership/specs/production-service-hardening/spec.md
+++ b/openspec/changes/archive/2026-08-06-shared-state-dir-ownership/specs/production-service-hardening/spec.md
@@ -1,0 +1,17 @@
+# production-service-hardening Specification
+
+## ADDED Requirements
+
+### Requirement: Each shared systemd resource directory has exactly one owning unit
+
+A directory managed through `StateDirectory=` or `LogsDirectory=` SHALL be declared by exactly one unit — the one whose user owns it. Any other unit needing access SHALL get it through `ReadWritePaths=` plus group membership, never by declaring the same directory, so that no service start rechowns a tree another service depends on.
+
+#### Scenario: Backup runs, then the app restarts
+
+- **WHEN** learning-app-backup-db runs and learning-app-run restarts afterwards, in either order
+- **THEN** `/var/lib/learning-app` stays owned by webapp:webapp throughout, and the backup reads and snapshots the database via group permissions
+
+#### Scenario: The database is quiescent when the backup fires
+
+- **WHEN** learning-app-backup-db runs while learning-app-run is stopped and no journal/-wal/-shm files exist
+- **THEN** sqlite3 can create them in the setgid group-writable state directory and the backup completes

--- a/openspec/changes/archive/2026-08-06-shared-state-dir-ownership/tasks.md
+++ b/openspec/changes/archive/2026-08-06-shared-state-dir-ownership/tasks.md
@@ -1,0 +1,6 @@
+# Tasks
+
+- [x] 1. Drop StateDirectory/LogsDirectory from learning-app-backup-db.service; add /var/lib/learning-app to ReadWritePaths with the reasoning recorded in the unit
+- [x] 2. Pin StateDirectoryMode=2770 on learning-app-run.service, recorded as the sole owner
+- [x] 3. Align tmpfiles.d /var/lib/learning-app to 2770
+- [x] 4. systemd-analyze verify on both changed units

--- a/openspec/specs/production-service-hardening/spec.md
+++ b/openspec/specs/production-service-hardening/spec.md
@@ -18,3 +18,17 @@ Every learning-app unit with a `[Service]` section SHALL declare a systemd harde
 - **WHEN** `systemd-analyze verify` runs against the units
 - **THEN** no directive is ignored as unparseable — in particular, no inline comments on directive lines
 
+### Requirement: Each shared systemd resource directory has exactly one owning unit
+
+A directory managed through `StateDirectory=` or `LogsDirectory=` SHALL be declared by exactly one unit — the one whose user owns it. Any other unit needing access SHALL get it through `ReadWritePaths=` plus group membership, never by declaring the same directory, so that no service start rechowns a tree another service depends on.
+
+#### Scenario: Backup runs, then the app restarts
+
+- **WHEN** learning-app-backup-db runs and learning-app-run restarts afterwards, in either order
+- **THEN** `/var/lib/learning-app` stays owned by webapp:webapp throughout, and the backup reads and snapshots the database via group permissions
+
+#### Scenario: The database is quiescent when the backup fires
+
+- **WHEN** learning-app-backup-db runs while learning-app-run is stopped and no journal/-wal/-shm files exist
+- **THEN** sqlite3 can create them in the setgid group-writable state directory and the backup completes
+


### PR DESCRIPTION
Closes #228.

## Choice: drop the backup's claim, don't split state homes

`learning-app-backup-db` declared `StateDirectory=learning-app` for one reason only (its own comment said so): keeping `/var/lib/learning-app` writable under `ProtectSystem=strict`, because sqlite3 needs to touch journal/-wal/-shm next to the source db even for a read. It has no state of its own there — borg cache/config live in `/var/lib/dbmaintainer`, already `ReadWritePaths`. A separate state home would give it a directory it stores nothing in and leave the write-access need unsolved. So:

- **backup-db**: `StateDirectory` and `LogsDirectory` dropped (it logs to the journal only — same rechown mechanism applied to `/var/log/learning-app`); `/var/lib/learning-app` added to `ReadWritePaths`, which punches through `strict` with zero ownership semantics.
- **run**: sole owner, pins `StateDirectoryMode=2770` — setgid group-writable, so dbmaintainer (member of group `webapp` via sysusers) can create sqlite side files when none exist without owning the tree.
- **tmpfiles.d**: `/var/lib/learning-app` 0750 → 2770 to match; postinst's `systemd-tmpfiles --create` converges existing installs.

## Both start orders

- *backup then app start*: backup no longer declares the directory, nothing rechowns; top dir stays webapp:webapp, so the app's `StateDirectory` sees matching ownership and does **not** recurse — a dbmaintainer-owned `-wal` left behind stays group-webapp rw via setgid and remains usable by the app.
- *app start then backup*: dir is webapp:webapp 2770; backup reads `db.sqlite` (0660, group webapp) and creates/uses side files via group write on the directory. Previously this leg worked only because the backup's own start had rechowned the tree to dbmaintainer.

Side effect fixed for free: the app's recursive rechown no longer periodically flips `/var/lib/learning-app/dictionary` away from its intended `deployer:webapp`.

## Verification

- `systemd-analyze verify` on both changed units: clean, exit 0 (`StateDirectoryMode=2770` parses).
- Reasoning above for both start orders; the app-down backup corner (no `-wal` present, dbmaintainer must create it) is covered by the setgid group-writable mode.
- Not proven live here: the real chown behavior end-to-end is exactly what the #214 container smoke (`infra/staging/run.sh`) exercises — that is where this should be confirmed green.

OpenSpec: delta on `production-service-hardening` (new requirement: one owning unit per shared resource directory), validated and archived in the same commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)