### PR TITLE
GH-283 Answer tokens are text-selectable

### DIFF
--- a/openspec/changes/archive/2026-08-09-selectable-answer-tokens/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-09-selectable-answer-tokens/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-with-adr
+created: 2026-08-09

--- a/openspec/changes/archive/2026-08-09-selectable-answer-tokens/proposal.md
+++ b/openspec/changes/archive/2026-08-09-selectable-answer-tokens/proposal.md
@@ -1,0 +1,24 @@
+# Proposal: selectable-answer-tokens
+
+## Why
+
+Annotated words in the revealed answer are buttons; the UA default `user-select: none` on buttons breaks mouse selection at every hinted word, so the sentence cannot be selected or copied whole. GitHub issue: #283.
+
+## What Changes
+
+- Answer tokens become text-selectable (`user-select: text`) while staying clickable.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `lesson`: the revealed answer, including hinted words, SHALL be selectable as continuous text.
+
+## Impact
+
+- `resources/public/css/blocks/lesson.css` — one declaration on `.lesson__answer-token`.
+- Browser test asserting cross-token selection.

--- a/openspec/changes/archive/2026-08-09-selectable-answer-tokens/specs/lesson/spec.md
+++ b/openspec/changes/archive/2026-08-09-selectable-answer-tokens/specs/lesson/spec.md
@@ -1,0 +1,18 @@
+# lesson Delta
+
+## ADDED Requirements
+
+### Requirement: Revealed answer is selectable as continuous text
+
+The revealed correct answer SHALL be selectable with the mouse as one continuous text run, across plain and hinted words alike, so it can be copied whole. Hinted words SHALL remain activatable.
+
+#### Scenario: Selecting across hinted words
+
+- **WHEN** the user drags a selection across the revealed answer
+- **THEN** the selection includes the hinted words' text
+- **AND** the copied text matches the visible sentence
+
+#### Scenario: Hinted word still opens the hint
+
+- **WHEN** the user clicks a hinted word without dragging
+- **THEN** the hint card opens as before

--- a/openspec/changes/archive/2026-08-09-selectable-answer-tokens/tasks.md
+++ b/openspec/changes/archive/2026-08-09-selectable-answer-tokens/tasks.md
@@ -1,0 +1,7 @@
+## 1. Fix
+
+- [x] 1.1 `user-select: text` on `.lesson__answer-token`
+
+## 2. Verify
+
+- [x] 2.1 Browser test: drag-selection across the revealed answer includes hinted words; click still opens the hint

--- a/openspec/specs/lesson/spec.md
+++ b/openspec/specs/lesson/spec.md
@@ -161,3 +161,18 @@ The lesson UI SHALL open a token-info card when the user activates an annotated 
 - **AND** on hover-capable devices it auto-closes after an idle timeout unless the pointer or focus is inside it
 - **AND** no modal chrome, backdrop dimming, or forced focus ring is presented
 
+### Requirement: Revealed answer is selectable as continuous text
+
+The revealed correct answer SHALL be selectable with the mouse as one continuous text run, across plain and hinted words alike, so it can be copied whole. Hinted words SHALL remain activatable.
+
+#### Scenario: Selecting across hinted words
+
+- **WHEN** the user drags a selection across the revealed answer
+- **THEN** the selection includes the hinted words' text
+- **AND** the copied text matches the visible sentence
+
+#### Scenario: Hinted word still opens the hint
+
+- **WHEN** the user clicks a hinted word without dragging
+- **THEN** the hint card opens as before
+

--- a/resources/public/css/blocks/lesson.css
+++ b/resources/public/css/blocks/lesson.css
@@ -221,6 +221,9 @@
   line-height: inherit;
   margin: 0;
   padding: 0 1px;
+  /* Buttons default to user-select:none; the answer must select as one
+     continuous text run across hinted words (#283). */
+  user-select: text;
   text-decoration-color: currentcolor;
   text-decoration-line: underline;
   text-decoration-style: dotted;

--- a/test/browser/lesson-answer-hints.spec.js
+++ b/test/browser/lesson-answer-hints.spec.js
@@ -107,6 +107,18 @@ test('adding a word updates the card in place and persists the word', async ({ p
   await expect(page.locator('.word-item__value').filter({ hasText: 'der Garten' })).toBeVisible();
 });
 
+test('revealed answer selects as continuous text across hinted words', async ({ page }) => {
+  await setUpLesson(page, 'Der Hund schläft im Garten.');
+  const body = page.locator('.lesson__answer-body');
+  const box = await body.boundingBox();
+  await page.mouse.move(box.x + 1, box.y + box.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(box.x + box.width - 1, box.y + box.height / 2, { steps: 8 });
+  await page.mouse.up();
+  const selected = await page.evaluate(() => window.getSelection().toString());
+  expect(selected.replace(/\s+/g, ' ').trim()).toContain('Der Hund schläft im Garten.');
+});
+
 test('popover light-dismisses instantly and auto-closes after pointer leaves', async ({ page }) => {
   await setUpLesson(page, 'Der Hund schläft im Garten.');
 


### PR DESCRIPTION
Closes #283.

Hinted words in the revealed answer are buttons; the UA default `user-select: none` on buttons broke mouse selection at every token. One declaration fixes it: `user-select: text` on `.lesson__answer-token` — the sentence selects and copies as one continuous run, clicks still open the hint card.

Verified:
- new browser test drags a selection across the revealed answer and asserts the full sentence, including token text; fails without the fix (checked by stashing the CSS)
- browser suite 9/9 green

Not merging — waiting for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)