### PR TITLE
GH-237 Extract uberjar build into reusable workflow

### DIFF
--- a/.github/workflows/build-jar.yml
+++ b/.github/workflows/build-jar.yml
@@ -1,0 +1,75 @@
+name: Build App Jar
+
+# The single home of the jar recipe (#237). deploy-app.yml and
+# staging-smoke.yml both call this workflow and consume the artifact it
+# uploads, so the recipe cannot drift between them.
+on:
+  workflow_call:
+    outputs:
+      jar-sha256:
+        description: sha256 of target/learning-app.jar, recorded at build time.
+        value: ${{ jobs.build.outputs.jar-sha256 }}
+
+jobs:
+  build:
+    name: Build app jar
+    runs-on: ubuntu-latest
+    outputs:
+      jar-sha256: ${{ steps.jar.outputs.sha256 }}
+    steps:
+      - uses: actions/checkout@v7.0.1
+
+      - uses: actions/setup-java@v5.7.0
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - uses: DeLaGuardo/setup-clojure@13.6.1
+        with:
+          cli: latest
+
+      - id: cache-clojure
+        uses: actions/cache/restore@v6.1.0
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+            ~/.deps.clj
+          key: clojure-${{ hashFiles('deps.edn', 'shadow-cljs.edn') }}
+          restore-keys: |
+            clojure-
+
+      - run: npm ci
+      - run: rm -rf resources/public/js/app
+      - run: npx shadow-cljs release app
+      - run: clojure -T:build uber
+
+      # $GITHUB_OUTPUT is a file GitHub provides per step; `key=value` lines
+      # appended to it become `steps.<id>.outputs.<key>` for later steps:
+      # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
+      - id: jar
+        run: echo "sha256=$(sha256sum target/learning-app.jar | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/cache/save@v6.1.0
+        if: ${{ always() && steps.cache-clojure.outputs.cache-hit != 'true' }}
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+            ~/.deps.clj
+          key: clojure-${{ hashFiles('deps.edn', 'shadow-cljs.edn') }}
+
+      # The artifact is a bus between jobs of one run, not a release channel;
+      # a day of retention is plenty.
+      - uses: actions/upload-artifact@v4.6.2
+        with:
+          name: app-jar
+          path: target/learning-app.jar
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -3,57 +3,23 @@ on:
   workflow_dispatch:
 
 jobs:
-  deployment:
+  build:
     name: Build Server Artifact
+    uses: ./.github/workflows/build-jar.yml
+
+  deployment:
+    name: Deploy Server Artifact
     runs-on: ubuntu-latest
+    needs: build
     environment: deployment
     steps:
-      - uses: actions/checkout@v7.0.1
-
-      - uses: actions/setup-java@v5.7.0
+      - uses: actions/download-artifact@v4.3.0
         with:
-          distribution: temurin
-          java-version: 21
+          name: app-jar
+          path: target
 
-      - uses: actions/setup-node@v7
-        with:
-          node-version: 20
-          cache: npm
-          cache-dependency-path: package-lock.json
-
-      - uses: DeLaGuardo/setup-clojure@13.6.1
-        with:
-          cli: latest
-
-      - id: cache-clojure
-        uses: actions/cache/restore@v6.1.0
-        with:
-          path: |
-            ~/.m2/repository
-            ~/.gitlibs
-            ~/.deps.clj
-          key: clojure-${{ hashFiles('deps.edn', 'shadow-cljs.edn') }}
-
-      - run: npm ci
-      - run: rm -rf resources/public/js/app
-      - run: npx shadow-cljs release app
-      - run: clojure -T:build uber
       # Unique per-run temp name: concurrent deploys never share an upload path.
       - run: cp target/learning-app.jar 'target/learning-app.jar.${{ github.run_id }}.tmp'
-      # $GITHUB_OUTPUT is a file GitHub provides per step; `key=value` lines
-      # appended to it become `steps.<id>.outputs.<key>` for later steps:
-      # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
-      - id: jar
-        run: echo "sha256=$(sha256sum target/learning-app.jar | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
-
-      - uses: actions/cache/save@v6.1.0
-        if: ${{ always() && steps.cache-clojure.outputs.cache-hit != 'true' }}
-        with:
-          path: |
-            ~/.m2/repository
-            ~/.gitlibs
-            ~/.deps.clj
-          key: clojure-${{ hashFiles('deps.edn', 'shadow-cljs.edn') }}
 
       - uses: appleboy/scp-action@v1.0.0
         with:
@@ -71,7 +37,7 @@ jobs:
       - uses: appleboy/ssh-action@v1.2.5
         env:
           JAR_TMP: /opt/learning-app/learning-app.jar.${{ github.run_id }}.tmp
