### PR TITLE
GH-217 phase 2a: jar reads secret under both names

### DIFF
--- a/openspec/changes/archive/2026-08-06-secret-dual-read/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-06-secret-dual-read/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-with-adr
+created: 2026-08-06

--- a/openspec/changes/archive/2026-08-06-secret-dual-read/proposal.md
+++ b/openspec/changes/archive/2026-08-06-secret-dual-read/proposal.md
@@ -1,0 +1,20 @@
+# Finish LEARNING_APP__ env naming — phase 2a, secret dual read
+
+## Why
+
+`LEARNING_APP_DB_AUTH_SECRET` is the sharp rename in #217: the name is exported by the systemd unit (ships in the deb) and read by the jar — two deploy artifacts. A naive rename opens a window where the packaged app throws at boot. The rename must be transitional: this release makes the jar read both names, so the later unit rename (phase 2b) cannot brick a boot in either deploy order.
+
+## What Changes
+
+- `src/backend/core.clj`: the secret resolves through a pure function over an env map — prefers `LEARNING_APP__DB_AUTH_SECRET`, falls back to `LEARNING_APP_DB_AUTH_SECRET`, then the checkout well-known value; the packaged boot-refusal message names the new variable.
+- The old-name fallback is transition scaffolding, removed in phase 2c after the deb rename deploys; #217 tracks the removal.
+- **Out of scope**: the unit's `Environment=` / ExecStart export and `LEARNING_APP_DB_AUTH_SECRET_PATH` — deb territory, phase 2b. The jar-side dual read alone makes old-unit + new-jar work: the old unit exports the old name, the jar falls back to it.
+
+## Capabilities
+
+- **New Capabilities**: none.
+- **Modified Capabilities**: `backend-configuration` — the naming-convention requirement gains the dual-read transition scenarios for the secret.
+
+## Impact
+
+`src/backend/core.clj`, `test/backend/core_test.clj`. No infra files. Behavior is identical for any environment that sets either name; only a packaged boot with neither name changes its error text.

