### PR TITLE
CouchDB credentials from env

### DIFF
--- a/infra/production/etc/systemd/system/learning-app-run.service
+++ b/infra/production/etc/systemd/system/learning-app-run.service
@@ -17,7 +17,9 @@ StateDirectory=learning-app
 StateDirectoryMode=2770
 Restart=always
 RestartSec=10
-ExecStart=sh -c 'if [ -z "${OPENROUTER_API_KEY:-}" ] && [ -n "${OPENROUTER_API_KEY_PATH:-}" ] && [ -f "${OPENROUTER_API_KEY_PATH}" ]; then export OPENROUTER_API_KEY="$(cat "${OPENROUTER_API_KEY_PATH}")"; fi; if [ -z "${LEARNING_APP_DB_AUTH_SECRET:-}" ] && [ -n "${LEARNING_APP_DB_AUTH_SECRET_PATH:-}" ] && [ -f "${LEARNING_APP_DB_AUTH_SECRET_PATH}" ]; then export LEARNING_APP_DB_AUTH_SECRET="$(cat "${LEARNING_APP_DB_AUTH_SECRET_PATH}")"; fi; if [ -z "${LEARNING_APP__COUCHDB_PASSWORD:-}" ] && [ -n "${LEARNING_APP__COUCHDB_PASSWORD_PATH:-}" ] && [ -f "${LEARNING_APP__COUCHDB_PASSWORD_PATH}" ]; then export LEARNING_APP__COUCHDB_PASSWORD="$(cat "${LEARNING_APP__COUCHDB_PASSWORD_PATH}")"; fi; java -jar /opt/learning-app/learning-app.jar'
+# The script bridges systemd credentials (files under %d) into the env vars
+# the app reads — ships in the deb next to the jar.
+ExecStart=/opt/learning-app/bin/run.sh
 
 # Environment
 EnvironmentFile=-/etc/learning-app/environment

--- a/infra/production/etc/systemd/system/learning-app-run.service
+++ b/infra/production/etc/systemd/system/learning-app-run.service
@@ -17,7 +17,7 @@ StateDirectory=learning-app
 StateDirectoryMode=2770
 Restart=always
 RestartSec=10
-ExecStart=sh -c 'if [ -z "${OPENROUTER_API_KEY:-}" ] && [ -n "${OPENROUTER_API_KEY_PATH:-}" ] && [ -f "${OPENROUTER_API_KEY_PATH}" ]; then export OPENROUTER_API_KEY="$(cat "${OPENROUTER_API_KEY_PATH}")"; fi; if [ -z "${LEARNING_APP_DB_AUTH_SECRET:-}" ] && [ -n "${LEARNING_APP_DB_AUTH_SECRET_PATH:-}" ] && [ -f "${LEARNING_APP_DB_AUTH_SECRET_PATH}" ]; then export LEARNING_APP_DB_AUTH_SECRET="$(cat "${LEARNING_APP_DB_AUTH_SECRET_PATH}")"; fi; java -jar /opt/learning-app/learning-app.jar'
+ExecStart=sh -c 'if [ -z "${OPENROUTER_API_KEY:-}" ] && [ -n "${OPENROUTER_API_KEY_PATH:-}" ] && [ -f "${OPENROUTER_API_KEY_PATH}" ]; then export OPENROUTER_API_KEY="$(cat "${OPENROUTER_API_KEY_PATH}")"; fi; if [ -z "${LEARNING_APP_DB_AUTH_SECRET:-}" ] && [ -n "${LEARNING_APP_DB_AUTH_SECRET_PATH:-}" ] && [ -f "${LEARNING_APP_DB_AUTH_SECRET_PATH}" ]; then export LEARNING_APP_DB_AUTH_SECRET="$(cat "${LEARNING_APP_DB_AUTH_SECRET_PATH}")"; fi; if [ -z "${LEARNING_APP__COUCHDB_PASSWORD:-}" ] && [ -n "${LEARNING_APP__COUCHDB_PASSWORD_PATH:-}" ] && [ -f "${LEARNING_APP__COUCHDB_PASSWORD_PATH}" ]; then export LEARNING_APP__COUCHDB_PASSWORD="$(cat "${LEARNING_APP__COUCHDB_PASSWORD_PATH}")"; fi; java -jar /opt/learning-app/learning-app.jar'
 
 # Environment
 EnvironmentFile=-/etc/learning-app/environment
