### PR TITLE
GH-273 Token-info card is an anchored popover again

### DIFF
--- a/openspec/changes/archive/2026-08-08-lesson-token-popover/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-08-lesson-token-popover/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-with-adr
+created: 2026-08-08

--- a/openspec/changes/archive/2026-08-08-lesson-token-popover/proposal.md
+++ b/openspec/changes/archive/2026-08-08-lesson-token-popover/proposal.md
@@ -1,0 +1,28 @@
+# Proposal: lesson-token-popover
+
+## Why
+
+GH-257 restored the token-info card as a native `<dialog>` (showModal): it opens centered with UA dialog chrome and a focus ring on the action button. The pre-Replicant UX was a popover anchored above the clicked word with an arrow, light-dismiss, and auto-close timers (`popover.js`, dropped in GH-151). GitHub issue: #273.
+
+## What Changes
+
+- Token-info card renders as an anchored popover above the clicked answer token (HTML Popover API), replacing the centered modal dialog.
+- Auto-close behavior restored: 900 ms for a word already in the dictionary, idle timeout on hover-capable devices, pointer/focus inside the card cancels the timer.
+- Add action shown only when the word or the translation is missing from the vocabulary (unchanged logic, restated).
+- `popover.js` positioning/auto-close logic ported into a ClojureScript namespace driven by lesson effects; no separate static JS file.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `lesson`: token-info card SHALL be an anchored popover with light-dismiss and auto-close, not a centered modal.
+
+## Impact
+
+- `src/client/pages/lesson/view.cljs` — popover shell instead of `<dialog>`; aria-expanded on tokens.
+- `src/client/pages/lesson/effects.cljs` + new popover namespace — show/position/auto-close wiring.
+- `resources/public/css/blocks/popover.css`, `token-card.css` — already present, reused.

--- a/openspec/changes/archive/2026-08-08-lesson-token-popover/specs/lesson/spec.md
+++ b/openspec/changes/archive/2026-08-08-lesson-token-popover/specs/lesson/spec.md
@@ -1,0 +1,30 @@
+# lesson Delta
+
+## MODIFIED Requirements
+
+### Requirement: Answer token click opens token-info card
+
+The lesson UI SHALL open a token-info card when the user activates an annotated word in the revealed correct answer. The card SHALL render as a popover anchored to the activated word — not as a centered modal — with an arrow pointing at the word, and SHALL reflect the word's vocabulary state, offering the matching action.
+
+#### Scenario: Unknown word
+
+- **WHEN** the user clicks an annotated word whose dictionary form is not in the vocabulary
+- **THEN** a popover opens anchored above the word (below when there is no room above), showing the dictionary form and translation
+- **AND** the popover offers an add-to-dictionary action that saves the word with the translation
+
+#### Scenario: Known word missing this translation
+
+- **WHEN** the user clicks an annotated word that exists in the vocabulary without this translation
+- **THEN** the popover offers an add-translation action that merges the translation into the word
+
+#### Scenario: Known word with translation
+
+- **WHEN** the user clicks an annotated word already stored with this translation
+- **THEN** the popover shows the word as already in the dictionary and dismisses itself after a short delay
+
+#### Scenario: Dismissal
+
+- **WHEN** the popover is open
+- **THEN** clicking outside it or pressing Escape closes it
+- **AND** on hover-capable devices it auto-closes after an idle timeout unless the pointer or focus is inside it
+- **AND** no modal chrome, backdrop dimming, or forced focus ring is presented

--- a/openspec/changes/archive/2026-08-08-lesson-token-popover/tasks.md
+++ b/openspec/changes/archive/2026-08-08-lesson-token-popover/tasks.md
@@ -1,0 +1,13 @@
+## 1. Popover mechanics
+
+- [x] 1.1 Port `popover.js` positioning + auto-close into `pages.lesson.popover` (cljs): position at anchor rect, flip below when no room, arrow offset, timers (data-dismiss / idle / leave), resize+scroll reposition
+- [x] 1.2 Lesson view: replace `<dialog>` with `#popover` shell (Popover API) containing the token card and arrow; `aria-expanded` on the active token
+
+## 2. Wiring
+
+- [x] 2.1 Effects: open popover after render, reposition after add-token content swap, dispatch close-modal on popover close
+
+## 3. Verify
+
+- [x] 3.1 Update view unit test (popover shell instead of dialog)
+- [x] 3.2 Browser check with geometry assertions: popover anchored to token, no centered dialog, auto-close works

--- a/openspec/specs/lesson/spec.md
+++ b/openspec/specs/lesson/spec.md
@@ -136,21 +136,28 @@ The lesson answer field SHALL be a multi-line textarea with browser text assista
 
 ### Requirement: Answer token click opens token-info card
 
-The lesson UI SHALL open a token-info card when the user activates an annotated word in the revealed correct answer. The card SHALL reflect the word's vocabulary state and offer the matching action.
+The lesson UI SHALL open a token-info card when the user activates an annotated word in the revealed correct answer. The card SHALL render as a popover anchored to the activated word — not as a centered modal — with an arrow pointing at the word, and SHALL reflect the word's vocabulary state, offering the matching action.
 
 #### Scenario: Unknown word
 
 - **WHEN** the user clicks an annotated word whose dictionary form is not in the vocabulary
-- **THEN** a card opens showing the dictionary form and translation
-- **AND** the card offers an add-to-dictionary action that saves the word with the translation
+- **THEN** a popover opens anchored above the word (below when there is no room above), showing the dictionary form and translation
+- **AND** the popover offers an add-to-dictionary action that saves the word with the translation
 
 #### Scenario: Known word missing this translation
 
 - **WHEN** the user clicks an annotated word that exists in the vocabulary without this translation
-- **THEN** the card offers an add-translation action that merges the translation into the word
+- **THEN** the popover offers an add-translation action that merges the translation into the word
 
 #### Scenario: Known word with translation
 
 - **WHEN** the user clicks an annotated word already stored with this translation
-- **THEN** the card shows the word as already in the dictionary and dismisses itself
+- **THEN** the popover shows the word as already in the dictionary and dismisses itself after a short delay
+
+#### Scenario: Dismissal
+
+- **WHEN** the popover is open
+- **THEN** clicking outside it or pressing Escape closes it
+- **AND** on hover-capable devices it auto-closes after an idle timeout unless the pointer or focus is inside it
+- **AND** no modal chrome, backdrop dimming, or forced focus ring is presented
 