-          JAR_SHA256: ${{ steps.jar.outputs.sha256 }}
+          JAR_SHA256: ${{ needs.build.outputs.jar-sha256 }}
         with:
           host: ${{ secrets.HOST }}
           username: ${{ secrets.USER }}

--- a/.github/workflows/staging-smoke.yml
+++ b/.github/workflows/staging-smoke.yml
@@ -21,55 +21,37 @@ jobs:
         env:
           BASE: ${{ github.event.pull_request.base.sha }}
         run: |
-          if git diff --name-only "$BASE" HEAD | grep -qE '^(infra/|\.github/workflows/staging-smoke\.yml$)'; then
+          if git diff --name-only "$BASE" HEAD | grep -qE '^(infra/|\.github/workflows/(staging-smoke|build-jar)\.yml$)'; then
             echo "relevant=true" >> "$GITHUB_OUTPUT"
           else
             echo "relevant=false" >> "$GITHUB_OUTPUT"
           fi
 
+  # The jar the runbook delivers, built by the shared recipe (#237). A called
+  # workflow inherits nothing implicit, so the needs/if gate lives here: the
+  # build runs exactly when the smoke will.
+  build:
+    name: Build app jar
+    needs: changes
+    if: ${{ needs.changes.outputs.relevant == 'true' }}
+    uses: ./.github/workflows/build-jar.yml
+
   container-smoke:
     name: Container smoke
     runs-on: ubuntu-latest
-    needs: changes
+    needs: [changes, build]
     if: ${{ needs.changes.outputs.relevant == 'true' }}
-    # Jar build ~8 min cold, image build + boot + smoke ~5 min; 20 leaves
-    # headroom without letting a wedged systemd boot hold the runner an hour.
-    timeout-minutes: 20
+    # Image build + boot + smoke ~5 min (the jar build has its own job now);
+    # 15 leaves headroom without letting a wedged systemd boot hold the
+    # runner an hour.
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7.0.1
 
-      - uses: actions/setup-java@v5.7.0
+      - uses: actions/download-artifact@v4.3.0
         with:
-          distribution: temurin
-          java-version: 21
-
-      - uses: actions/setup-node@v7
-        with:
-          node-version: 20
-          cache: npm
-          cache-dependency-path: package-lock.json
-
-      - uses: DeLaGuardo/setup-clojure@13.6.1
-        with:
-          cli: latest
-
-      - id: cache-clojure
-        uses: actions/cache/restore@v6.1.0
-        with:
-          path: |
-            ~/.m2/repository
-            ~/.gitlibs
-            ~/.deps.clj
-          key: clojure-${{ hashFiles('deps.edn', 'shadow-cljs.edn') }}
-          restore-keys: |
-            clojure-
-
-      # The jar the runbook delivers, built the way deploy-app.yml builds it.
-      - name: Build the app jar
-        run: |
-          npm ci
-          npx shadow-cljs release app
-          clojure -T:build uber
+          name: app-jar
+          path: target
 
       # The systemd-in-docker incantation (cgroupns=host, rw cgroup bind,
       # CAP_SYS_ADMIN, unconfined seccomp/apparmor) lives inside run.sh and is
@@ -85,12 +67,3 @@ jobs:
           name: staging-smoke-output
           path: smoke-output.log
           if-no-files-found: ignore
-
-      - uses: actions/cache/save@v6.1.0
-        if: ${{ always() && steps.cache-clojure.outputs.cache-hit != 'true' }}
-        with:
-          path: |
-            ~/.m2/repository
-            ~/.gitlibs
-            ~/.deps.clj
-          key: clojure-${{ hashFiles('deps.edn', 'shadow-cljs.edn') }}

--- a/openspec/changes/archive/2026-08-06-reusable-jar-build/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-06-reusable-jar-build/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-with-adr
+created: 2026-08-06