@@ -26,6 +26,11 @@ LoadCredentialEncrypted=openrouter_api_key:/etc/credstore.encrypted/openrouter_a
 Environment=OPENROUTER_API_KEY_PATH=%d/openrouter_api_key
 LoadCredentialEncrypted=db_auth_secret:/etc/credstore.encrypted/db_auth_secret
 Environment=LEARNING_APP_DB_AUTH_SECRET_PATH=%d/db_auth_secret
+# The same credential dictionary-import and postinst already use: the app's
+# server-side CouchDB calls must authenticate against the real admin
+# password, not the dev fallback (#246).
+LoadCredentialEncrypted=couchdb_admin_password:/etc/credstore.encrypted/couchdb_admin_password
+Environment=LEARNING_APP__COUCHDB_PASSWORD_PATH=%d/couchdb_admin_password
 
 # Security settings
 #

--- a/infra/production/opt/learning-app/bin/run.sh
+++ b/infra/production/opt/learning-app/bin/run.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Bridges systemd credentials into the environment the app reads: every
+# secret is a file under $CREDENTIALS_DIRECTORY (decrypted by systemd),
+# and the app wants plain env vars. An already-set variable wins, so a
+# dev override in /etc/learning-app/environment keeps working.
+set -eu
+
+env_from_file() {
+    var="$1"
+    file="$2"
+    if [ -z "$(eval "printf %s \"\${$var:-}\"")" ] && [ -n "$file" ] && [ -f "$file" ]; then
+        export "$var"="$(cat "$file")"
+    fi
+}
+
+env_from_file OPENROUTER_API_KEY              "${OPENROUTER_API_KEY_PATH:-}"
+env_from_file LEARNING_APP_DB_AUTH_SECRET     "${LEARNING_APP_DB_AUTH_SECRET_PATH:-}"
+env_from_file LEARNING_APP__COUCHDB_PASSWORD  "${LEARNING_APP__COUCHDB_PASSWORD_PATH:-}"
+
+exec java -jar /opt/learning-app/learning-app.jar

--- a/lib/db/src/db.cljc
+++ b/lib/db/src/db.cljc
@@ -20,11 +20,17 @@
 
 
 (def conn
+  ;; The credentials come from the environment so the packaged app can talk
+  ;; to a CouchDB whose admin password is not the dev one (#246). The
+  ;; fallbacks match the dev stand; core refuses to boot packaged without
+  ;; the real password.
   {:scheme   "http"
    :host     "localhost"
    :port     5984
-   :username "admin"
-   :password "3434"})
+   :username #?(:clj (or (System/getenv "LEARNING_APP__COUCHDB_USER") "admin")
+                :cljs "admin")
+   :password #?(:clj (or (System/getenv "LEARNING_APP__COUCHDB_PASSWORD") "3434")
+                :cljs "3434")})
 
 
 #?(:clj

