### PR TITLE
Home refreshes after every replication pass

### DIFF
--- a/openspec/specs/push-sync/spec.md
+++ b/openspec/specs/push-sync/spec.md
@@ -31,6 +31,7 @@ The client SHALL hold the poke socket only while the page is visible, SHALL pull
 #### Scenario: Idle device learns of a remote write
 - **WHEN** another device of the same account writes a word
 - **THEN** the idle visible device pulls without navigation and the word appears locally
+- **AND** the current page reflects it — home recomputes lesson availability without touching a half-typed add form
 
 #### Scenario: Pairing confirmed by its own echo
 - **WHEN** the QR carried nonce N and a new device adopts the account and writes receipt `pairing:N`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "agent-a50136ddd22f72382",
+  "name": "learning-app",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/src/client/application.cljs
+++ b/src/client/application.cljs
@@ -479,7 +479,7 @@
   [dispatch]
   [["/home"
     {:name        :page/home
-     :controllers [{:start #(dispatch [[:effect/load-home]])}]}]
+     :controllers [{:start #(dispatch [[:effect/load-home] [:effect/sync-pull]])}]}]
    ["/words"
     {:name        :page/words
      :controllers [{:start #(dispatch [[:effect/load-words] [:effect/sync-pull]])}]}]

--- a/src/client/pages/home/actions.cljs
+++ b/src/client/pages/home/actions.cljs
@@ -16,7 +16,11 @@
   (fn show-home [_ {:keys [active-id active-name total]}]
     [[:effect/save
       {:page/current        :page/home
-       :page/load           nil
+       ;; Reloaded after every replication pass (#255): lesson availability
+       ;; is derived from synced data, so a pull landing while the user sits
+       ;; here — a poke, a pairing adoption — must recompute it. The refresh
+       ;; variant leaves the add form alone.
+       :page/load           [:effect/refresh-home]
        :home/active-coll-id active-id
        :home/active-coll-name active-name
        :home/add-error      nil
@@ -24,6 +28,14 @@
        :home/suggestions    empty-suggestions
        :home/translation    ""
        :home/word           ""}]]))
+
+
+(nxr/register-action! :action/refresh-home
+  (fn refresh-home [_ {:keys [active-id active-name total]}]
+    [[:effect/save
+      {:home/active-coll-id   active-id
+       :home/active-coll-name active-name
+       :home/empty-vocab?     (zero? total)}]]))
 
 
 (nxr/register-action! :action/handle-collection-rename-keydown

--- a/src/client/pages/home/effects.cljs
+++ b/src/client/pages/home/effects.cljs
@@ -43,19 +43,35 @@
       {:active-id nil :active-name nil :word-count nil})))
 
 
+(defn- ^:async home-data
+  [capabilities]
+  (let [colls (:collections capabilities)
+        total (await (vocabulary/count capabilities))
+        {:keys [active-id active-name word-count]} (await (resolve-active colls))]
+    {:active-id   active-id
+     :active-name active-name
+     :total       (or word-count total)}))
+
+
 (nxr/register-effect! :effect/load-home
   (fn ^:async load-home
     [{:keys [capabilities dispatch]} _]
     (try
-      (let [colls (:collections capabilities)
-            total (await (vocabulary/count capabilities))
-            {:keys [active-id active-name word-count]} (await (resolve-active colls))]
-        (dispatch [[:action/show-home
-                    {:active-id   active-id
-                     :active-name active-name
-                     :total       (or word-count total)}]]))
+      (dispatch [[:action/show-home (await (home-data capabilities))]])
       (catch js/Error err
         (log/error :effect/load-home {:error (str err)})))))
+
+
+(nxr/register-effect! :effect/refresh-home
+  ;; The post-pull reload (#255): recomputes what synced data decides —
+  ;; lesson availability, the active collection — without :action/show-home's
+  ;; reset of the add form the user may be typing into.
+  (fn ^:async refresh-home
+    [{:keys [capabilities dispatch]} _]
+    (try
+      (dispatch [[:action/refresh-home (await (home-data capabilities))]])
+      (catch js/Error err
+        (log/error :effect/refresh-home {:error (str err)})))))
 
 
 (nxr/register-effect! :effect/suggest-completions


### PR DESCRIPTION
Home set `:page/load nil`, so a pull landing while the user sits there (poke, pairing adoption) never recomputed lesson availability — the button waited for a navigation. Now home reloads a derived-only slice after each pass (the add form a user may be typing into is untouched) and pulls on entry like the other data pages.

Proven live on the stand both ways: adopted device shows the button without navigation; a poke mid-typing preserved the input. Playwright suite 3/3.

Closes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)