--- a/src/client/pages/lesson/actions.cljs
+++ b/src/client/pages/lesson/actions.cljs
@@ -47,13 +47,18 @@
 
 
 (nxr/register-action! :action/view-token-info
-  (fn view-token-info [_ {:keys [dictionary-form translation]}]
-    [[:effect/open-token-info {:dictionary-form dictionary-form :translation translation}]]))
+  (fn view-token-info [_ payload]
+    [[:effect/open-token-info payload]]))
+
+
+(nxr/register-action! :action/show-token-popover
+  (fn show-token-popover [_ word-index]
+    [[:effect/show-token-popover word-index]]))
 
 
 (nxr/register-action! :action/save-lesson-word
-  (fn save-lesson-word [_ {:keys [dictionary-form translation]}]
-    [[:effect/add-token {:dictionary-form dictionary-form :translation translation}]]))
+  (fn save-lesson-word [_ payload]
+    [[:effect/add-token payload]]))
 
 
 (nxr/register-action! :action/focus-lesson-input

--- a/src/client/pages/lesson/actions.cljs
+++ b/src/client/pages/lesson/actions.cljs
@@ -14,7 +14,15 @@
 
 (nxr/register-action! :action/update-lesson
   (fn update-lesson [_ lesson-state]
-    [[:effect/save {:lesson/state lesson-state}]]))
+    [[:effect/save
+      {:lesson/state        lesson-state
+       :lesson/answer-hints nil
+       :lesson/open-hint-index nil}]]))
+
+
+(nxr/register-action! :action/annotate-answer
+  (fn annotate-answer [_ hints]
+    [[:effect/save {:lesson/answer-hints hints}]]))
 
 
 (nxr/register-action! :action/check-answer
@@ -36,19 +44,14 @@
 (nxr/register-action! :action/finish-lesson end-lesson-handler)
 
 
-(nxr/register-action! :action/open-modal
-  (fn open-modal [_ data]
-    [[:effect/save {:modal/type :token-info :modal/data data}]]))
+(nxr/register-action! :action/open-answer-hint
+  (fn open-answer-hint [_ word-index]
+    [[:effect/save {:lesson/open-hint-index word-index}]]))
 
 
-(nxr/register-action! :action/close-modal
-  (fn close-modal [_]
-    [[:effect/save {:modal/type nil :modal/data nil}]]))
-
-
-(nxr/register-action! :action/view-token-info
-  (fn view-token-info [_ payload]
-    [[:effect/open-token-info payload]]))
+(nxr/register-action! :action/close-answer-hint
+  (fn close-answer-hint [_]
+    [[:effect/save {:lesson/open-hint-index nil}]]))
 
 
 (nxr/register-action! :action/show-token-popover

--- a/src/client/pages/lesson/actions.cljs
+++ b/src/client/pages/lesson/actions.cljs
@@ -61,8 +61,8 @@
 
 
 (nxr/register-action! :action/save-lesson-word
-  (fn save-lesson-word [_ payload]
-    [[:effect/add-token payload]]))
+  (fn save-lesson-word [state payload]
+    [[:effect/add-token (assoc payload :hints (:lesson/answer-hints state))]]))
 
 
 (nxr/register-action! :action/focus-lesson-input

--- a/src/client/pages/lesson/actions.cljs
+++ b/src/client/pages/lesson/actions.cljs
@@ -46,7 +46,8 @@
 
 (nxr/register-action! :action/open-answer-hint
   (fn open-answer-hint [_ word-index]
-    [[:effect/save {:lesson/open-hint-index word-index}]]))
+    [[:effect/save {:lesson/open-hint-index word-index}]
+     [:effect/show-token-popover]]))
 
 
 (nxr/register-action! :action/close-answer-hint
@@ -54,9 +55,9 @@
     [[:effect/save {:lesson/open-hint-index nil}]]))
 
 
-(nxr/register-action! :action/show-token-popover
-  (fn show-token-popover [_ word-index]
-    [[:effect/show-token-popover word-index]]))
+(nxr/register-action! :action/reposition-token-popover
+  (fn reposition-token-popover [_]
+    [[:effect/reposition-token-popover]]))
 
 
 (nxr/register-action! :action/save-lesson-word

--- a/src/client/pages/lesson/effects.cljs
+++ b/src/client/pages/lesson/effects.cljs
@@ -65,14 +65,7 @@
 (nxr/register-effect! :effect/show-token-popover
   (fn show-token-popover
     [{:keys [dispatch]} _ word-index]
-    ;; Anchor is re-found by data attribute rather than captured from the click:
-    ;; the popover re-anchors on content updates too, when no event exists, and
-    ;; action payloads stay plain data.
-    (let [anchor (js/document.querySelector
-                  (str ".lesson__answer-token[data-word-index=\"" word-index "\"]"))]
-      (if anchor
-        (popover/open! anchor #(dispatch [[:action/close-answer-hint]]))
-        (dispatch [[:action/close-answer-hint]])))))
+    (popover/open-for-word! word-index #(dispatch [[:action/close-answer-hint]]))))
 
 
 (nxr/register-effect! :effect/add-token

--- a/src/client/pages/lesson/effects.cljs
+++ b/src/client/pages/lesson/effects.cljs
@@ -1,5 +1,6 @@
 (ns pages.lesson.effects
   (:require
+   [domain.lesson :as domain]
    [lambdaisland.glogi :as log]
    [nexus.registry :as nxr]
    [pages.lesson.popover :as popover]
@@ -28,7 +29,13 @@
     (try
       (let [{:keys [lesson-state]} (await (lesson/check-answer! capabilities answer))]
         (when lesson-state
-          (dispatch [[:action/update-lesson lesson-state]])))
+          (dispatch [[:action/update-lesson lesson-state]])
+          ;; The revealed answer carries hints for its annotated words; their
+          ;; vocabulary states are looked up once here, not on every click.
+          (let [trial (domain/current-trial lesson-state)]
+            (when (domain/example-trial? trial)
+              (let [hints (await (lesson/answer-annotations capabilities trial))]
+                (dispatch [[:action/annotate-answer hints]]))))))
       (catch js/Error err
         (log/error :effect/check-answer {:error (str err)})))))
 
@@ -55,35 +62,26 @@
         (log/error :effect/end-lesson {:error (str err)})))))
 
 
-(nxr/register-effect! :effect/open-token-info
-  (fn ^:async open-token-info
-    [{:keys [capabilities dispatch]} _ {:keys [dictionary-form translation word-index]}]
-    (try
-      (let [td (await (lesson/token-info capabilities dictionary-form translation))]
-        (dispatch [[:action/open-modal (assoc td :word-index word-index)]]))
-      (catch js/Error err
-        (log/error :effect/open-token-info {:error (str err)})))))
-
-
 (nxr/register-effect! :effect/show-token-popover
   (fn show-token-popover
     [{:keys [dispatch]} _ word-index]
+    ;; Anchor is re-found by data attribute rather than captured from the click:
+    ;; the popover re-anchors on content updates too, when no event exists, and
+    ;; action payloads stay plain data.
     (let [anchor (js/document.querySelector
                   (str ".lesson__answer-token[data-word-index=\"" word-index "\"]"))]
       (if anchor
-        (popover/open! anchor #(dispatch [[:action/close-modal]]))
-        (dispatch [[:action/close-modal]])))))
+        (popover/open! anchor #(dispatch [[:action/close-answer-hint]]))
+        (dispatch [[:action/close-answer-hint]])))))
 
 
 (nxr/register-effect! :effect/add-token
   (fn ^:async add-token
-    [{:keys [capabilities dispatch]} _ {:keys [dictionary-form translation word-index]}]
+    [{:keys [capabilities dispatch]} system {:keys [dictionary-form translation word-index]}]
     (try
       (await (vocabulary/add! capabilities dictionary-form translation))
-      (dispatch [[:action/open-modal
-                  {:dictionary-form dictionary-form
-                   :state           :known-with-translation
-                   :translation     translation
-                   :word-index      word-index}]])
+      (let [hints (:lesson/answer-hints (deref (:store system)))]
+        (dispatch [[:action/annotate-answer
+                    (assoc hints word-index :known-with-translation)]]))
       (catch js/Error err
         (log/error :effect/add-token {:error (str err)})))))