--- a/lib/db/src/db.cljc
+++ b/lib/db/src/db.cljc
@@ -19,18 +19,18 @@
 (defn- kebab->snake [k] (str/replace (name k) #"-" "_"))
 
 
-(def conn
-  ;; The credentials come from the environment so the packaged app can talk
-  ;; to a CouchDB whose admin password is not the dev one (#246). The
-  ;; fallbacks match the dev stand; core refuses to boot packaged without
-  ;; the real password.
-  {:scheme   "http"
-   :host     "localhost"
-   :port     5984
-   :username #?(:clj (or (System/getenv "LEARNING_APP__COUCHDB_USER") "admin")
-                :cljs "admin")
-   :password #?(:clj (or (System/getenv "LEARNING_APP__COUCHDB_PASSWORD") "3434")
-                :cljs "3434")})
+#?(:clj
+   (def conn
+     ;; Server-side only: the browser talks to CouchDB through the nginx
+     ;; proxy and never holds credentials. The env vars let a packaged app
+     ;; talk to a CouchDB whose admin password is not the dev one (#246);
+     ;; the fallbacks match the dev stand, and core refuses to boot
+     ;; packaged without the real password.
+     {:scheme   "http"
+      :host     "localhost"
+      :port     5984
+      :username (or (System/getenv "LEARNING_APP__COUCHDB_USER") "admin")
+      :password (or (System/getenv "LEARNING_APP__COUCHDB_PASSWORD") "3434")}))
 
 
 #?(:clj

--- a/openspec/changes/archive/2026-08-07-couchdb-creds-env/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-07-couchdb-creds-env/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-with-adr
+created: 2026-08-07

--- a/openspec/changes/archive/2026-08-07-couchdb-creds-env/proposal.md
+++ b/openspec/changes/archive/2026-08-07-couchdb-creds-env/proposal.md
@@ -1,0 +1,15 @@
+# CouchDB credentials from the environment
+
+## Why
+
+lib/db hardcodes the dev credentials, and a packaged deployment has no way to override them — any environment whose CouchDB password differs loses every admin-side call: provisioning, reconciliation, the push fan-in. Staging never noticed because its preseed matches the dev value.
+
+## What changes
+
+- `db/conn` reads `LEARNING_APP__COUCHDB_USER` / `LEARNING_APP__COUCHDB_PASSWORD`, falling back to the dev values.
+- `-main` refuses to boot a packaged app without the password — silently wrong credentials keep the server up while everything admin-side 401s, which is exactly the failure this closes.
+- `learning-app-run.service` loads the `couchdb_admin_password` credential postinst and dictionary-import already use, and exports it into the app's environment.
+
+## Impact
+
+`lib/db/src/db.cljc`, `src/backend/core.clj` (+2 tests), `infra/production/etc/systemd/system/learning-app-run.service`. Spec: backend-configuration.

--- a/openspec/changes/archive/2026-08-07-couchdb-creds-env/specs/backend-configuration/spec.md
+++ b/openspec/changes/archive/2026-08-07-couchdb-creds-env/specs/backend-configuration/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: CouchDB credentials come from the environment
+The backend SHALL authenticate its server-side CouchDB calls with credentials from `LEARNING_APP__COUCHDB_USER` / `LEARNING_APP__COUCHDB_PASSWORD`, SHALL fall back to the dev-stand values only in a source checkout, and a packaged app SHALL refuse to start without the password rather than run with credentials that 401 on every admin call.
+
+#### Scenario: Packaged app without the password
+- **WHEN** the jar starts with no `LEARNING_APP__COUCHDB_PASSWORD` in its environment
+- **THEN** boot fails with an error naming the variable
+
+#### Scenario: Source checkout
+- **WHEN** the app runs from a checkout with no CouchDB variables set
+- **THEN** it uses the dev stand's admin credentials
+
+#### Scenario: Production unit
+- **WHEN** the packaged app starts under systemd
+- **THEN** the unit exports the decrypted `couchdb_admin_password` credential as `LEARNING_APP__COUCHDB_PASSWORD`

--- a/openspec/changes/archive/2026-08-07-couchdb-creds-env/tasks.md
+++ b/openspec/changes/archive/2026-08-07-couchdb-creds-env/tasks.md
@@ -1,0 +1,6 @@
+# Tasks
+
+- [x] 1. `db/conn` credentials from env with dev fallbacks
+- [x] 2. Boot guard in `-main`: packaged app without `LEARNING_APP__COUCHDB_PASSWORD` refuses to start; tests
+- [x] 3. Unit loads the existing `couchdb_admin_password` credential and exports it
+- [x] 4. Container smoke green (staging credstore already carries the credential)

--- a/openspec/specs/backend-configuration/spec.md
+++ b/openspec/specs/backend-configuration/spec.md
@@ -63,3 +63,18 @@ Every `:git/tag` + `:git/sha` coordinate in the repository SHALL name the same c
 - **WHEN** a coordinate pins a tag with the sha of a different commit
 - **THEN** a clean-cache build fails, and the fix is aligning the sha with the tag
 
+### Requirement: CouchDB credentials come from the environment
+The backend SHALL authenticate its server-side CouchDB calls with credentials from `LEARNING_APP__COUCHDB_USER` / `LEARNING_APP__COUCHDB_PASSWORD`, SHALL fall back to the dev-stand values only in a source checkout, and a packaged app SHALL refuse to start without the password rather than run with credentials that 401 on every admin call.
+
+#### Scenario: Packaged app without the password
+- **WHEN** the jar starts with no `LEARNING_APP__COUCHDB_PASSWORD` in its environment
+- **THEN** boot fails with an error naming the variable
+
+#### Scenario: Source checkout
+- **WHEN** the app runs from a checkout with no CouchDB variables set
+- **THEN** it uses the dev stand's admin credentials
+
+#### Scenario: Production unit
+- **WHEN** the packaged app starts under systemd
+- **THEN** the unit exports the decrypted `couchdb_admin_password` credential as `LEARNING_APP__COUCHDB_PASSWORD`
+

--- a/src/backend/core.clj
+++ b/src/backend/core.clj
@@ -77,6 +77,15 @@
   (configured-db-auth-secret (System/getenv) running-from-source?))
 
 