--- a/openspec/changes/archive/2026-08-06-reusable-jar-build/proposal.md
+++ b/openspec/changes/archive/2026-08-06-reusable-jar-build/proposal.md
@@ -1,0 +1,13 @@
+# The uberjar recipe lives in one reusable workflow
+
+## Why
+
+Noticed in #234 review (#237): the jar recipe (`npm ci` → shadow release → `clojure -T:build uber`) is duplicated between `deploy-app.yml` and `staging-smoke.yml` and will drift — the next recipe change lands in one file and silently not the other, and the smoke stops proving what the deploy ships.
+
+## What changes
+
+New `.github/workflows/build-jar.yml` with `on: workflow_call`: the recipe, the clojure/m2 caching deploy-app carries today, the jar uploaded as an `app-jar` artifact, and the sha256 exposed as a workflow output. `deploy-app.yml` calls it and its deploy job downloads the artifact; scp with a per-run temp name, `sha256sum -c`, atomic `mv` are unchanged. `staging-smoke.yml` calls it behind the `changes` gate (a called workflow inherits nothing implicit, so the needs/if wiring is explicit) and the smoke job downloads instead of building; the `changes` filter now also watches `build-jar.yml`, and the #204 always-reporting shape is preserved. `infra/staging/run.sh` already consumes a prebuilt `target/learning-app.jar` — no change there.
+
+## Impact
+
+`.github/workflows/build-jar.yml` (new), `deploy-app.yml`, `staging-smoke.yml`. Deploy behavior on the server is byte-identical; the smoke job sheds its toolchain setup and drops to a 15-minute cap. `deploy-pipeline` gains the single-recipe requirement; `staging-environment`'s CI requirement now consumes the shared artifact.

--- a/openspec/changes/archive/2026-08-06-reusable-jar-build/specs/deploy-pipeline/spec.md
+++ b/openspec/changes/archive/2026-08-06-reusable-jar-build/specs/deploy-pipeline/spec.md
@@ -1,0 +1,22 @@
+# deploy-pipeline Specification
+
+## ADDED Requirements
+
+### Requirement: One jar recipe feeds every consumer
+
+The uberjar SHALL be produced by a single reusable workflow that every consumer calls: it runs the recipe (`npm ci`, shadow-cljs release, `clojure -T:build uber`), publishes the jar as a build artifact, and records its sha256 as a workflow output. Consumers SHALL download that artifact rather than rebuild, so the recipe cannot drift between the deploy and the smoke.
+
+#### Scenario: The deploy consumes the shared build
+
+- **WHEN** a deploy run starts
+- **THEN** the jar it uploads is the artifact from the reusable workflow, and the checksum it verifies on the server is the sha256 that workflow recorded at build time
+
+#### Scenario: The smoke consumes the shared build
+
+- **WHEN** the staging smoke runs on an infra pull request
+- **THEN** the jar it delivers into the container is the artifact from the same reusable workflow, not a second in-job build
+
+#### Scenario: The recipe changes
+
+- **WHEN** the build recipe needs a change
+- **THEN** exactly one workflow file changes, and both consumers pick it up on their next run

--- a/openspec/changes/archive/2026-08-06-reusable-jar-build/specs/staging-environment/spec.md
+++ b/openspec/changes/archive/2026-08-06-reusable-jar-build/specs/staging-environment/spec.md
@@ -1,0 +1,17 @@
+# staging-environment Specification
+
+## MODIFIED Requirements
+
+### Requirement: Infra pull requests run the smoke in CI
+
+CI SHALL run `infra/staging/run.sh` on every pull request to master that touches `infra/**`, the smoke workflow itself, or the shared jar-build workflow, and the check SHALL report on every pull request: the workflow fires unconditionally and a cheap diff job decides between running the smoke and reporting skipped, so that a required check can never block a merge by failing to start. The jar the smoke delivers SHALL come from the shared reusable build workflow, downloaded as an artifact, not from an in-job rebuild. On failure the smoke output SHALL be preserved as a build artifact.
+
+#### Scenario: An infra-touching pull request
+
+- **WHEN** a pull request changes files under `infra/`
+- **THEN** the smoke check downloads the jar built by the shared workflow, runs `infra/staging/run.sh` on the CI runner, and turns red if any smoke assertion fails
+
+#### Scenario: An unrelated pull request
+
+- **WHEN** a pull request touches no infra path, not the smoke workflow, and not the jar-build workflow
+- **THEN** the smoke and build jobs report skipped, satisfying branch protection without spending a runner

