### PR TITLE
GH-191 restore drill and borg-key custody docs

### DIFF
--- a/docs/ops/runbook.md
+++ b/docs/ops/runbook.md
@@ -88,15 +88,46 @@ itself stays safe at the new home.
 
 ## Restore from backup
 
-Archives named `app-<timestamp>` carry both stores: the SQLite snapshot and
-`/var/lib/couchdb`. Restore them together, from the same archive — an account
-row and its userdb must come from one moment, or you manufacture the orphan
-states #182/#205 exist to catch. `borg list ::` to pick, `borg extract` into a
-scratch dir, then: stop services, put the sqlite file at
-`/var/lib/learning-app/db.sqlite`, the couch tree at `/var/lib/couchdb`
-(ownership `couchdb:couchdb`), start, and check `/auth/check` with a known
-token before calling it done. Older `db-*.sqlite` archives predate #206 and
-hold SQLite only.
+Archives named `app-<timestamp>` carry both stores: the SQLite snapshot (at
+its backup path, `var/backups/learning-app/db.sqlite`) and `/var/lib/couchdb`.
+Restore them together, from the same archive — an account row and its userdb
+must come from one moment, or you manufacture the orphan states #182/#205
+exist to catch. Older `db-*.sqlite` archives predate #206 and hold SQLite only.
+
+Borg runs as `dbmaintainer` (the repository owner) throughout — root would
+leave root-owned lock/cache state in the repository and break the backup
+timer. The passphrase and its handling: see "Borg key" in
+`docs/ops/server-configuration.md`.
+
+```sh
+sudo runuser -u dbmaintainer -- env BORG_REPO=... BORG_PASSPHRASE=... borg list   # pick an archive
+sudo systemctl stop learning-app-run.service couchdb.service
+# extract into a dbmaintainer-writable scratch dir
+sudo runuser -u dbmaintainer -- env BORG_REPO=... BORG_PASSPHRASE=... \
+    sh -c 'cd /var/tmp/restore && borg extract ::app-<timestamp>'
+# SQLite: snapshot to the live path; ownership webapp (borg extracted as
+# dbmaintainer, so ownership does NOT come back on its own). Stale -wal/-shm
+# from the old database MUST go — SQLite would replay them into the snapshot.
+sudo install -o webapp -g webapp -m 660 \
+    /var/tmp/restore/var/backups/learning-app/db.sqlite /var/lib/learning-app/db.sqlite
+sudo rm -f /var/lib/learning-app/db.sqlite-wal /var/lib/learning-app/db.sqlite-shm
+# CouchDB: replace the tree wholesale (an overlay mixes old state into the
+# restore), ownership couchdb:couchdb.
+sudo rm -rf /var/lib/couchdb
+sudo cp -a /var/tmp/restore/var/lib/couchdb /var/lib/couchdb
+sudo chown -R couchdb:couchdb /var/lib/couchdb
+# CouchDB first, answering before the app starts — the app's boot
+# reconciliation (orphan report) needs to enumerate databases.
+sudo systemctl start couchdb.service
+until curl -sf http://127.0.0.1:5984/ >/dev/null; do sleep 1; done
+sudo systemctl start learning-app-run.service
+```
+
+Before calling it done: `/auth/check` answers 200 for a known token, that
+account's userdb serves its documents through `/db/`, and the boot
+`orphan-userdbs` report in the app journal is clean. This procedure is
+exercised end to end by `infra/staging/restore-drill.sh` — if reality and
+this section disagree, fix whichever is wrong in the same PR.
 
 ## Manual admin steps (bootstrap + secrets + one-off ops)
 

