### PR TITLE
GH-257 Render token-info dialog on lesson page

### DIFF
--- a/openspec/changes/archive/2026-08-08-lesson-token-info-render/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-08-lesson-token-info-render/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-with-adr
+created: 2026-08-08

--- a/openspec/changes/archive/2026-08-08-lesson-token-info-render/proposal.md
+++ b/openspec/changes/archive/2026-08-08-lesson-token-info-render/proposal.md
@@ -1,0 +1,24 @@
+# Proposal: lesson-token-info-render
+
+## Why
+
+Clicking an annotated word in the revealed correct answer no longer opens the token-info card, so unknown words cannot be added to the dictionary from a lesson. Regression from the Replicant migration (GH-151): `pages.lesson.view/token-info-dialog` was ported as a function but never wired into the render tree — the click writes `:modal/type :token-info` into state and nothing reads it. GitHub issue: #257.
+
+## What Changes
+
+- Lesson page renders `token-info-dialog` when modal state is `:token-info`, restoring the card (known word / add translation / add to dictionary) on token click.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `lesson`: token-info card SHALL open when the user activates an annotated word in the revealed correct answer; card actions add the word or translation to the vocabulary.
+
+## Impact
+
+- `src/client/pages/lesson/view.cljs` — render the dialog from lesson page state.
+- No backend, data-model, or port changes.

--- a/openspec/changes/archive/2026-08-08-lesson-token-info-render/specs/lesson/spec.md
+++ b/openspec/changes/archive/2026-08-08-lesson-token-info-render/specs/lesson/spec.md
@@ -1,0 +1,23 @@
+# lesson Delta
+
+## ADDED Requirements
+
+### Requirement: Answer token click opens token-info card
+
+The lesson UI SHALL open a token-info card when the user activates an annotated word in the revealed correct answer. The card SHALL reflect the word's vocabulary state and offer the matching action.
+
+#### Scenario: Unknown word
+
+- **WHEN** the user clicks an annotated word whose dictionary form is not in the vocabulary
+- **THEN** a card opens showing the dictionary form and translation
+- **AND** the card offers an add-to-dictionary action that saves the word with the translation
+
+#### Scenario: Known word missing this translation
+
+- **WHEN** the user clicks an annotated word that exists in the vocabulary without this translation
+- **THEN** the card offers an add-translation action that merges the translation into the word
+
+#### Scenario: Known word with translation
+
+- **WHEN** the user clicks an annotated word already stored with this translation
+- **THEN** the card shows the word as already in the dictionary and dismisses itself

--- a/openspec/changes/archive/2026-08-08-lesson-token-info-render/tasks.md
+++ b/openspec/changes/archive/2026-08-08-lesson-token-info-render/tasks.md
@@ -1,0 +1,7 @@
+## 1. Fix
+
+- [x] 1.1 Render `token-info-dialog` from the lesson page when `:modal/type` is `:token-info`, passing `:modal/data`
+
+## 2. Verify
+
+- [x] 2.1 Browser check: click annotated word in revealed answer opens the card; add-to-dictionary works

--- a/openspec/specs/lesson/spec.md
+++ b/openspec/specs/lesson/spec.md
@@ -134,3 +134,23 @@ The lesson answer field SHALL be a multi-line textarea with browser text assista
 - **WHEN** the typed answer exceeds the field width
 - **THEN** the text soft-wraps onto further lines within the textarea
 
+### Requirement: Answer token click opens token-info card
+
+The lesson UI SHALL open a token-info card when the user activates an annotated word in the revealed correct answer. The card SHALL reflect the word's vocabulary state and offer the matching action.
+
+#### Scenario: Unknown word
+
+- **WHEN** the user clicks an annotated word whose dictionary form is not in the vocabulary
+- **THEN** a card opens showing the dictionary form and translation
+- **AND** the card offers an add-to-dictionary action that saves the word with the translation
+
+#### Scenario: Known word missing this translation
+
+- **WHEN** the user clicks an annotated word that exists in the vocabulary without this translation
+- **THEN** the card offers an add-translation action that merges the translation into the word
+
+#### Scenario: Known word with translation
+
+- **WHEN** the user clicks an annotated word already stored with this translation
+- **THEN** the card shows the word as already in the dictionary and dismisses itself
+

--- a/src/client/pages/lesson/view.cljs
+++ b/src/client/pages/lesson/view.cljs
@@ -168,6 +168,8 @@
     (empty-state)
     (let [lesson-state (:lesson/state state)]
       [:div.lesson
+       (when (= :token-info (:modal/type state))
+         (token-info-dialog (:modal/data state)))
        [:h1.lesson__title "Урок"]
        [:header.lesson__header
         (progress lesson-state {})

--- a/test/client/pages/lesson_view_test.cljs
+++ b/test/client/pages/lesson_view_test.cljs
@@ -1,0 +1,41 @@
+(ns client.pages.lesson-view-test
+  "Token-info card in the lesson page render tree (GH-257): the click on an
+   annotated answer word saves :modal/type :token-info, and the page must
+   actually render the dialog for that state — after the Replicant migration
+   the dialog function existed but nothing called it."
+  (:require
+   [cljs.test :refer-macros [deftest is testing]]
+   [domain.lesson :as domain]
+   [pages.lesson.view :as sut]))
+
+
+(defn- lesson-page-state
+  [modal]
+  (merge {:lesson/state (domain/initial-state
+                         [{:id "word-1" :value "der Hund" :translation "пёс"}]
+                         []
+                         :first)}
+         modal))
+
+
+(defn- contains-node?
+  [tree tag]
+  (->> (tree-seq coll? seq tree)
+       (some #(= tag %))
+       boolean))
+
+
+(deftest page-renders-token-info-dialog-for-modal-state
+  (testing "modal state :token-info puts the dialog into the render tree"
+    (let [page (sut/page (lesson-page-state
+                          {:modal/data {:dictionary-form "die Katze"
+                                        :state       :unknown-word
+                                        :translation "кошка"}
+                           :modal/type :token-info}))]
+      (is (contains-node? page :dialog#token-info-dialog)))))
+
+
+(deftest page-omits-token-info-dialog-without-modal-state
+  (testing "no modal state — no dialog in the render tree"
+    (is (not (contains-node? (sut/page (lesson-page-state {}))
+                             :dialog#token-info-dialog)))))


### PR DESCRIPTION
Closes #257.

Regression from the Replicant migration (GH-151): `token-info-dialog` survived as a function but nothing rendered it — clicking an annotated word in the revealed answer wrote `:modal/type :token-info` into state nobody read, so unknown words could not be added to the dictionary from a lesson.

Fix: lesson page renders the dialog when modal state is `:token-info`.

Verified:
- new view test: dialog in render tree with modal state, absent without; fails on pre-fix code
- node test suite: 160 tests, 0 failures
- real browser (local backend, Playwright): dialog opens, «+ В СЛОВАРЬ» click saves the word, word appears in vocabulary; committed browser suite 3/3 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)