--- a/src/client/pages/lesson/effects.cljs
+++ b/src/client/pages/lesson/effects.cljs
@@ -77,11 +77,12 @@
 
 (nxr/register-effect! :effect/add-token
   (fn ^:async add-token
-    [{:keys [capabilities dispatch]} system {:keys [dictionary-form translation word-index]}]
+    [{:keys [capabilities dispatch]} _ {:keys [dictionary-form hints translation word-index]}]
     (try
       (await (vocabulary/add! capabilities dictionary-form translation))
-      (let [hints (:lesson/answer-hints (deref (:store system)))]
-        (dispatch [[:action/annotate-answer
-                    (assoc hints word-index :known-with-translation)]]))
+      ;; The saved hint map re-renders the open card to its added state;
+      ;; the popover's on-update then repositions the shell.
+      (dispatch [[:action/annotate-answer
+                  (assoc hints word-index :known-with-translation)]])
       (catch js/Error err
         (log/error :effect/add-token {:error (str err)})))))

--- a/src/client/pages/lesson/effects.cljs
+++ b/src/client/pages/lesson/effects.cljs
@@ -2,6 +2,7 @@
   (:require
    [lambdaisland.glogi :as log]
    [nexus.registry :as nxr]
+   [pages.lesson.popover :as popover]
    [use-cases.lesson :as lesson]
    [use-cases.vocabulary :as vocabulary]))
 
@@ -56,25 +57,33 @@
 
 (nxr/register-effect! :effect/open-token-info
   (fn ^:async open-token-info
-    [{:keys [capabilities dispatch]} _ {:keys [dictionary-form translation]}]
+    [{:keys [capabilities dispatch]} _ {:keys [dictionary-form translation word-index]}]
     (try
       (let [td (await (lesson/token-info capabilities dictionary-form translation))]
-        (dispatch [[:action/open-modal td]])
-        (when (= :known-with-translation (:state td))
-          (js/setTimeout #(dispatch [[:action/close-modal]]) 900)))
+        (dispatch [[:action/open-modal (assoc td :word-index word-index)]]))
       (catch js/Error err
         (log/error :effect/open-token-info {:error (str err)})))))
 
 
+(nxr/register-effect! :effect/show-token-popover
+  (fn show-token-popover
+    [{:keys [dispatch]} _ word-index]
+    (let [anchor (js/document.querySelector
+                  (str ".lesson__answer-token[data-word-index=\"" word-index "\"]"))]
+      (if anchor
+        (popover/open! anchor #(dispatch [[:action/close-modal]]))
+        (dispatch [[:action/close-modal]])))))
+
+
 (nxr/register-effect! :effect/add-token
   (fn ^:async add-token
-    [{:keys [capabilities dispatch]} _ {:keys [dictionary-form translation]}]
+    [{:keys [capabilities dispatch]} _ {:keys [dictionary-form translation word-index]}]
     (try
       (await (vocabulary/add! capabilities dictionary-form translation))
       (dispatch [[:action/open-modal
                   {:dictionary-form dictionary-form
-                   :translation translation
-                   :state       :known-with-translation}]])
-      (js/setTimeout #(dispatch [[:action/close-modal]]) 900)
+                   :state           :known-with-translation
+                   :translation     translation
+                   :word-index      word-index}]])
       (catch js/Error err
         (log/error :effect/add-token {:error (str err)})))))

--- a/src/client/pages/lesson/effects.cljs
+++ b/src/client/pages/lesson/effects.cljs
@@ -64,8 +64,15 @@
 
 (nxr/register-effect! :effect/show-token-popover
   (fn show-token-popover
-    [{:keys [dispatch]} _ word-index]
-    (popover/open-for-word! word-index #(dispatch [[:action/close-answer-hint]]))))
+    [{:keys [dispatch dispatch-data]} _]
+    (popover/open! (:replicant/node dispatch-data)
+                   #(dispatch [[:action/close-answer-hint]]))))
+
+
+(nxr/register-effect! :effect/reposition-token-popover
+  (fn reposition-token-popover
+    [_ _]
+    (popover/reposition!)))
 
 
 (nxr/register-effect! :effect/add-token

--- a/src/client/pages/lesson/popover.cljs
+++ b/src/client/pages/lesson/popover.cljs
@@ -129,7 +129,7 @@
                           0)))))
 
 
-(defn open!
+(defn- open!
   "Shows the popover anchored to `anchor`, or re-anchors and repositions an
    already-open one. `on-closed` runs once when the popover closes for any
    reason (light-dismiss, Escape, auto-close)."
@@ -147,6 +147,17 @@
      (fn []
        (position!)
        (schedule-auto-close! (if (active?) 0 (initial-close-ms)))))))
+
+
+(defn open-for-word!
+  "Shows the popover anchored to the answer token carrying `word-index`.
+   Owns the markup details (token selector) so effects stay markup-free.
+   Calls `on-closed` immediately when no such token is rendered."
+  [word-index on-closed]
+  (if-let [anchor (js/document.querySelector
+                   (str ".lesson__answer-token[data-word-index=\"" word-index "\"]"))]
+    (open! anchor on-closed)
+    (on-closed)))
 
 
 (defonce window-listeners

--- a/src/client/pages/lesson/popover.cljs
+++ b/src/client/pages/lesson/popover.cljs
@@ -1,0 +1,151 @@
+(ns pages.lesson.popover
+  "Anchored popover for the lesson token-info card — port of the pre-Replicant
+   popover.js. The HTML Popover API supplies light-dismiss and top-layer
+   rendering; positioning against the anchor rect and the auto-close timers
+   live here. Replicant owns the popover contents; this namespace only moves
+   and shows/hides the shell element.")
+
+
+(def ^:private pad 8)
+
+
+(def ^:private offset 10)
+
+
+(def ^:private idle-open-ms 3000)
+
+
+(def ^:private idle-leave-ms 600)
+
+
+(defonce ^:private state (atom {:anchor nil :on-closed nil :timer nil}))
+
+
+(defn- popover-el
+  []
+  (js/document.getElementById "popover"))
+
+
+(defn- content-el
+  []
+  (js/document.getElementById "popover-content"))
+
+
+(defn- arrow-el
+  []
+  (js/document.getElementById "popover-arrow"))
+
+
+(defn- open?
+  [el]
+  (.matches el ":popover-open"))
+
+
+(defn- position!
+  []
+  (let [pop    (popover-el)
+        arrow  (arrow-el)
+        anchor (:anchor @state)]
+    (when (and pop arrow anchor (open? pop))
+      (let [rect     (.getBoundingClientRect anchor)
+            pw       (.-offsetWidth pop)
+            ph       (.-offsetHeight pop)
+            center-x (+ (.-left rect) (/ (.-width rect) 2))
+            left     (max pad
+                          (min (- js/window.innerWidth pw pad)
+                               (- center-x (/ pw 2))))
+            above    (- (.-top rect) ph offset)
+            flip?    (and (< above pad)
+                          (<= (+ (.-bottom rect) ph offset pad)
+                              js/window.innerHeight))
+            top      (if flip? (+ (.-bottom rect) offset) above)]
+        (set! (.. pop -style -left) (str left "px"))
+        (set! (.. pop -style -top) (str top "px"))
+        (.setAttribute pop "data-side" (if flip? "bottom" "top"))
+        (set! (.. arrow -style -left)
+              (str (max 12 (min (- pw 12) (- center-x left))) "px"))))))
+
+
+(defn- active?
+  []
+  (when-let [pop (popover-el)]
+    (or (.matches pop ":hover")
+        (.contains pop js/document.activeElement))))
+
+
+(defn- clear-auto-timer!
+  []
+  (when-let [timer (:timer @state)]
+    (js/clearTimeout timer)
+    (swap! state assoc :timer nil)))
+
+
+(defn- schedule-auto-close!
+  [ms]
+  (clear-auto-timer!)
+  (when-let [pop (and (pos? (or ms 0)) (popover-el))]
+    (swap! state assoc
+      :timer
+      (js/setTimeout #(when (and (open? pop) (not (active?)))
+                        (.hidePopover pop))
+                     ms))))
+
+
+(defn- initial-close-ms
+  []
+  (let [card   (some-> (content-el) .-firstElementChild)
+        forced (some-> card (.getAttribute "data-dismiss") js/parseInt)]
+    (cond
+      (and forced (pos? forced)) forced
+      (.-matches (js/window.matchMedia "(hover: hover)")) idle-open-ms
+      :else 0)))
+
+
+(defn- wire-listeners!
+  "One-time listeners per shell element. Replicant may recreate the element
+   between opens; the data flag keeps a reused element from double-wiring."
+  [pop]
+  (when-not (.getAttribute pop "data-wired")
+    (.setAttribute pop "data-wired" "true")
+    (.addEventListener pop
+                       "toggle"
+                       (fn [event]
+                         (when (= "closed" (.-newState event))
+                           (clear-auto-timer!)
+                           (let [on-closed (:on-closed @state)]
+                             (swap! state assoc :anchor nil :on-closed nil)
+                             (when on-closed (on-closed))))))
+    (.addEventListener pop "pointerenter" (fn [_] (clear-auto-timer!)))
+    (.addEventListener pop
+                       "pointerleave"
+                       (fn [_] (schedule-auto-close! idle-leave-ms)))
+    (.addEventListener pop "focusin" (fn [_] (clear-auto-timer!)))
+    (.addEventListener pop
+                       "focusout"
+                       (fn [_]
+                         (js/setTimeout
+                          #(when-not (active?)
+                             (schedule-auto-close! idle-leave-ms))
+                          0)))))
+
+
+(defn open!
+  "Shows the popover anchored to `anchor`, or re-anchors and repositions an
+   already-open one. `on-closed` runs once when the popover closes for any
+   reason (light-dismiss, Escape, auto-close)."
+  [anchor on-closed]
+  (when-let [pop (popover-el)]
+    (wire-listeners! pop)
+    (swap! state assoc :anchor anchor :on-closed on-closed)
+    (when-not (open? pop)
+      (.showPopover pop))
+    (js/requestAnimationFrame
+     (fn []
+       (position!)
+       (schedule-auto-close! (if (active?) 0 (initial-close-ms)))))))
+
+
+(defonce window-listeners
+  (do (js/window.addEventListener "resize" position! #js {:passive true})
+      (js/window.addEventListener "scroll" position! #js {:passive true :capture true})
+      true))

--- a/src/client/pages/lesson/popover.cljs
+++ b/src/client/pages/lesson/popover.cljs
@@ -129,35 +129,35 @@
                           0)))))
 
 