+(defn- require-couchdb-password!
+  "The value itself is read by lib/db's `conn` at load; this only refuses to
+   serve a packaged app on the dev fallback — silently wrong credentials keep
+   the server up while provisioning, reconciliation and push all 401 (#246)."
+  [env from-source?]
+  (when-not (or (get env "LEARNING_APP__COUCHDB_PASSWORD") from-source?)
+    (throw (ex-info "LEARNING_APP__COUCHDB_PASSWORD is required outside a source checkout" {}))))
+
+
 ;;
 ;; DB
 ;;
@@ -644,6 +653,7 @@
     ;; speak before the server starts, and events without a handler are
     ;; dropped silently (#218 — the dev alias ships none).
     (ensure-log-handler!)
+    (require-couchdb-password! (System/getenv) running-from-source?)
     ;; Adopt, then migrate, then serve: the app never runs against an
     ;; outdated schema or a stranded database.
     (adopt-legacy-database!)

--- a/src/backend/core.clj
+++ b/src/backend/core.clj
@@ -78,9 +78,12 @@
 
 
 (defn- require-couchdb-password!
-  "The value itself is read by lib/db's `conn` at load; this only refuses to
-   serve a packaged app on the dev fallback — silently wrong credentials keep
-   the server up while provisioning, reconciliation and push all 401 (#246)."
+  "The dev fallback in lib/db's `conn` serves exactly one audience: a source
+   checkout talking to the dev stand's CouchDB. For the packaged app the
+   fallback is never right — its CouchDB has a real password — but with wrong
+   credentials the server still boots and looks alive while provisioning,
+   reconciliation and push silently 401. So the jar demands the variable up
+   front and dies loudly instead (#246)."
   [env from-source?]
   (when-not (or (get env "LEARNING_APP__COUCHDB_PASSWORD") from-source?)
     (throw (ex-info "LEARNING_APP__COUCHDB_PASSWORD is required outside a source checkout" {}))))

--- a/test/backend/core_test.clj
+++ b/test/backend/core_test.clj
@@ -131,6 +131,17 @@
   (is (= "secret" (#'sut/configured-db-auth-secret {} true))))
 
 
+(deftest a-packaged-app-without-a-couchdb-password-refuses-to-start
+  (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                        #"LEARNING_APP__COUCHDB_PASSWORD"
+                        (#'sut/require-couchdb-password! {} false))))
+
+
+(deftest a-couchdb-password-or-a-checkout-satisfies-the-guard
+  (is (nil? (#'sut/require-couchdb-password! {"LEARNING_APP__COUCHDB_PASSWORD" "x"} false)))
+  (is (nil? (#'sut/require-couchdb-password! {} true))))
+
+
 (deftest a-recycled-id-is-refused-not-inherited
   (testing "a userdb left by a previous owner of the id blocks provisioning"
     (let [db (migrated-db)]


### PR DESCRIPTION
The app's server-side CouchDB calls authenticated with the hardcoded dev fallback — a packaged deployment has no way to supply real credentials. Now: `LEARNING_APP__COUCHDB_PASSWORD` from the environment (the unit exports the credential postinst already holds), dev fallback only in a source checkout, packaged boot refuses without the password.

Closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)