--- a/openspec/changes/archive/2026-08-06-reusable-jar-build/tasks.md
+++ b/openspec/changes/archive/2026-08-06-reusable-jar-build/tasks.md
@@ -1,0 +1,6 @@
+# Tasks
+
+- [x] 1. `build-jar.yml`: `workflow_call`, the recipe, clojure/m2 cache restore/save, jar uploaded as `app-jar` artifact, sha256 as workflow output
+- [x] 2. `deploy-app.yml`: build job calls the reusable workflow; deploy job downloads the artifact and keeps scp temp name, `sha256sum -c`, atomic `mv` intact
+- [x] 3. `staging-smoke.yml`: build called behind the `changes` gate, smoke downloads the artifact; filter watches `build-jar.yml` too; skipped-but-reporting shape (#204) preserved
+- [x] 4. Proof on this PR's own check run: the smoke fires (its file changed) and goes green consuming the artifact; deploy-app is dispatch-only, so its path is YAML/graph-checked, not run

--- a/openspec/specs/deploy-pipeline/spec.md
+++ b/openspec/specs/deploy-pipeline/spec.md
@@ -43,3 +43,22 @@ When the deb ships configuration that a running daemon reads only at startup, po
 - **WHEN** the deb installs and the shipped ini matches the stamp
 - **THEN** CouchDB is not restarted
 
+### Requirement: One jar recipe feeds every consumer
+
+The uberjar SHALL be produced by a single reusable workflow that every consumer calls: it runs the recipe (`npm ci`, shadow-cljs release, `clojure -T:build uber`), publishes the jar as a build artifact, and records its sha256 as a workflow output. Consumers SHALL download that artifact rather than rebuild, so the recipe cannot drift between the deploy and the smoke.
+
+#### Scenario: The deploy consumes the shared build
+
+- **WHEN** a deploy run starts
+- **THEN** the jar it uploads is the artifact from the reusable workflow, and the checksum it verifies on the server is the sha256 that workflow recorded at build time
+
+#### Scenario: The smoke consumes the shared build
+
+- **WHEN** the staging smoke runs on an infra pull request
+- **THEN** the jar it delivers into the container is the artifact from the same reusable workflow, not a second in-job build
+
+#### Scenario: The recipe changes
+
+- **WHEN** the build recipe needs a change
+- **THEN** exactly one workflow file changes, and both consumers pick it up on their next run
+

--- a/openspec/specs/staging-environment/spec.md
+++ b/openspec/specs/staging-environment/spec.md
@@ -23,15 +23,15 @@ The staging container SHALL NOT contact production systems or real credential st
 
 ### Requirement: Infra pull requests run the smoke in CI
 
-CI SHALL run `infra/staging/run.sh` on every pull request to master that touches `infra/**` or the smoke workflow itself, and the check SHALL report on every pull request: the workflow fires unconditionally and a cheap diff job decides between running the smoke and reporting skipped, so that a required check can never block a merge by failing to start. On failure the smoke output SHALL be preserved as a build artifact.
+CI SHALL run `infra/staging/run.sh` on every pull request to master that touches `infra/**`, the smoke workflow itself, or the shared jar-build workflow, and the check SHALL report on every pull request: the workflow fires unconditionally and a cheap diff job decides between running the smoke and reporting skipped, so that a required check can never block a merge by failing to start. The jar the smoke delivers SHALL come from the shared reusable build workflow, downloaded as an artifact, not from an in-job rebuild. On failure the smoke output SHALL be preserved as a build artifact.
 
 #### Scenario: An infra-touching pull request
 
 - **WHEN** a pull request changes files under `infra/`
-- **THEN** the smoke check builds the jar, runs `infra/staging/run.sh` on the CI runner, and turns red if any smoke assertion fails
+- **THEN** the smoke check downloads the jar built by the shared workflow, runs `infra/staging/run.sh` on the CI runner, and turns red if any smoke assertion fails
 
 #### Scenario: An unrelated pull request
 
-- **WHEN** a pull request touches no infra path and not the workflow file
-- **THEN** the smoke job reports skipped, satisfying branch protection without spending a runner
+- **WHEN** a pull request touches no infra path, not the smoke workflow, and not the jar-build workflow
+- **THEN** the smoke and build jobs report skipped, satisfying branch protection without spending a runner
 


### PR DESCRIPTION
Closes #237.

Jar recipe (npm ci → shadow release → `clojure -T:build uber`) lived in both deploy-app.yml and staging-smoke.yml — drift waiting to happen (noticed in #234 review).

- New `.github/workflows/build-jar.yml` (`workflow_call`): recipe + clojure/m2 caching, jar uploaded as `app-jar` artifact, sha256 as workflow output.
- deploy-app.yml: build job calls it; deploy job downloads the artifact. Server-side behavior byte-identical: per-run tmp scp name, `sha256sum -c` against the build-time checksum, atomic `mv`.
- staging-smoke.yml: build called behind the `changes` gate (explicit needs/if — called workflows inherit nothing); smoke downloads instead of rebuilding; `changes` filter now also watches build-jar.yml; #204 always-reporting shape preserved. Smoke timeout 20→15 min since the jar build moved out.
- `infra/staging/run.sh` untouched — it already consumes a prebuilt `target/learning-app.jar`.

Verification: staging-smoke fires on this PR (its file changed) and exercises the exact workflow_call + artifact path. deploy-app is workflow_dispatch-only — its path is YAML-validated and graph-checked but not executed; first real proof is the next deploy.

Note: #237 was closed today with no linked PR and master unchanged — looks like a board misclose; this PR is the actual fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)