--- a/openspec/changes/archive/2026-08-06-secret-dual-read/specs/backend-configuration/spec.md
+++ b/openspec/changes/archive/2026-08-06-secret-dual-read/specs/backend-configuration/spec.md
@@ -1,0 +1,28 @@
+## MODIFIED Requirements
+
+### Requirement: Environment variables follow the LEARNING_APP__ prefix convention
+Every application environment variable SHALL be named `LEARNING_APP__XXX` — double underscore between the app prefix and the variable name. Legacy single-underscore names SHALL NOT be read, with one transitional exception: a rename that spans more than one deploy artifact SHALL ship as a dual-read transition — the reader prefers the new name and falls back to the old — before the old name is dropped. During the `LEARNING_APP_DB_AUTH_SECRET` transition (#217 phase 2a) the jar SHALL prefer `LEARNING_APP__DB_AUTH_SECRET`, fall back to the old name, and name the new variable when refusing to boot; the fallback SHALL be removed (phase 2c) once the unit's rename (phase 2b) is deployed.
+
+#### Scenario: Double-underscore name is honored
+- **WHEN** the backend starts with `LEARNING_APP__PORT=9999`
+- **THEN** it listens on 9999
+
+#### Scenario: Legacy single-underscore name is ignored
+- **WHEN** the backend starts with only `LEARNING_APP_PORT=9999` set
+- **THEN** it listens on the default port 8083
+
+#### Scenario: Backup pipeline uses the convention
+- **WHEN** the backup unit runs `backup.sh`
+- **THEN** the database and backup paths flow through `LEARNING_APP__DB_PATH` and `LEARNING_APP__DB_BACKUP_PATH`, both wired within the same deb artifact
+
+#### Scenario: Old unit, new jar — the secret still resolves
+- **WHEN** only `LEARNING_APP_DB_AUTH_SECRET` is set, as the pre-rename unit exports it
+- **THEN** the jar signs with that value
+
+#### Scenario: Both secret names set
+- **WHEN** both `LEARNING_APP__DB_AUTH_SECRET` and `LEARNING_APP_DB_AUTH_SECRET` are set
+- **THEN** the new name wins
+
+#### Scenario: Packaged app with neither secret name
+- **WHEN** neither name is set outside a source checkout
+- **THEN** boot is refused with an error naming `LEARNING_APP__DB_AUTH_SECRET`

--- a/openspec/changes/archive/2026-08-06-secret-dual-read/tasks.md
+++ b/openspec/changes/archive/2026-08-06-secret-dual-read/tasks.md
@@ -1,0 +1,13 @@
+# Tasks
+
+## 1. Dual read
+
+- [x] 1.1 `configured-db-auth-secret` — pure over an env map: new name, then old name, then checkout fallback, then throw naming `LEARNING_APP__DB_AUTH_SECRET`
+- [x] 1.2 `db-auth-secret` def reads through it with `(System/getenv)`; `running-from-source?` behavior unchanged
+- [x] 1.3 Transition comment names the scaffolding and the phase 2c removal condition
+
+## 2. Verification
+
+- [x] 2.1 Tests: new-only → new; old-only → old; both → new wins; neither + packaged → throw naming the new var; neither + checkout → "secret"
+- [x] 2.2 Backend suite green (28 tests / 56 assertions), zero reflection warnings
+- [x] 2.3 No infra files touched — unit/ExecStart rename is phase 2b (deb artifact)

--- a/openspec/specs/backend-configuration/spec.md
+++ b/openspec/specs/backend-configuration/spec.md
@@ -26,7 +26,7 @@ On startup, before opening the database, the backend SHALL move a database found
 - **THEN** the target wins, nothing is deleted, and the log names both paths for the operator
 
 ### Requirement: Environment variables follow the LEARNING_APP__ prefix convention
-Every application environment variable SHALL be named `LEARNING_APP__XXX` — double underscore between the app prefix and the variable name. Legacy single-underscore names SHALL NOT be read; a rename that spans more than one deploy artifact SHALL ship as a dual-read transition before the old name is dropped.
+Every application environment variable SHALL be named `LEARNING_APP__XXX` — double underscore between the app prefix and the variable name. Legacy single-underscore names SHALL NOT be read, with one transitional exception: a rename that spans more than one deploy artifact SHALL ship as a dual-read transition — the reader prefers the new name and falls back to the old — before the old name is dropped. During the `LEARNING_APP_DB_AUTH_SECRET` transition (#217 phase 2a) the jar SHALL prefer `LEARNING_APP__DB_AUTH_SECRET`, fall back to the old name, and name the new variable when refusing to boot; the fallback SHALL be removed (phase 2c) once the unit's rename (phase 2b) is deployed.
 
 #### Scenario: Double-underscore name is honored
 - **WHEN** the backend starts with `LEARNING_APP__PORT=9999`
@@ -39,6 +39,18 @@ Every application environment variable SHALL be named `LEARNING_APP__XXX` — do
 #### Scenario: Backup pipeline uses the convention
 - **WHEN** the backup unit runs `backup.sh`
 - **THEN** the database and backup paths flow through `LEARNING_APP__DB_PATH` and `LEARNING_APP__DB_BACKUP_PATH`, both wired within the same deb artifact
+
+#### Scenario: Old unit, new jar — the secret still resolves
+- **WHEN** only `LEARNING_APP_DB_AUTH_SECRET` is set, as the pre-rename unit exports it
+- **THEN** the jar signs with that value
+
+#### Scenario: Both secret names set
+- **WHEN** both `LEARNING_APP__DB_AUTH_SECRET` and `LEARNING_APP_DB_AUTH_SECRET` are set
+- **THEN** the new name wins
+
+#### Scenario: Packaged app with neither secret name
+- **WHEN** neither name is set outside a source checkout
+- **THEN** boot is refused with an error naming `LEARNING_APP__DB_AUTH_SECRET`
 
 ### Requirement: Git dependency coordinates are internally consistent
 Every `:git/tag` + `:git/sha` coordinate in the repository SHALL name the same commit: the sha SHALL be a prefix of the commit the tag points to. A coordinate SHALL be proven by resolving it with cold dependency caches, not only on machines whose caches already hold the commit.

--- a/src/backend/core.clj
+++ b/src/backend/core.clj
@@ -54,13 +54,24 @@
   (some? (io/resource "core.clj")))
 
 
+(defn- configured-db-auth-secret
+  [env from-source?]
+  ;; GH-217 phase 2a: the unit still exports the old single-underscore name,
+  ;; and unit (deb) and reader (jar) ship in different artifacts — so the jar
+  ;; reads both, preferring the new name. The old-name fallback is transition
+  ;; scaffolding: remove it in phase 2c, once the deb's rename (phase 2b) is
+  ;; deployed. #217 tracks the removal.
+  (or (get env "LEARNING_APP__DB_AUTH_SECRET")
+      (get env "LEARNING_APP_DB_AUTH_SECRET")
+      (when from-source? "secret")
+      (throw (ex-info "LEARNING_APP__DB_AUTH_SECRET is required outside a source checkout" {}))))
+
+
 (def db-auth-secret
   "Signs the proxy-auth headers `/auth/check` hands to CouchDB. A checkout may
    fall back to a well-known value; a packaged app may not, and says so instead
    of signing with something an attacker can guess."
-  (or (System/getenv "LEARNING_APP_DB_AUTH_SECRET")
-      (when running-from-source? "secret")
-      (throw (ex-info "LEARNING_APP_DB_AUTH_SECRET is required outside a source checkout" {}))))
+  (configured-db-auth-secret (System/getenv) running-from-source?))
 
 
 ;;