-(defn- open!
-  "Shows the popover anchored to `anchor`, or re-anchors and repositions an
-   already-open one. `on-closed` runs once when the popover closes for any
-   reason (light-dismiss, Escape, auto-close)."
+(defn open!
+  "Shows the popover anchored to `anchor` (the clicked token from Replicant's
+   dispatch data), or re-anchors an already-open one. `on-closed` runs once
+   when the popover closes for any reason (light-dismiss, Escape, auto-close).
+
+   Everything is deferred a frame: this runs from the click's effect, before
+   the render that mounts the shell — next frame the shell and the card exist
+   and their sizes are real."
   [anchor on-closed]
-  (when-let [pop (popover-el)]
-    (wire-listeners! pop)
-    (swap! state assoc :anchor anchor :on-closed on-closed)
-    (when-not (open? pop)
-      (.showPopover pop))
-    ;; Positioning reads the popover's rendered size (offsetWidth/Height), and
-    ;; this runs from a Replicant life-cycle hook — the card's content may not
-    ;; be laid out yet. One frame later the size is real and reading it does
-    ;; not force a mid-patch reflow.
-    (js/requestAnimationFrame
-     (fn []
+  (swap! state assoc :anchor anchor :on-closed on-closed)
+  (js/requestAnimationFrame
+   (fn []
+     (when-let [pop (popover-el)]
+       (wire-listeners! pop)
+       (when-not (open? pop)
+         (.showPopover pop))
        (position!)
        (schedule-auto-close! (if (active?) 0 (initial-close-ms)))))))
 
 
-(defn open-for-word!
-  "Shows the popover anchored to the answer token carrying `word-index`.
-   Owns the markup details (token selector) so effects stay markup-free.
-   Calls `on-closed` immediately when no such token is rendered."
-  [word-index on-closed]
-  (if-let [anchor (js/document.querySelector
-                   (str ".lesson__answer-token[data-word-index=\"" word-index "\"]"))]
-    (open! anchor on-closed)
-    (on-closed)))
+(defn reposition!
+  "Recomputes position against the stored anchor and re-arms auto-close after
+   the card's content swap (the add flow changes the card's size and its
+   data-dismiss)."
+  []
+  (js/requestAnimationFrame
+   (fn []
+     (position!)
+     (schedule-auto-close! (if (active?) 0 (initial-close-ms))))))
 
 
 (defonce window-listeners

--- a/src/client/pages/lesson/popover.cljs
+++ b/src/client/pages/lesson/popover.cljs
@@ -139,6 +139,10 @@
     (swap! state assoc :anchor anchor :on-closed on-closed)
     (when-not (open? pop)
       (.showPopover pop))
+    ;; Positioning reads the popover's rendered size (offsetWidth/Height), and
+    ;; this runs from a Replicant life-cycle hook — the card's content may not
+    ;; be laid out yet. One frame later the size is real and reading it does
+    ;; not force a mid-patch reflow.
     (js/requestAnimationFrame
      (fn []
        (position!)

--- a/src/client/pages/lesson/presenter.cljs
+++ b/src/client/pages/lesson/presenter.cljs
@@ -15,13 +15,37 @@
   (domain/progress state))
 
 
+(defn- token-info-data
+  [state]
+  (when (= :token-info (:modal/type state))
+    (:modal/data state)))
+
+
+(defn token-popover-props
+  "Props for the token-info popover, or nil when it is closed. The card
+   auto-dismisses only for a word already stored with this translation."
+  [state]
+  (when-let [data (token-info-data state)]
+    (assoc data :data-dismiss (when (= :known-with-translation (:state data)) "900"))))
+
+
+(defn- answer-segments
+  [trial open-token-index]
+  (mapv (fn [{:keys [word-index] :as segment}]
+          (assoc segment :expanded? (= word-index open-token-index)))
+        (domain/answer-segments trial)))
+
+
 (defn footer-props
   [state]
-  (when-let [result (domain/last-result state)]
-    (let [trial (domain/current-trial state)]
-      {:variant        (if (:correct? result) :success :error)
-       :correct-answer (domain/expected-answer state)
-       :correct-answer-segments (when (domain/example-trial? trial)
-                                  (domain/answer-segments trial))
-       :user-answer    (:answer result)
-       :finished?      (domain/finished? state)})))
+  (let [lesson-state (:lesson/state state)]
+    (when-let [result (domain/last-result lesson-state)]
+      (let [trial (domain/current-trial lesson-state)]
+        {:variant        (if (:correct? result) :success :error)
+         :correct-answer (domain/expected-answer lesson-state)
+         :correct-answer-segments (when (domain/example-trial? trial)
+                                    (answer-segments
+                                     trial
+                                     (:word-index (token-info-data state))))
+         :user-answer    (:answer result)
+         :finished?      (domain/finished? lesson-state)}))))

--- a/src/client/pages/lesson/presenter.cljs
+++ b/src/client/pages/lesson/presenter.cljs
@@ -15,24 +15,37 @@
   (domain/progress state))
 
 
-(defn- token-info-data
+(defn- open-hint-segment
   [state]
-  (when (= :token-info (:modal/type state))
-    (:modal/data state)))
+  (when-let [open-index (:lesson/open-hint-index state)]
+    (->> (domain/answer-segments (domain/current-trial (:lesson/state state)))
+         (filter #(= open-index (:word-index %)))
+         first)))
 
 
-(defn token-popover-props
-  "Props for the token-info popover, or nil when it is closed. The card
-   auto-dismisses only for a word already stored with this translation."
+(defn answer-hint-props
+  "Props for the hint card over the opened answer word, or nil when closed.
+   The card names the word, its translation, and — depending on the word's
+   vocabulary state — either a status note or an add action. A word already
+   stored with this translation auto-dismisses the card."
   [state]
-  (when-let [data (token-info-data state)]
-    (assoc data :data-dismiss (when (= :known-with-translation (:state data)) "900"))))
+  (when-let [{:keys [dictionary-form translation word-index]} (open-hint-segment state)]
+    (let [word-state (get (:lesson/answer-hints state) word-index)]
+      {:word         dictionary-form
+       :translation  translation
+       :word-index   word-index
+       :data-dismiss (when (= :known-with-translation word-state) "900")
+       :status-note  (when (= :known-with-translation word-state) "✓ В словаре")
+       :action-label (case word-state
+                       :known-missing-translation "+ ДОБАВИТЬ ПЕРЕВОД"
+                       :unknown-word "+ В СЛОВАРЬ"
+                       nil)})))
 
 
 (defn- answer-segments
-  [trial open-token-index]
+  [trial open-hint-index]
   (mapv (fn [{:keys [word-index] :as segment}]
-          (assoc segment :expanded? (= word-index open-token-index)))
+          (assoc segment :expanded? (= word-index open-hint-index)))
         (domain/answer-segments trial)))
 
 
@@ -46,6 +59,6 @@
          :correct-answer-segments (when (domain/example-trial? trial)
                                     (answer-segments
                                      trial
-                                     (:word-index (token-info-data state))))
+                                     (:lesson/open-hint-index state)))
          :user-answer    (:answer result)
          :finished?      (domain/finished? lesson-state)}))))