--- a/docs/ops/server-configuration.md
+++ b/docs/ops/server-configuration.md
@@ -50,6 +50,26 @@ Static reference only. Procedures live in `docs/ops/runbook.md` and `docs/ops/ve
 **Cert renewal**
 - Units: `learning-app-certbot.service` and `learning-app-certbot.timer`.
 
+## Borg key
+
+- Repository encryption is `repokey`: the key sits inside the repository,
+  locked by the passphrase. **Losing the passphrase loses every archive** —
+  there is no recovery path.
+- The passphrase lives as the systemd encrypted credential
+  `/etc/credstore.encrypted/borg-passphrase`; the backup unit decrypts it via
+  `LoadCredentialEncrypted=` and hands the path to `backup.sh` as
+  `BORG_PASSPHRASE_PATH`. It exists nowhere else on the server — keep an
+  offline copy (password manager), since the encrypted credential is bound to
+  this host's `/var/lib/systemd/credential.secret` and does not survive it.
+- Set/rotate: `learning-app-admin-setup --rotate-borg`.
+- Verify the key still opens the repository (read-only, safe anytime):
+  ```sh
+  sudo runuser -u dbmaintainer -- env \
+      BORG_REPO="$(grep '^BORG_REPO=' /etc/learning-app/environment | cut -d= -f2-)" \
+      BORG_PASSPHRASE="$(sudo systemd-creds --name=borg-passphrase decrypt /etc/credstore.encrypted/borg-passphrase -)" \
+      borg list
+  ```
+
 ## Environment
 
 **Env files:**

--- a/docs/ops/verification.md
+++ b/docs/ops/verification.md
@@ -46,3 +46,11 @@ curl -sf --resolve sprecha.de:443:127.0.0.1 https://sprecha.de/db/dictionary-db/
 systemctl is-enabled learning-app-backup-db.timer
 systemctl status learning-app-backup-db.timer
 ```
+Borg key dry check — the passphrase credential still opens the repository
+(see "Borg key" in `server-configuration.md`):
+```sh
+sudo runuser -u dbmaintainer -- env \
+    BORG_REPO="$(grep '^BORG_REPO=' /etc/learning-app/environment | cut -d= -f2-)" \
+    BORG_PASSPHRASE="$(sudo systemd-creds --name=borg-passphrase decrypt /etc/credstore.encrypted/borg-passphrase -)" \
+    borg list >/dev/null && echo borg-key-ok
+```

--- a/infra/staging/Dockerfile
+++ b/infra/staging/Dockerfile
@@ -32,12 +32,16 @@ RUN curl -fsSL https://couchdb.apache.org/repo/keys.asc \
 # Preseed CouchDB: single node on localhost with a known staging admin
 # password (plaintext by design — this container never holds real secrets).
 # On the real server the operator answers these prompts during bootstrap.
+# The password is the one the app itself carries (lib/db/src/db.cljc `conn`,
+# hardcoded): with any other value the app cannot create userdbs or run the
+# boot reconciliation report, and the restore drill cannot seed through the
+# real provisioning endpoint. Must match COUCH_PASS in run.sh.
 RUN printf '%s\n' \
         'couchdb couchdb/mode select standalone' \
         'couchdb couchdb/bindaddress string 127.0.0.1' \
         'couchdb couchdb/cookie string learning-app-staging' \
-        'couchdb couchdb/adminpass password staging-couch-pass' \
-        'couchdb couchdb/adminpass_again password staging-couch-pass' \
+        'couchdb couchdb/adminpass password 3434' \
+        'couchdb couchdb/adminpass_again password 3434' \
     | debconf-set-selections
 
 # Everything the infra deb Depends on, baked at image build so installing the

--- a/infra/staging/README.md
+++ b/infra/staging/README.md
@@ -64,6 +64,13 @@ encrypted-credential flow — `systemd-creds` in postinst,
   real unit sandbox).
 - `learning-app-backup-db.service` produces a borg archive carrying both the
   SQLite snapshot and `/var/lib/couchdb`.
