### PR TITLE
GH-229 restart CouchDB in postinst when the shipped ini changed

### DIFF
--- a/infra/production/DEBIAN/postinst
+++ b/infra/production/DEBIAN/postinst
@@ -61,6 +61,23 @@ fi
 # Enable CouchDB and configure admin
 systemctl enable --now couchdb.service
 
+# CouchDB reads local.d only at startup, so a changed 10-learning-app.ini
+# riding the deb would otherwise apply on the next unrelated restart (GH-229).
+# Restart when the shipped content differs from what the last install stamped;
+# repeat installs with the same ini stay restart-free. The restart sits before
+# the wait-loop below, so readiness and admin setup run against the instance
+# that has the shipped config loaded.
+COUCH_INI="/opt/couchdb/etc/local.d/10-learning-app.ini"
+COUCH_INI_STAMP="/var/lib/misc/learning-app-couchdb-ini.sha256"
+if [ -f "${COUCH_INI}" ]; then
+    ini_hash="$(sha256sum "${COUCH_INI}" | cut -d' ' -f1)"
+    if [ ! -f "${COUCH_INI_STAMP}" ] || [ "$(cat "${COUCH_INI_STAMP}")" != "${ini_hash}" ]; then
+        systemctl restart couchdb.service
+        mkdir -p "$(dirname "${COUCH_INI_STAMP}")"
+        echo "${ini_hash}" > "${COUCH_INI_STAMP}"
+    fi
+fi
+
 # Wait for CouchDB to become available
 for i in $(seq 1 30); do
     curl -sf http://127.0.0.1:5984/ >/dev/null && break

--- a/openspec/changes/archive/2026-08-06-couchdb-config-applies-on-install/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-06-couchdb-config-applies-on-install/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-with-adr
+created: 2026-08-06

--- a/openspec/changes/archive/2026-08-06-couchdb-config-applies-on-install/proposal.md
+++ b/openspec/changes/archive/2026-08-06-couchdb-config-applies-on-install/proposal.md
@@ -1,0 +1,13 @@
+# The deb's CouchDB config applies on install, not on the next accident
+
+## Why
+
+#224's container smoke observed that postinst only ever `enable --now`s CouchDB. The deb ships `/opt/couchdb/etc/local.d/10-learning-app.ini` (proxy auth handlers), but CouchDB reads `local.d` at startup — so on an upgrade where CouchDB is already running, a changed ini rides the deb and takes effect only on the next unrelated restart. True on production today (GH-229).
+
+## What changes
+
+postinst hashes the shipped ini against a stamp from the previous install and restarts `couchdb.service` when they differ, updating the stamp. The restart sits between `enable --now` and the existing wait-loop, so readiness and admin configuration run against the instance that has the shipped config loaded. Same ini, no restart — repeat installs stay idempotent.
+
+## Impact
+
+`infra/production/DEBIAN/postinst` only; stamp lives in `/var/lib/misc/learning-app-couchdb-ini.sha256`. Delta on `deploy-pipeline`. Proves out in the #214 container smoke.

--- a/openspec/changes/archive/2026-08-06-couchdb-config-applies-on-install/specs/deploy-pipeline/spec.md
+++ b/openspec/changes/archive/2026-08-06-couchdb-config-applies-on-install/specs/deploy-pipeline/spec.md
@@ -1,0 +1,17 @@
+# deploy-pipeline Specification
+
+## ADDED Requirements
+
+### Requirement: Configuration shipped in the deb is in effect when postinst finishes
+
+When the deb ships configuration that a running daemon reads only at startup, postinst SHALL restart that daemon if and only if the shipped content changed since the previous install, and SHALL do so before any postinst step that depends on the daemon being ready. Installs that ship unchanged content SHALL NOT restart the daemon.
+
+#### Scenario: An upgrade changes the CouchDB ini
+
+- **WHEN** the deb installs over a running CouchDB and the shipped `10-learning-app.ini` differs from the content stamped at the previous install
+- **THEN** postinst restarts couchdb.service before its readiness wait and admin configuration, and the new configuration is live when postinst exits
+
+#### Scenario: A re-install ships the same ini
+
+- **WHEN** the deb installs and the shipped ini matches the stamp
+- **THEN** CouchDB is not restarted

--- a/openspec/changes/archive/2026-08-06-couchdb-config-applies-on-install/tasks.md
+++ b/openspec/changes/archive/2026-08-06-couchdb-config-applies-on-install/tasks.md
@@ -1,0 +1,5 @@
+# Tasks
+
+- [x] 1. Hash-stamped conditional CouchDB restart in postinst, placed before the readiness wait-loop
+- [x] 2. Idempotence: second install with an unchanged ini performs no restart
+- [x] 3. bash -n on postinst

--- a/openspec/specs/deploy-pipeline/spec.md
+++ b/openspec/specs/deploy-pipeline/spec.md
@@ -29,3 +29,17 @@ The deploy pipeline SHALL remove leftover temp jars in `/opt/learning-app` after
 - **THEN** the stale temp jar is deleted
 - **AND** temp jars younger than one hour are left alone
 
+### Requirement: Configuration shipped in the deb is in effect when postinst finishes
+
+When the deb ships configuration that a running daemon reads only at startup, postinst SHALL restart that daemon if and only if the shipped content changed since the previous install, and SHALL do so before any postinst step that depends on the daemon being ready. Installs that ship unchanged content SHALL NOT restart the daemon.
+
+#### Scenario: An upgrade changes the CouchDB ini
+
+- **WHEN** the deb installs over a running CouchDB and the shipped `10-learning-app.ini` differs from the content stamped at the previous install
+- **THEN** postinst restarts couchdb.service before its readiness wait and admin configuration, and the new configuration is live when postinst exits
+
+#### Scenario: A re-install ships the same ini
+
+- **WHEN** the deb installs and the shipped ini matches the stamp
+- **THEN** CouchDB is not restarted
+


### PR DESCRIPTION
Closes #229.

## Choice: sha256 stamp, restart only on change

dpkg gives postinst no signal about whether a conffile-like payload actually changed (`/opt/couchdb/etc/local.d/10-learning-app.ini` is a plain payload file, not a dpkg conffile, so there is no `ucf`/conffile machinery to lean on). Simplest honest means: postinst hashes the shipped ini and compares against a stamp from the previous install (`/var/lib/misc/learning-app-couchdb-ini.sha256`); on mismatch it restarts `couchdb.service` and rewrites the stamp.

Properties:

- **Idempotent**: re-running the install with the same ini finds a matching stamp and performs no restart.
- **Ordering preserved**: the restart sits between `systemctl enable --now couchdb.service` and the existing 30-second readiness wait-loop, so the wait and the admin/dictionary-db configuration run against the restarted instance — the postinst flow that #224 exercised still holds.
- **First stamped install restarts once** (stamp missing counts as changed). Deliberate: on hosts where CouchDB predates the stamp — production included — that one restart is exactly what loads the shipped proxy-auth handlers that today are only loaded by accident.
- Stamp update sits after the restart under `set -e`, so a failed restart leaves the stamp unwritten and the next install retries.

## Verification

- `bash -n infra/production/DEBIAN/postinst` clean (shellcheck not available on this machine).
- Honestly: this is syntax plus reasoning only. The behavioral proof — upgrade over a running CouchDB restarts it, second install does not, admin setup still lands — is exactly what the #214 container smoke (`infra/staging/run.sh`) exists for; I did not run it here (the docker daemon is in use by other work).

OpenSpec: delta on `deploy-pipeline` (new requirement: config shipped in the deb is in effect when postinst finishes), validated and archived in the same commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)