--- a/src/client/pages/lesson/view.cljs
+++ b/src/client/pages/lesson/view.cljs
@@ -116,14 +116,14 @@
 
 
 (defn answer-hint-popover
-  "Popover shell anchored to the opened answer word. The Popover API gives
-   light-dismiss and top-layer rendering; pages.lesson.popover positions the
-   shell and arms the auto-close timers via :action/show-token-popover."
-  [{:keys [word-index] :as props}]
+  "Popover shell anchored to the clicked answer word. The Popover API gives
+   light-dismiss and top-layer rendering; pages.lesson.popover opens the shell
+   at the clicked token (from the click's dispatch data) and re-positions it
+   when the card's content changes."
+  [props]
   [:div#popover.popover
    {:popover "auto"
-    :replicant/on-mount [[:action/show-token-popover word-index]]
-    :replicant/on-update [[:action/show-token-popover word-index]]}
+    :replicant/on-update [[:action/reposition-token-popover]]}
    [:div#popover-content (hint-card props)]
    [:div#popover-arrow.popover__arrow]])
 

--- a/src/client/pages/lesson/view.cljs
+++ b/src/client/pages/lesson/view.cljs
@@ -113,7 +113,8 @@
 (defn- token-card
   [{:keys [dictionary-form translation state] :as data}]
   [:div.token-card
-   (when (= state :known-with-translation) {:data-dismiss "900"})
+   (cond-> {}
+     (= state :known-with-translation) (assoc :data-dismiss "900"))
    [:p.token-card__word {:lang "de"} dictionary-form]
    [:p.token-card__translation {:lang "ru"} translation]
    (case state

--- a/src/client/pages/lesson/view.cljs
+++ b/src/client/pages/lesson/view.cljs
@@ -4,19 +4,19 @@
 
 
 (defn- answer-body
-  [{:keys [correct-answer correct-answer-segments open-token-index]}]
+  [{:keys [correct-answer correct-answer-segments]}]
   (if (seq correct-answer-segments)
     (into
      [:p.lesson__answer-body {:lang "de"}]
      (interpose " ")
-     (for [{:keys [type text dictionary-form translation word-index]} correct-answer-segments]
+     (for [{:keys [expanded? type text dictionary-form translation word-index]} correct-answer-segments]
        (if (= :annotated-word type)
          [:button.lesson__answer-token
           {:type "button"
            :data-word-index word-index
            :aria-haspopup "dialog"
            :aria-controls "popover"
-           :aria-expanded (str (= word-index open-token-index))
+           :aria-expanded (str expanded?)
            :on {:click [[:action/view-token-info
                          {:dictionary-form dictionary-form
                           :translation     translation
@@ -111,10 +111,10 @@
 
 
 (defn- token-card
-  [{:keys [dictionary-form translation state] :as data}]
+  [{:keys [data-dismiss dictionary-form translation state] :as data}]
   [:div.token-card
    (cond-> {}
-     (= state :known-with-translation) (assoc :data-dismiss "900"))
+     data-dismiss (assoc :data-dismiss data-dismiss))
    [:p.token-card__word {:lang "de"} dictionary-form]
    [:p.token-card__translation {:lang "ru"} translation]
    (case state
@@ -183,8 +183,7 @@
   (if (:lesson/empty? state)
     (empty-state)
     (let [lesson-state (:lesson/state state)
-          token-info   (when (= :token-info (:modal/type state))
-                         (:modal/data state))]
+          token-info   (presenter/token-popover-props state)]
       [:div.lesson
        (when token-info (token-popover token-info))
        [:h1.lesson__title "Урок"]
@@ -202,8 +201,7 @@
             "M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"}]]]]
        [:main.lesson__body
         (challenge lesson-state)]
-       (let [footer-props (some-> (presenter/footer-props lesson-state)
-                                  (assoc :open-token-index (:word-index token-info)))]
+       (let [footer-props (presenter/footer-props state)]
          (if footer-props
            (case (:variant footer-props)
              :success (success-footer footer-props)

--- a/src/client/pages/lesson/view.cljs
+++ b/src/client/pages/lesson/view.cljs
@@ -9,7 +9,7 @@
     (into
      [:p.lesson__answer-body {:lang "de"}]
      (interpose " ")
-     (for [{:keys [expanded? type text dictionary-form translation word-index]} correct-answer-segments]
+     (for [{:keys [expanded? type text word-index]} correct-answer-segments]
        (if (= :annotated-word type)
          [:button.lesson__answer-token
           {:type "button"
@@ -17,10 +17,7 @@
            :aria-haspopup "dialog"
            :aria-controls "popover"
            :aria-expanded (str expanded?)
-           :on {:click [[:action/view-token-info
-                         {:dictionary-form dictionary-form
-                          :translation     translation
-                          :word-index      word-index}]]}}
+           :on {:click [[:action/open-answer-hint word-index]]}}
           text]
          text)))
     [:p.lesson__answer-body {:lang "de"} correct-answer]))
@@ -99,40 +96,35 @@
       "ДАЛЕЕ"]]]])
 
 
-(defn- token-add-button
-  [{:keys [dictionary-form translation word-index]} label]
-  [:button.token-card__button
-   {:type "button"
-    :on   {:click [[:action/save-lesson-word
-                    {:dictionary-form dictionary-form
-                     :translation     translation
-                     :word-index      word-index}]]}}
-   label])
-
-
-(defn- token-card
-  [{:keys [data-dismiss dictionary-form translation state] :as data}]
+(defn- hint-card
+  [{:keys [action-label data-dismiss status-note translation word word-index]}]
   [:div.token-card
    (cond-> {}
      data-dismiss (assoc :data-dismiss data-dismiss))
-   [:p.token-card__word {:lang "de"} dictionary-form]
+   [:p.token-card__word {:lang "de"} word]
    [:p.token-card__translation {:lang "ru"} translation]
-   (case state
-     :known-with-translation [:p.token-card__state "✓ В словаре"]
-     :known-missing-translation (token-add-button data "+ ДОБАВИТЬ ПЕРЕВОД")
-     :unknown-word (token-add-button data "+ В СЛОВАРЬ"))])
+   (when status-note
+     [:p.token-card__state status-note])
+   (when action-label
+     [:button.token-card__button
+      {:type "button"
+       :on   {:click [[:action/save-lesson-word
+                       {:dictionary-form word
+                        :translation     translation
+                        :word-index      word-index}]]}}
+      action-label])])
 
 
-(defn token-popover
-  "Popover shell anchored to the clicked answer token. The Popover API gives
+(defn answer-hint-popover
+  "Popover shell anchored to the opened answer word. The Popover API gives
    light-dismiss and top-layer rendering; pages.lesson.popover positions the
    shell and arms the auto-close timers via :action/show-token-popover."
-  [{:keys [word-index] :as data}]
+  [{:keys [word-index] :as props}]
   [:div#popover.popover
    {:popover "auto"
     :replicant/on-mount [[:action/show-token-popover word-index]]
     :replicant/on-update [[:action/show-token-popover word-index]]}
-   [:div#popover-content (token-card data)]
+   [:div#popover-content (hint-card props)]
    [:div#popover-arrow.popover__arrow]])
 
 
@@ -183,9 +175,9 @@
   (if (:lesson/empty? state)
     (empty-state)
     (let [lesson-state (:lesson/state state)
-          token-info   (presenter/token-popover-props state)]
+          answer-hint  (presenter/answer-hint-props state)]
       [:div.lesson
-       (when token-info (token-popover token-info))
+       (when answer-hint (answer-hint-popover answer-hint))
        [:h1.lesson__title "Урок"]
        [:header.lesson__header
         (progress lesson-state {})

--- a/src/client/pages/lesson/view.cljs
+++ b/src/client/pages/lesson/view.cljs
@@ -4,7 +4,7 @@
 
 
 (defn- answer-body
-  [{:keys [correct-answer correct-answer-segments]}]
+  [{:keys [correct-answer correct-answer-segments open-token-index]}]
   (if (seq correct-answer-segments)
     (into
      [:p.lesson__answer-body {:lang "de"}]
@@ -14,9 +14,13 @@
          [:button.lesson__answer-token
           {:type "button"
            :data-word-index word-index
-           :on   {:click [[:action/view-token-info
-                           {:dictionary-form dictionary-form
-                            :translation     translation}]]}}
+           :aria-haspopup "dialog"
+           :aria-controls "popover"
+           :aria-expanded (str (= word-index open-token-index))
+           :on {:click [[:action/view-token-info
+                         {:dictionary-form dictionary-form
+                          :translation     translation
+                          :word-index      word-index}]]}}
           text]
          text)))
     [:p.lesson__answer-body {:lang "de"} correct-answer]))
@@ -95,29 +99,40 @@
       "ДАЛЕЕ"]]]])
 
 
-(defn token-info-dialog
-  [{:keys [dictionary-form translation state]}]
-  [:dialog#token-info-dialog
-   {:replicant/on-mount [[:action/open-dialog]]
-    :on {:close [[:action/close-modal]]}}
-   [:div.token-card
-    (when (= state :known-with-translation) {:data-dismiss "900"})
-    [:p.token-card__word {:lang "de"} dictionary-form]
-    [:p.token-card__translation {:lang "ru"} translation]
-    (case state
-      :known-with-translation [:p.token-card__state "✓ В словаре"]
-      :known-missing-translation [:button.token-card__button
-                                  {:type "button"
-                                   :on   {:click [[:action/save-lesson-word
-                                                   {:dictionary-form dictionary-form
-                                                    :translation     translation}]]}}
-                                  "+ ДОБАВИТЬ ПЕРЕВОД"]
-      :unknown-word [:button.token-card__button
-                     {:type "button"
-                      :on   {:click [[:action/save-lesson-word
-                                      {:dictionary-form dictionary-form
-                                       :translation     translation}]]}}
-                     "+ В СЛОВАРЬ"])]])
+(defn- token-add-button
+  [{:keys [dictionary-form translation word-index]} label]
+  [:button.token-card__button
+   {:type "button"
+    :on   {:click [[:action/save-lesson-word
+                    {:dictionary-form dictionary-form
+                     :translation     translation
+                     :word-index      word-index}]]}}
+   label])
+
+
+(defn- token-card
+  [{:keys [dictionary-form translation state] :as data}]
+  [:div.token-card
+   (when (= state :known-with-translation) {:data-dismiss "900"})
+   [:p.token-card__word {:lang "de"} dictionary-form]
+   [:p.token-card__translation {:lang "ru"} translation]
+   (case state
+     :known-with-translation [:p.token-card__state "✓ В словаре"]
+     :known-missing-translation (token-add-button data "+ ДОБАВИТЬ ПЕРЕВОД")
+     :unknown-word (token-add-button data "+ В СЛОВАРЬ"))])
+
+
+(defn token-popover
+  "Popover shell anchored to the clicked answer token. The Popover API gives
+   light-dismiss and top-layer rendering; pages.lesson.popover positions the
+   shell and arms the auto-close timers via :action/show-token-popover."
+  [{:keys [word-index] :as data}]
+  [:div#popover.popover
+   {:popover "auto"
+    :replicant/on-mount [[:action/show-token-popover word-index]]
+    :replicant/on-update [[:action/show-token-popover word-index]]}
+   [:div#popover-content (token-card data)]
+   [:div#popover-arrow.popover__arrow]])
 
 
 (defn progress
@@ -166,10 +181,11 @@
   [state]
   (if (:lesson/empty? state)
     (empty-state)
-    (let [lesson-state (:lesson/state state)]
+    (let [lesson-state (:lesson/state state)
+          token-info   (when (= :token-info (:modal/type state))
+                         (:modal/data state))]
       [:div.lesson
-       (when (= :token-info (:modal/type state))
-         (token-info-dialog (:modal/data state)))
+       (when token-info (token-popover token-info))
        [:h1.lesson__title "Урок"]
        [:header.lesson__header
         (progress lesson-state {})
@@ -185,7 +201,8 @@
             "M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"}]]]]
        [:main.lesson__body
         (challenge lesson-state)]
-       (let [footer-props (presenter/footer-props lesson-state)]
+       (let [footer-props (some-> (presenter/footer-props lesson-state)
+                                  (assoc :open-token-index (:word-index token-info)))]
          (if footer-props
            (case (:variant footer-props)
              :success (success-footer footer-props)

--- a/src/client/use_cases/lesson.cljs
+++ b/src/client/use_cases/lesson.cljs
@@ -130,3 +130,17 @@
     {:dictionary-form dictionary-form
      :translation translation
      :state       (token-state existing translation)}))
+
+
+(defn ^:async answer-annotations
+  "Vocabulary state per annotated word of the trial's answer:
+   {word-index :unknown-word | :known-missing-translation | :known-with-translation}."
+  [capabilities trial]
+  (let [segments (filterv #(= :annotated-word (:type %))
+                          (domain/answer-segments trial))
+        infos    (await (js/Promise.all
+                         (into-array
+                          (map #(token-info capabilities (:dictionary-form %) (:translation %))
+                               segments))))]
+    (zipmap (map :word-index segments)
+            (map :state infos))))

--- a/test/browser/lesson-answer-hints.spec.js
+++ b/test/browser/lesson-answer-hints.spec.js
@@ -1,0 +1,126 @@
+const { test, expect } = require('@playwright/test');
+
+// Answer-hint popover in the lesson (GH-273). Scenarios:
+//
+// 1. Example answered correctly → the revealed answer carries clickable
+//    annotated words; answered incorrectly → same, under «Правильно:».
+// 2. Word not in the vocabulary → hint card offers «+ В СЛОВАРЬ»;
+//    word already in the vocabulary → card shows «✓ В словаре» instead.
+// 3. Adding from the card updates the same popover in place to the
+//    "added" state and the word lands in the vocabulary list.
+// 4. The popover appears on token click, hides instantly on a click
+//    outside, and hides after a timeout once the pointer leaves it.
+//
+// The examples backend needs an external API, so the example document is
+// seeded straight into the app's device-db through the dev-build globals —
+// the same layer the app itself uses (see test/browser/README.md).
+
+async function addWord(page, value, translation) {
+  await page.getByLabel('Слово (немецкий)').fill(value);
+  await page.getByLabel('Перевод (русский)').fill(translation);
+  await page.getByRole('button', { name: 'ДОБАВИТЬ' }).click();
+  await expect(page.getByLabel('Слово (немецкий)')).toHaveValue('');
+}
+
+async function seedExample(page) {
+  await page.evaluate(async () => {
+    const kw = cljs.core.keyword;
+    const toClj = (o) => cljs.core.js__GT_clj(o, kw('keywordize-keys'), true);
+    const dbs = await db.pouch.init_BANG_(null);
+    const found = await db.pouch.find_all(dbs, toClj({ selector: { type: 'vocab' } }));
+    const wordId = cljs.core.get(cljs.core.first(cljs.core.get(found, kw('docs'))), kw('_id'));
+    await db.pouch.insert(dbs, toClj({
+      'type': 'example',
+      'word-id': wordId,
+      'word': 'der Hund',
+      'value': 'Der Hund schläft im Garten.',
+      'translation': 'Пёс спит в саду.',
+      'created-at': new Date().toISOString(),
+      'structure': [
+        { usedForm: 'Hund', dictionaryForm: 'der Hund', translation: 'пёс', wordIndex: 1 },
+        { usedForm: 'Garten', dictionaryForm: 'der Garten', translation: 'сад', wordIndex: 4 },
+      ],
+    }));
+  });
+}
+
+// Answers the word trial, advances, and answers the example trial with
+// `exampleAnswer`. Returns with the revealed answer on screen.
+async function playToExampleReveal(page, exampleAnswer) {
+  await page.goto('/lesson');
+  await expect(page.locator('.lesson__prompt')).toBeVisible();
+  await page.locator('#lesson-answer').fill('der Hund');
+  await page.getByRole('button', { name: 'ПРОВЕРИТЬ' }).click();
+  await page.getByRole('button', { name: 'ДАЛЕЕ' }).click();
+  await expect(page.locator('.lesson__instruction')).toContainText('предложение');
+  await page.locator('#lesson-answer').fill(exampleAnswer);
+  await page.getByRole('button', { name: 'ПРОВЕРИТЬ' }).click();
+}
+
+async function setUpLesson(page, exampleAnswer) {
+  await page.goto('/home');
+  await addWord(page, 'der Hund', 'пёс');
+  await seedExample(page);
+  await playToExampleReveal(page, exampleAnswer);
+}
+
+const popover = (page) => page.locator('#popover');
+const token = (page, index) => page.locator(`.lesson__answer-token[data-word-index="${index}"]`);
+
+test('correct example answer reveals clickable annotated words', async ({ page }) => {
+  await setUpLesson(page, 'Der Hund schläft im Garten.');
+  await expect(page.getByRole('heading', { name: 'Правильно!' })).toBeVisible();
+  await expect(token(page, 1)).toHaveText('Hund');
+  await expect(token(page, 4)).toHaveText('Garten.');
+});
+
+test('wrong example answer reveals the correct answer with annotated words', async ({ page }) => {
+  await setUpLesson(page, 'Die Katze schläft.');
+  await expect(page.getByRole('heading', { name: 'Правильно:' })).toBeVisible();
+  await expect(token(page, 4)).toHaveText('Garten.');
+});
+
+test('unknown word offers add, known word shows already-in-dictionary', async ({ page }) => {
+  await setUpLesson(page, 'Der Hund schläft im Garten.');
+
+  await token(page, 4).click();
+  await expect(popover(page).locator('.token-card__word')).toHaveText('der Garten');
+  await expect(popover(page).getByRole('button', { name: '+ В СЛОВАРЬ' })).toBeVisible();
+
+  await token(page, 1).click();
+  await expect(popover(page).locator('.token-card__word')).toHaveText('der Hund');
+  await expect(popover(page).locator('.token-card__state')).toHaveText('✓ В словаре');
+  await expect(popover(page).getByRole('button')).toHaveCount(0);
+});
+
+test('adding a word updates the card in place and persists the word', async ({ page }) => {
+  await setUpLesson(page, 'Der Hund schläft im Garten.');
+
+  await token(page, 4).click();
+  await popover(page).getByRole('button', { name: '+ В СЛОВАРЬ' }).click();
+
+  // The same popover flips to the added state without closing.
+  await expect(popover(page).locator('.token-card__state')).toHaveText('✓ В словаре');
+  await expect(popover(page).locator('.token-card__word')).toHaveText('der Garten');
+
+  await page.goto('/words');
+  await expect(page.locator('.word-item__value').filter({ hasText: 'der Garten' })).toBeVisible();
+});
+
+test('popover light-dismisses instantly and auto-closes after pointer leaves', async ({ page }) => {
+  await setUpLesson(page, 'Der Hund schläft im Garten.');
+
+  // Click outside → gone immediately.
+  await token(page, 4).click();
+  await expect(popover(page)).toBeVisible();
+  await page.locator('.lesson__prompt').click();
+  await expect(popover(page)).toBeHidden({ timeout: 500 });
+
+  // Pointer parked on the card holds it open; leaving arms the close timer.
+  await token(page, 4).click();
+  await expect(popover(page)).toBeVisible();
+  const card = await popover(page).locator('.token-card').boundingBox();
+  await page.mouse.move(card.x + card.width / 2, card.y + card.height / 2);
+  await page.mouse.move(5, 5);
+  await expect(popover(page)).toBeHidden({ timeout: 3000 });
+});

--- a/test/client/pages/lesson_view_test.cljs
+++ b/test/client/pages/lesson_view_test.cljs
@@ -1,8 +1,9 @@
 (ns client.pages.lesson-view-test
-  "Token-info card in the lesson page render tree (GH-257): the click on an
-   annotated answer word saves :modal/type :token-info, and the page must
-   actually render the dialog for that state — after the Replicant migration
-   the dialog function existed but nothing called it."
+  "Token-info card in the lesson page render tree (GH-257, GH-273): the click
+   on an annotated answer word saves :modal/type :token-info, and the page
+   must render the anchored popover shell for that state — after the
+   Replicant migration the card existed but nothing rendered it, and the
+   first fix rendered it as a centered modal dialog instead of a popover."
   (:require
    [cljs.test :refer-macros [deftest is testing]]
    [domain.lesson :as domain]
@@ -25,17 +26,19 @@
        boolean))
 
 
-(deftest page-renders-token-info-dialog-for-modal-state
-  (testing "modal state :token-info puts the dialog into the render tree"
+(deftest page-renders-token-popover-for-modal-state
+  (testing "modal state :token-info puts the anchored popover into the render tree"
     (let [page (sut/page (lesson-page-state
                           {:modal/data {:dictionary-form "die Katze"
-                                        :state       :unknown-word
-                                        :translation "кошка"}
+                                        :state           :unknown-word
+                                        :translation     "кошка"
+                                        :word-index      2}
                            :modal/type :token-info}))]
-      (is (contains-node? page :dialog#token-info-dialog)))))
+      (is (contains-node? page :div#popover.popover))
+      (is (not (contains-node? page :dialog#token-info-dialog))))))
 
 
-(deftest page-omits-token-info-dialog-without-modal-state
-  (testing "no modal state — no dialog in the render tree"
+(deftest page-omits-token-popover-without-modal-state
+  (testing "no modal state — no popover in the render tree"
     (is (not (contains-node? (sut/page (lesson-page-state {}))
-                             :dialog#token-info-dialog)))))
+                             :div#popover.popover)))))

--- a/test/client/pages/lesson_view_test.cljs
+++ b/test/client/pages/lesson_view_test.cljs
@@ -1,22 +1,34 @@
 (ns client.pages.lesson-view-test
-  "Token-info card in the lesson page render tree (GH-257, GH-273): the click
-   on an annotated answer word saves :modal/type :token-info, and the page
-   must render the anchored popover shell for that state — after the
+  "Answer-hint popover in the lesson page render tree (GH-257, GH-273): the
+   annotated answer is marked up in state, a click stores only the open word
+   index, and the page renders the anchored popover for it — after the
    Replicant migration the card existed but nothing rendered it, and the
    first fix rendered it as a centered modal dialog instead of a popover."
   (:require
    [cljs.test :refer-macros [deftest is testing]]
-   [domain.lesson :as domain]
    [pages.lesson.view :as sut]))
 
 
+(def ^:private example-trial
+  {:type      "example"
+   :word-id   "word-1"
+   :prompt    "Пёс спит"
+   :answer    "Der Hund schlaeft."
+   :structure [{:usedForm       "Hund"
+                :dictionaryForm "der Hund"
+                :translation    "пёс"
+                :wordIndex      1}]
+   :locked?   false})
+
+
 (defn- lesson-page-state
-  [modal]
-  (merge {:lesson/state (domain/initial-state
-                         [{:id "word-1" :value "der Hund" :translation "пёс"}]
-                         []
-                         :first)}
-         modal))
+  [hint-state]
+  (merge {:lesson/state {:trials           [example-trial]
+                         :remaining-trials [example-trial]
+                         :current-trial    example-trial
+                         :last-result      {:correct? true
+                                            :answer   "Der Hund schlaeft."}}}
+         hint-state))
 
 
 (defn- contains-node?
@@ -26,19 +38,17 @@
        boolean))
 
 
-(deftest page-renders-token-popover-for-modal-state
-  (testing "modal state :token-info puts the anchored popover into the render tree"
+(deftest page-renders-answer-hint-popover-for-open-index
+  (testing "open hint index puts the anchored popover into the render tree"
     (let [page (sut/page (lesson-page-state
-                          {:modal/data {:dictionary-form "die Katze"
-                                        :state           :unknown-word
-                                        :translation     "кошка"
-                                        :word-index      2}
-                           :modal/type :token-info}))]
+                          {:lesson/answer-hints    {1 :unknown-word}
+                           :lesson/open-hint-index 1}))]
       (is (contains-node? page :div#popover.popover))
+      (is (contains-node? page :button.token-card__button))
       (is (not (contains-node? page :dialog#token-info-dialog))))))
 
 
-(deftest page-omits-token-popover-without-modal-state
-  (testing "no modal state — no popover in the render tree"
+(deftest page-omits-answer-hint-popover-without-open-index
+  (testing "no open hint index — no popover in the render tree"
     (is (not (contains-node? (sut/page (lesson-page-state {}))
                              :div#popover.popover)))))

--- a/test/client/presenter/lesson_test.cljs
+++ b/test/client/presenter/lesson_test.cljs
@@ -11,7 +11,7 @@
                  [{:id "word-1" :value "der Hund" :translation "пёс"}]
                  []
                  :first)]
-      (is (nil? (sut/footer-props state))))))
+      (is (nil? (sut/footer-props {:lesson/state state}))))))
 
 
 (deftest footer-props-includes-user-answer-for-example-trial
@@ -45,18 +45,19 @@
                                     :locked?   false}
                  :last-result      {:correct? false
                                     :answer   "Mein Hund schlaeft"}}
-          props (sut/footer-props state)]
+          props (sut/footer-props {:lesson/state state})]
       (is (= :error (:variant props)))
       (is (= "Mein Hund schlaeft" (:user-answer props)))
       (is (= "Der Hund schlaeft." (:correct-answer props)))
-      (is (= [{:type :plain-word :text "Der" :word-index 0}
-              {:type        :annotated-word
-               :text        "Hund"
-               :used-form   "Hund"
+      (is (= [{:type :plain-word :text "Der" :word-index 0 :expanded? false}
+              {:type            :annotated-word
+               :text            "Hund"
+               :used-form       "Hund"
                :dictionary-form "der Hund"
-               :translation "пёс"
-               :word-index  1}
-              {:type :plain-word :text "schlaeft." :word-index 2}]
+               :translation     "пёс"
+               :word-index      1
+               :expanded?       false}
+              {:type :plain-word :text "schlaeft." :word-index 2 :expanded? false}]
              (:correct-answer-segments props))))))
 
 
@@ -67,7 +68,7 @@
                  []
                  :first)
           state (domain/check-answer state "die Katze")
-          props (sut/footer-props state)]
+          props (sut/footer-props {:lesson/state state})]
       (is (= :error (:variant props)))
       (is (= "die Katze" (:user-answer props)))
       (is (= "der Hund" (:correct-answer props))))))


### PR DESCRIPTION
Closes #273.

GH-257 restored the token-info card as a native `<dialog>`: centered, UA default border, focus ring on the button. The pre-Replicant UX was an anchored popover (`popover.js`, dropped in GH-151).

This ports the popover into the Replicant architecture:
- `pages.lesson.popover` — positioning at the anchor rect (flip below when no room, arrow offset) and auto-close timers (900 ms for a known word via `data-dismiss`, idle timeout on hover-capable devices, pointer/focus inside cancels, 600 ms after leave); HTML Popover API gives light-dismiss and top layer.
- Lesson view renders the `#popover` shell instead of the dialog; `aria-expanded` restored on tokens.
- Add action still only when the word/translation is missing (unchanged use-case logic).

Verified (local backend + Playwright, real clicks):
- popover opens anchored above the clicked token (`side=top`, gap 10 px), no `<dialog>`, no border, `aria-expanded=true`
- «+ В СЛОВАРЬ» adds the word, card flips to «✓ В словаре», auto-dismisses after pointer leaves
- known word card auto-dismisses; click outside light-dismisses
- node suite 160 tests green, committed browser suite 3/3 green

Not merging — waiting for review (local check: `npx shadow-cljs compile app`, then lesson with an example trial).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Скриншот

![Попап над словом Garten в показанном ответе](https://raw.githubusercontent.com/u473t8/learning-app/pr-assets/gh-274-popover-open.png)