+- An archive actually restores into a working system (`restore-drill.sh`,
+  GH-191): seed an account and a userdb doc, back up, destroy both stores,
+  restore by the runbook's "Restore from backup" procedure, then prove
+  coherence — the seeded token authenticates, the userdb serves its doc
+  through nginx, and the boot orphan report (#205) is clean. The runbook
+  section is the spec; when drill and runbook disagree, one of them is wrong
+  and both live in the same PR.
 
 ## What it deliberately does not prove
 

--- a/infra/staging/restore-drill.sh
+++ b/infra/staging/restore-drill.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Restore drill (GH-191). Runs INSIDE the staging container, after smoke.sh:
+# seed real data, back it up, destroy both stores, restore from the borg
+# archive by the runbook's procedure, and prove the restored system coheres —
+# token authenticates, userdb serves its doc, orphan report is clean.
+# The runbook's "Restore from backup" section is the spec; this script keeps
+# that document honest. One PASS/FAIL line per assertion, nonzero exit on FAIL.
+set -u
+
+BORG_PASS="staging-borg-pass"        # must match run.sh
+BORG_REPO="/var/lib/dbmaintainer/borg-repo"
+COUCH_PASS="3434"                    # must match the debconf preseed in Dockerfile
+COUCH="http://127.0.0.1:5984"
+DB="/var/lib/learning-app/db.sqlite"
+SCRATCH="/var/tmp/learning-app-restore-drill"
+
+fails=0
+
+check() {
+    local name="$1"
+    shift
+    if "$@" >/dev/null 2>&1; then
+        echo "PASS ${name}"
+    else
+        echo "FAIL ${name}"
+        fails=$((fails + 1))
+    fi
+}
+
+http_code() {
+    curl -k -s -o /dev/null -w '%{http_code}' "$@"
+}
+
+borg_dbm() {
+    runuser -u dbmaintainer -- env \
+        BORG_REPO="${BORG_REPO}" BORG_PASSPHRASE="${BORG_PASS}" borg "$@"
+}
+
+echo "== drill: seed =="
+# An invite grant, planted straight into the store the way mint-grant! would;
+# provisioning then runs through the real endpoint so the account row and its
+# userdb are created by the app itself.
+invite="$(openssl rand -hex 20)"
+invite_sha="$(printf '%s' "${invite}" | sha256sum | cut -d' ' -f1)"
+expires_ms=$((($(date +%s) + 3600) * 1000))
+sqlite3 "${DB}" \
+    "INSERT INTO grants (sha256, expires_at) VALUES ('${invite_sha}', ${expires_ms});"
+
+# Explicit JSON content type: without it curl sends form-urlencoded and the
+# parameters interceptor consumes the body before the handler can parse it.
+provision="$(curl -s -X POST http://127.0.0.1:8083/api/identity/provision \
+    -H 'Content-Type: application/json' -d "{\"invite\":\"${invite}\"}")"
+token="$(grep -oP '"token":"\K[0-9a-f]+' <<< "${provision}")"
+account_id="$(grep -oP '"id":\K[0-9]+' <<< "${provision}")"
+check "seed: provisioning returned an account" \
+    bash -c "test -n '${token}' && test -n '${account_id}'"
+userdb="userdb-${account_id}"
+
+payload="drill-$(openssl rand -hex 8)"
+check "seed: doc written to the userdb" \
+    bash -c "curl -sf -u admin:${COUCH_PASS} -X PUT ${COUCH}/${userdb}/drill-doc \
+        -d '{\"payload\":\"${payload}\"}' >/dev/null"
+check "seed: /auth/check accepts the token" \
+    test "$(http_code -H "Cookie: sprecha-token=${token}" http://127.0.0.1:8083/auth/check)" = 200
+
+echo "== drill: backup =="
+check "backup: learning-app-backup-db.service runs clean" \
+    systemctl start learning-app-backup-db.service
+archive="$(borg_dbm list --short 2>/dev/null | tail -1)"
+check "backup: archive exists" test -n "${archive}"
+
+echo "== drill: destroy both stores =="
+curl -sf -u "admin:${COUCH_PASS}" -X DELETE "${COUCH}/${userdb}" >/dev/null
+check "destroy: userdb gone from couchdb" \
+    test "$(http_code -u "admin:${COUCH_PASS}" "${COUCH}/${userdb}")" = 404
+rm -f "${DB}" "${DB}-wal" "${DB}-shm"
+check "destroy: token no longer authenticates" \
+    bash -c "test \"\$(http_code -H 'Cookie: sprecha-token=${token}' http://127.0.0.1:8083/auth/check)\" != 200"
+
+echo "== drill: restore (runbook procedure) =="
+# Stop services before touching either store.
+systemctl stop learning-app-run.service couchdb.service
+
+# Extract as dbmaintainer — the repository owner. Running borg as root would
+# leave root-owned lock/cache state in the repository and break later timer
+# runs; the flip side is that a non-root extract cannot restore file
+# ownership, so both stores are chowned explicitly below (runbook says so).
+rm -rf "${SCRATCH}"
+install -d -o dbmaintainer -g dbmaintainer "${SCRATCH}"
+check "restore: borg extract ${archive}" \
+    runuser -u dbmaintainer -- env \
+        BORG_REPO="${BORG_REPO}" BORG_PASSPHRASE="${BORG_PASS}" \
+        bash -c "cd '${SCRATCH}' && borg extract \"::${archive}\""
+
+# SQLite: the archive carries the snapshot at var/backups/learning-app/ —
+# place it at the live path, owned by the app user. Stale -wal/-shm from the
+# destroyed database must not survive: SQLite would replay them into the
+# restored snapshot.
+install -o webapp -g webapp -m 660 \
+    "${SCRATCH}/var/backups/learning-app/db.sqlite" "${DB}"
+rm -f "${DB}-wal" "${DB}-shm"
+
+# CouchDB: replace the tree wholesale — an overlay would leave the destroyed
+# state's newer files mixed into the restored one.
+rm -rf /var/lib/couchdb
+cp -a "${SCRATCH}/var/lib/couchdb" /var/lib/couchdb
+chown -R couchdb:couchdb /var/lib/couchdb
+
+# CouchDB first, and answering, then the app: boot reconciliation reports
+# orphans only when it can enumerate databases.
+systemctl start couchdb.service
+for _ in $(seq 1 30); do
+    curl -sf -o /dev/null "${COUCH}/" && break
+    sleep 1
+done
+systemctl start learning-app-run.service
+
+up=0
+for _ in $(seq 1 90); do
+    if curl -sf -o /dev/null http://127.0.0.1:8083/; then up=1; break; fi
+    sleep 1
+done
+check "restore: app answers after restore" test "${up}" = 1
+
+echo "== drill: coherence =="
+check "coherence: /auth/check accepts the seeded token" \
+    test "$(http_code -H "Cookie: sprecha-token=${token}" http://127.0.0.1:8083/auth/check)" = 200
+doc="$(curl -k -s --resolve sprecha.de:443:127.0.0.1 \
+    -H "Cookie: sprecha-token=${token}" \
+    "https://sprecha.de/db/${userdb}/drill-doc")"
+check "coherence: userdb serves the seeded doc through nginx" \
+    bash -c "grep -q '${payload}' <<< '${doc}'"
+# Boot reconciliation (#205) logs :reconciliation/orphan-userdbs with the
+# orphan vector; a clean restore reports none. Only the latest boot counts.
+orphan_line="$(journalctl -u learning-app-run.service --no-pager \
+    | grep 'orphan-userdbs' | tail -1)"
+check "coherence: orphan report present after restore" \
+    test -n "${orphan_line}"
+check "coherence: orphan report is clean" \
+    bash -c "! grep -q 'userdb-[0-9]' <<< '${orphan_line}'"
+
+rm -rf "${SCRATCH}"
+
+if [ "${fails}" -gt 0 ]; then
+    echo "DRILL: ${fails} assertion(s) failed"
+    exit 1
+fi
+echo "DRILL: all assertions passed"

--- a/infra/staging/run.sh
+++ b/infra/staging/run.sh
@@ -12,7 +12,9 @@ CONTAINER="${LEARNING_APP_STAGING_CONTAINER:-learning-app-staging-run}"
 KEEP="${LEARNING_APP_STAGING_KEEP:-0}"
 
 # Test-only secrets, plaintext by design: nothing in this container is real.
-COUCH_PASS="staging-couch-pass"   # must match the debconf preseed in Dockerfile
+# CouchDB's password is the app's hardcoded one (lib/db/src/db.cljc `conn`) —
+# see the Dockerfile preseed comment; the two must stay identical.
+COUCH_PASS="3434"                 # must match the debconf preseed in Dockerfile
 BORG_PASS="staging-borg-pass"     # must match smoke.sh
 
 cleanup() {
@@ -101,6 +103,7 @@ echo "== Stage inputs =="
 docker cp "${ROOT}/target/learning-app-infra.deb" "${CONTAINER}:/root/"
 docker cp "${ROOT}/target/learning-app.jar" "${CONTAINER}:/root/"
 docker cp "${HERE}/smoke.sh" "${CONTAINER}:/root/smoke.sh"
+docker cp "${HERE}/restore-drill.sh" "${CONTAINER}:/root/restore-drill.sh"
 
 echo "== Credentials the operator creates via admin-setup.sh =="
 # The OpenRouter key is withheld until after the first install so postinst's
@@ -164,4 +167,13 @@ in_c runuser -u dbmaintainer -- env \
     borg init --encryption=repokey
 
 echo "== Smoke =="
-in_c bash /root/smoke.sh
+smoke_exit=0
+in_c bash /root/smoke.sh || smoke_exit=$?
+
+# The drill runs even on a red smoke: its subject (backup/restore) is
+# independent of whichever smoke assertion is failing that day.
+echo "== Restore drill (GH-191) =="
+drill_exit=0
+in_c bash /root/restore-drill.sh || drill_exit=$?
+
+exit $(( smoke_exit > drill_exit ? smoke_exit : drill_exit ))

--- a/openspec/changes/archive/2026-08-06-restore-drill/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-06-restore-drill/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-with-adr
+created: 2026-08-06

--- a/openspec/changes/archive/2026-08-06-restore-drill/proposal.md
+++ b/openspec/changes/archive/2026-08-06-restore-drill/proposal.md
@@ -1,0 +1,15 @@
+# A backup counts only when it restores
+
+## Why
+
+The staging rung proves an archive exists and names both stores (#211) — it never proves the archive restores into a working system. The runbook's "Restore from backup" section has never been executed; untested restore procedures are where backups go to die. And the borg passphrase — the single value whose loss makes every archive unreadable — is documented nowhere (#191).
+
+## What changes
+
+`infra/staging/restore-drill.sh`, run by `run.sh` after the smoke: seed a real account (grant → provision endpoint) and a userdb doc, run the backup unit, destroy both stores (rm the SQLite file, DELETE the userdb), restore from the borg archive exactly as the runbook prescribes, then assert coherence — the seeded token gets 200 from `/auth/check`, the userdb serves the doc through nginx, the boot orphan report (#205) is clean. PASS/FAIL per assertion, nonzero exit on FAIL. The runbook section is rewritten as the executable procedure the drill revealed: extract as `dbmaintainer`, explicit ownership on both stores (borg cannot restore it from a non-root extract), stale `-wal`/`-shm` removal, wholesale CouchDB tree replacement, CouchDB-before-app start order. Borg key custody lands in `server-configuration.md` (where the passphrase lives, that losing it loses all archives, the `borg list` dry check) with the check echoed in `verification.md`.
+
+The drill's first run surfaced a config split: the app carries its CouchDB admin credentials hardcoded (`lib/db/src/db.cljc` `conn`), so with the container's previous `staging-couch-pass` the app could neither create userdbs (provisioning answered 503) nor run the boot reconciliation report (skipped on 401). The staging preseed now matches the app's value — the only configuration under which the packaged shape actually works.
+
+## Impact
+
+New `infra/staging/restore-drill.sh`; `run.sh` gains the drill phase; `docs/ops/runbook.md` restore section corrected; `docs/ops/server-configuration.md` + `docs/ops/verification.md` gain borg-key custody; delta on `backup-pipeline`.

--- a/openspec/changes/archive/2026-08-06-restore-drill/specs/backup-pipeline/spec.md
+++ b/openspec/changes/archive/2026-08-06-restore-drill/specs/backup-pipeline/spec.md
@@ -1,18 +1,6 @@
 # backup-pipeline Specification
 
-## Purpose
-TBD - created by archiving change couchdb-in-backups. Update Purpose after archive.
-## Requirements
-### Requirement: Both stores are backed up as one coherent archive
-Every backup run SHALL capture the SQLite database and the CouchDB data tree in a single archive, taken back to back, so a restore recovers matching account rows and userdbs. Backup SHALL read CouchDB with access scoped to the backup service.
-
-#### Scenario: A backup run
-- **WHEN** the backup timer fires
-- **THEN** one archive contains the SQLite snapshot and /var/lib/couchdb
-
-#### Scenario: A restore
-- **WHEN** an operator restores from an archive
-- **THEN** both stores come from the same moment and an existing token authenticates against its userdb
+## ADDED Requirements
 
 ### Requirement: A restore is proven by drill, not assumed
 The staging run SHALL restore a real backup archive into the running container following the runbook's restore procedure — services stopped, files back, ownership corrected, services restarted — after destroying both stores, and SHALL verify coherence of the result: the seeded token authenticates via `/auth/check`, the seeded userdb document is served through the authenticated proxy, and the boot orphan-userdb report is clean. Each assertion SHALL report PASS or FAIL on its own line and the run SHALL exit nonzero on any FAIL. The runbook's restore section and the drill SHALL agree; a divergence is a defect in one of them.
@@ -31,4 +19,3 @@ Operator documentation SHALL state where the borg passphrase lives (the systemd 
 #### Scenario: An operator checks the key
 - **WHEN** the operator runs the documented `borg list` dry check
 - **THEN** success proves the stored passphrase still opens the repository without touching any archive
-

--- a/openspec/changes/archive/2026-08-06-restore-drill/tasks.md
+++ b/openspec/changes/archive/2026-08-06-restore-drill/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+- [x] 1. restore-drill.sh: seed (grant → provision → userdb doc), backup unit run, destroy both stores, restore per runbook, coherence asserts (auth 200, doc via nginx, orphan report clean) — PASS/FAIL per line, nonzero exit on FAIL
+- [x] 2. run.sh runs the drill after the smoke; both exit codes surface
+- [x] 3. Runbook "Restore from backup" rewritten as the executable procedure (ownership, -wal/-shm, wholesale couch tree, service order)
+- [x] 4. Borg key custody documented: credential location, loss consequence, rotation, `borg list` dry check (server-configuration.md, verification.md)
+- [x] 5. Real run; drill output in the PR


### PR DESCRIPTION
Closes #191.

Restore drill in the staging container: seed a real account (grant → provision endpoint) and a userdb doc, run the backup unit, destroy both stores, restore from the borg archive by the runbook's procedure, assert coherence. Runbook's "Restore from backup" rewritten as the executable procedure the drill demanded. Borg key custody (credential location, loss = all archives gone, rotation, `borg list` dry check) added to server-configuration.md and verification.md.

Runbook corrections the drill forced:
- archive holds the sqlite snapshot at `var/backups/learning-app/db.sqlite`, not the live path
- extract as `dbmaintainer` (root would plant root-owned lock/cache in the repo); ownership therefore restored by hand — sqlite `webapp:webapp` 0660, couch tree `couchdb:couchdb`
- stale `db.sqlite-wal`/`-shm` must be removed or SQLite replays them into the snapshot
- couch tree replaced wholesale, not overlaid
- CouchDB started and answering before the app, so boot reconciliation can report orphans

Finding: the app read its CouchDB admin credentials from the dev fallback (`lib/db/src/db.cljc` `conn`) — the first drill run caught provisioning failing when the container's couch password differed. Staging preseed aligned here; proper env-based credentials are #246.

Drill output (full run, smoke included, exit 0):

```
== Smoke ==
PASS unit active: nginx.service
PASS unit active: couchdb.service
PASS unit active: learning-app-run.service
PASS unit active: learning-app-restart.path
PASS unit active: learning-app-certbot.timer
PASS unit active: learning-app-backup-db.timer
PASS nginx: https:// answers 200
PASS nginx: http:// redirects 301
PASS app: /auth/check without cookie is 401
PASS nginx: /db/ without cookie is 401
PASS migrations: schema_migrations has rows
PASS adoption: database-adopted in the journal
PASS adoption: marker row survived the move
PASS adoption: legacy file retired
PASS backup: learning-app-backup-db.service runs clean
PASS backup: archive exists
PASS backup: archive carries the sqlite store
PASS backup: archive carries the couchdb store
SMOKE: all assertions passed
== Restore drill (GH-191) ==
== drill: seed ==
PASS seed: provisioning returned an account
PASS seed: doc written to the userdb
PASS seed: /auth/check accepts the token
== drill: backup ==
PASS backup: learning-app-backup-db.service runs clean
PASS backup: archive exists
== drill: destroy both stores ==
PASS destroy: userdb gone from couchdb
PASS destroy: token no longer authenticates
== drill: restore (runbook procedure) ==
PASS restore: borg extract app-2026-08-06T13:33:40
PASS restore: app answers after restore
== drill: coherence ==
PASS coherence: /auth/check accepts the seeded token
PASS coherence: userdb serves the seeded doc through nginx
PASS coherence: orphan report present after restore
PASS coherence: orphan report is clean
DRILL: all assertions passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

