### PR TITLE
Rename the auth cookie to auth-token

### DIFF
--- a/src/backend/core.clj
+++ b/src/backend/core.clj
@@ -1,6 +1,7 @@
 (ns core
   (:gen-class)
   (:require
+   [auth :as auth]
    [cheshire.core :as cheshire]
    [clojure.edn :as edn]
    [clojure.java.io :as io]
@@ -277,13 +278,10 @@
 ;;
 
 
-(def ^:private token-cookie "auth-token")
-
-
 (defn- request-token
   "Reads the bearer token from the parsed cookies, or nil."
   [request]
-  (get-in request [:cookies token-cookie :value]))
+  (get-in request [:cookies auth/token-cookie :value]))
 
 
 (defn hmac-sign
@@ -465,7 +463,7 @@
          ;; cookie resolves to an account, or the upgrade is refused. A poke
          ;; carries no payload, so a hijacked socket learns only "something
          ;; changed".
-         (let [token (get-in request [:cookies token-cookie :value])
+         (let [token (get-in request [:cookies auth/token-cookie :value])
                id    (on-connection [db db-spec] (authenticated-user-id db token))]
            (if id
              (server/as-channel request

--- a/src/backend/core.clj
+++ b/src/backend/core.clj
@@ -277,7 +277,7 @@
 ;;
 
 
-(def ^:private token-cookie "sprecha-token")
+(def ^:private token-cookie "auth-token")
 
 
 (defn- request-token
@@ -465,7 +465,7 @@
          ;; cookie resolves to an account, or the upgrade is refused. A poke
          ;; carries no payload, so a hijacked socket learns only "something
          ;; changed".
-         (let [token (get-in request [:cookies "sprecha-token" :value])
+         (let [token (get-in request [:cookies token-cookie :value])
                id    (on-connection [db db-spec] (authenticated-user-id db token))]
            (if id
              (server/as-channel request

--- a/src/client/adapters/identity.cljs
+++ b/src/client/adapters/identity.cljs
@@ -1,9 +1,7 @@
 (ns adapters.identity
   (:require
+   [auth :as auth]
    [db :as db]))
-
-
-(def ^:private token-cookie "auth-token")
 
 
 (def ^:private identity-doc-id "identity:local")
@@ -46,7 +44,7 @@
    token, it builds the QR and the recovery link from it."
   [{:keys [token]}]
   (set! js/document.cookie
-        (str token-cookie "=" token "; path=/; SameSite=Lax; Secure")))
+        (str auth/token-cookie "=" token "; path=/; SameSite=Lax; Secure")))
 
 
 (defn ^:async account-id!

--- a/src/client/adapters/identity.cljs
+++ b/src/client/adapters/identity.cljs
@@ -3,7 +3,7 @@
    [db :as db]))
 
 
-(def ^:private token-cookie "sprecha-token")
+(def ^:private token-cookie "auth-token")
 
 
 (def ^:private identity-doc-id "identity:local")

--- a/src/shared/auth.cljc
+++ b/src/shared/auth.cljc
@@ -1,0 +1,8 @@
+(ns auth
+  "The client↔server auth contract.")
+
+
+(def token-cookie
+  "The bearer-token cookie. The client derives it from device-db on every
+   boot (ADR-0006); the server only ever reads it."
+  "auth-token")


### PR DESCRIPTION
Brand-neutral cookie name. No dual-accept window: no devices exist yet, the cookie is client-derived from device-db on every boot anyway.

`infra/staging/restore-drill.sh` (#240) hardcodes the old name — will be fixed here once #240 merges.

Depends-on: #191
Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)