--- a/test/backend/core_test.clj
+++ b/test/backend/core_test.clj
@@ -105,6 +105,32 @@
         "build.clj writes the service worker version under a different name than core.clj reads")))
 
 
+(deftest the-new-secret-name-is-read
+  (is (= "new" (#'sut/configured-db-auth-secret {"LEARNING_APP__DB_AUTH_SECRET" "new"} false))))
+
+
+(deftest the-old-secret-name-still-works-until-the-unit-renames
+  (is (= "old" (#'sut/configured-db-auth-secret {"LEARNING_APP_DB_AUTH_SECRET" "old"} false))))
+
+
+(deftest the-new-secret-name-wins-when-both-are-set
+  (is (= "new"
+         (#'sut/configured-db-auth-secret
+          {"LEARNING_APP_DB_AUTH_SECRET"  "old"
+           "LEARNING_APP__DB_AUTH_SECRET" "new"}
+          false))))
+
+
+(deftest a-packaged-app-without-a-secret-refuses-to-start
+  (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                        #"LEARNING_APP__DB_AUTH_SECRET"
+                        (#'sut/configured-db-auth-secret {} false))))
+
+
+(deftest a-checkout-falls-back-to-the-well-known-secret
+  (is (= "secret" (#'sut/configured-db-auth-secret {} true))))
+
+
 (deftest a-recycled-id-is-refused-not-inherited
   (testing "a userdb left by a previous owner of the id blocks provisioning"
     (let [db (migrated-db)]


### PR DESCRIPTION
Part of #217. Phases 2b (deb unit rename) and 2c (fallback removal) remain.

## What

`db-auth-secret` now resolves through a pure `configured-db-auth-secret` over an env map:

1. `LEARNING_APP__DB_AUTH_SECRET` (new name) wins,
2. `LEARNING_APP_DB_AUTH_SECRET` (old name) as fallback,
3. checkout well-known value (`running-from-source?` unchanged),
4. else throw — the message now names the NEW variable.

The old-name fallback is transition scaffolding; the in-code comment names the removal condition (phase 2c, after the deb rename deploys). #217 tracks removal.

## Why no infra changes here

`LEARNING_APP_DB_AUTH_SECRET_PATH` and the unit's ExecStart export are deb territory — phase 2b. The jar-side dual read alone makes old-unit + new-jar work in either deploy order: the old unit exports the old name and the jar falls back to it; a renamed unit exports the new name and the jar prefers it.

## Proof

Backend suite green: 28 tests / 56 assertions, zero reflection warnings. New tests cover new-only, old-only, both (new wins), neither+packaged (throw names new var), neither+checkout. No dev stand / docker used.

OpenSpec: `backend-configuration` requirement extended with the dual-read scenarios; validated strict and archived as `2026-08-06-secret-dual-read`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)