### PR TITLE
GH-331 Ask the project API only for what the script reads

### DIFF
--- a/.skills/gh-project-workflow/scripts/start_issue_flow.sh
+++ b/.skills/gh-project-workflow/scripts/start_issue_flow.sh
@@ -48,6 +48,10 @@ die() {
   exit 1
 }
 
+graphql_remaining() {
+  gh api rate_limit --jq '.resources.graphql.remaining' 2>/dev/null || true
+}
+
 normalize_fields_json() {
   local raw_json="$1"
   jq -c 'if type == "array" then . else (.fields // []) end' <<<"$raw_json"
@@ -98,8 +102,58 @@ apply_single_select_field() {
     --single-select-option-id "$option_id" >/dev/null
 }
 
+# `gh project item-list` asks for every field value of every item — 203 points of the 5000
+# hourly GraphQL budget on a board this size. Matching an item needs four fields, so ask for
+# those. Output keeps the shape the CLI produced, so the jq matchers below are unchanged.
 project_items_json() {
-  gh project item-list "$project_number" --owner "$owner" --limit "${GHWF_ITEM_LIMIT:-200}" --format json
+  local query='
+    query($owner: String!, $number: Int!, $after: String) {
+      owner: repositoryOwner(login: $owner) {
+        ... on ProjectV2Owner {
+          projectV2(number: $number) {
+            items(first: 100, after: $after) {
+              pageInfo { hasNextPage endCursor }
+              nodes {
+                id
+                isArchived
+                content {
+                  __typename
+                  ... on Issue { number url title }
+                  ... on PullRequest { number url title }
+                  ... on DraftIssue { title }
+                }
+              }
+            }
+          }
+        }
+      }
+    }'
+
+  local after="null" page nodes all="[]" has_next
+  while :; do
+    if [[ "$after" == "null" ]]; then
+      page="$(gh api graphql -f query="$query" -F owner="$owner" -F number="$project_number")"
+    else
+      page="$(gh api graphql -f query="$query" -F owner="$owner" -F number="$project_number" -F after="$after")"
+    fi
+
+    # Archived items are out of the CLI's listing too; reusing one would resurrect
+    # work the owner had put away.
+    nodes="$(jq -c '[.data.owner.projectV2.items.nodes[]
+                     | select(.isArchived | not)
+                     | {id: .id,
+                        title: (.content.title // ""),
+                        content: {type: .content.__typename,
+                                  number: .content.number,
+                                  url: .content.url}}]' <<<"$page")"
+    all="$(jq -c --argjson nodes "$nodes" '. + $nodes' <<<"$all")"
+
+    has_next="$(jq -r '.data.owner.projectV2.items.pageInfo.hasNextPage' <<<"$page")"
+    [[ "$has_next" == "true" ]] || break
+    after="$(jq -r '.data.owner.projectV2.items.pageInfo.endCursor' <<<"$page")"
+  done
+
+  jq -c --argjson items "$all" -n '{items: $items}'
 }
 
 find_project_item_by_title() {
@@ -344,9 +398,31 @@ done
 [[ -n "$project_number" ]] || die "--project-number or GHWF_PROJECT_NUMBER is required"
 [[ "$mode" == "issue" || "$mode" == "draft-convert" ]] || die "--mode must be 'issue' or 'draft-convert'"
 
-project_id="$(gh project view "$project_number" --owner "$owner" --format json --jq '.id')"
+graphql_budget_before="$(graphql_remaining)"
+
+# `gh project field-list` pulls every option of every field (102 points); the script reads the
+# ids of single-select fields and their options. One query answers that and the project id.
+project_query='
+  query($owner: String!, $number: Int!) {
+    owner: repositoryOwner(login: $owner) {
+      ... on ProjectV2Owner {
+        projectV2(number: $number) {
+          id
+          fields(first: 50) {
+            nodes {
+              ... on ProjectV2FieldCommon { id name }
+              ... on ProjectV2SingleSelectField { id name options { id name } }
+            }
+          }
+        }
+      }
+    }
+  }'
+project_json="$(gh api graphql -f query="$project_query" -F owner="$owner" -F number="$project_number")"
+
+project_id="$(jq -r '.data.owner.projectV2.id // empty' <<<"$project_json")"
 [[ -n "$project_id" ]] || die "Unable to resolve project id"
-fields_json="$(normalize_fields_json "$(gh project field-list "$project_number" --owner "$owner" --format json)")"
+fields_json="$(normalize_fields_json "$(jq -c '[.data.owner.projectV2.fields.nodes[] | select(.id)]' <<<"$project_json")")"
 
 issue_url=""
 issue_number=""
@@ -453,4 +529,13 @@ echo "Issue Number: $issue_number"
 echo "Project Item ID: $item_id"
 if [[ -n "$checked_out_branch" ]]; then
   echo "Checked Out Branch: $checked_out_branch"
+fi
+
+# A run that quietly eats a tenth of the hourly budget is only noticed an hour later, when
+# the next run is refused. Print the price.
+if [[ -n "$graphql_budget_before" ]]; then
+  graphql_budget_after="$(graphql_remaining)"
+  if [[ -n "$graphql_budget_after" ]]; then
+    echo "GraphQL Cost: $(( graphql_budget_before - graphql_budget_after )) points (${graphql_budget_after} left this hour)"
+  fi
 fi

--- a/openspec/changes/archive/2026-08-15-cheap-issue-filing/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-15-cheap-issue-filing/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-with-adr
+created: 2026-08-15

--- a/openspec/changes/archive/2026-08-15-cheap-issue-filing/proposal.md
+++ b/openspec/changes/archive/2026-08-15-cheap-issue-filing/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+Filing one issue through `start_issue_flow.sh` costs about 323 points of the 5000-point
+hourly GraphQL budget, so a batch of backlog work exhausts the budget after eleven issues and
+then waits an hour. Measured today while filing twenty-five issues: the run stopped twice.
+
+Measured per call, by reading `rate_limit` before and after:
+
+| call | points |
+|---|---|
+| `gh project item-list --limit 200` | 203 |
+| `gh project field-list` | 102 |
+| `gh project view` | 2 |
+| `gh issue list --search` | 1 |
+
+The two expensive ones are expensive for the same reason: the GitHub CLI asks for far more
+than the script reads. `item-list` pulls every field value of every board item when the script
+only matches on title, type and number; `field-list` pulls every option of every field when
+the script needs the ids of two single-select fields.
+
+The board walk itself has to stay — it is what lets a same-titled **draft** item be converted
+into the issue instead of being duplicated, and the board holds such drafts today.
+
+## What Changes
+
+- The board walk and the field lookup ask for the fields the script actually reads, through
+  direct GraphQL queries, instead of the CLI's exhaustive ones.
+- The script reports what the run cost, so a regression is visible immediately rather than
+  inferred an hour later from a rate-limit error.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `repo-delivery-workflow`: filing an issue gets a cost ceiling — the workflow must not
+  consume a disproportionate share of the hourly API budget per issue, and must keep reusing
+  a same-titled draft item while doing so.
+
+## Impact
+
+- `.skills/gh-project-workflow/scripts/start_issue_flow.sh`
+- Anything that shells out to it: `repo-task-delivery`, `gh-project-workflow`, and agents
+  filing tracked work.
+- No effect on the GitHub Project schema, the issue bodies, or the board itself.

--- a/openspec/changes/archive/2026-08-15-cheap-issue-filing/specs/repo-delivery-workflow/spec.md
+++ b/openspec/changes/archive/2026-08-15-cheap-issue-filing/specs/repo-delivery-workflow/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: Filing an issue stays within a small share of the API budget
+
+The tracked-delivery workflow SHALL file an issue without consuming a disproportionate share
+of the hourly GraphQL budget, so that a batch of backlog work can be filed in one sitting.
+
+Lookups the workflow performs SHALL request only the data the workflow reads. Matching a board
+item needs its id, title, type and issue number; resolving a field needs that field's id and
+the id of the option being set. Requesting every field value of every board item, or every
+option of every field, is not permitted merely because a convenience command offers it.
+
+Reducing the cost SHALL NOT cost behaviour: a same-titled draft item on the board is still
+found and converted into the issue rather than duplicated.
+
+#### Scenario: Filing twenty issues in a row
+
+- **WHEN** twenty issues are filed one after another through the start-work script
+- **THEN** every one of them is created, placed on the board, and given Status and Priority
+- **AND** the hourly GraphQL budget is not exhausted
+
+#### Scenario: A same-titled draft is still reused
+
+- **WHEN** the board holds a draft item whose title matches the issue being filed
+- **THEN** that draft is converted into the issue
+- **AND** no second board item is created
+
+#### Scenario: The cost is visible
+
+- **WHEN** the script finishes a run
+- **THEN** it reports what that run cost against the GraphQL budget

--- a/openspec/changes/archive/2026-08-15-cheap-issue-filing/tasks.md
+++ b/openspec/changes/archive/2026-08-15-cheap-issue-filing/tasks.md
@@ -1,0 +1,34 @@
+## 1. Measure the baseline
+
+- [x] 1.1 Record the GraphQL cost of one full `start_issue_flow.sh` run, read from
+      `gh api rate_limit` before and after — 323 points
+- [x] 1.2 Record the cost of each call the script makes — `item-list` 203,
+      `field-list` 102, `project view` 2, `issue list --search` 1, `label list` 1
+
+## 2. Ask for what the script reads
+
+- [x] 2.1 Replace `gh project item-list` with a GraphQL query for id, title, type and issue
+      number, paginated, shaped so the existing jq matchers keep working
+- [x] 2.2 Replace `gh project field-list` with a GraphQL query for single-select field ids and
+      option ids only — the same query now also returns the project id
+- [x] 2.3 Keep `--no-reuse-existing` skipping the board lookup entirely — untouched
+- [x] 2.4 Drop archived items from the walk, matching what the CLI listing returned
+
+## 3. Make the cost visible
+
+- [x] 3.1 Report the run's GraphQL cost when the script finishes
+
+## 4. Verify
+
+- [x] 4.1 Re-measure a full run: 19 points against the 323-point baseline; the board walk
+      alone went from 203 to 2
+- [x] 4.2 File a real issue end to end — #332 landed on the board with Status Backlog and
+      Priority Minor, confirmed by querying the item's field values
+- [x] 4.3 Re-run with the same title — the existing #332 and its item id came back, no
+      duplicate, 10 points
+- [x] 4.4 Compare the walk against `gh project item-list` — 156 items each, identical except
+      #288, where the query returns the issue's current title and the CLI returns the stale
+      one stored on the board. Draft items appear with their titles, so draft conversion still
+      has its input; converting a live draft was not exercised, as that would alter the board.
+- [ ] 4.5 Run shellcheck over the changed script — not installed in this environment;
+      `bash -n` passes

--- a/openspec/specs/repo-delivery-workflow/spec.md
+++ b/openspec/specs/repo-delivery-workflow/spec.md
@@ -148,3 +148,33 @@ branch rule and the worktree rule.
 - **THEN** the issue branch is created first and the worktree is placed on that branch,
   so the issue keeps its development link
 
+### Requirement: Filing an issue stays within a small share of the API budget
+
+The tracked-delivery workflow SHALL file an issue without consuming a disproportionate share
+of the hourly GraphQL budget, so that a batch of backlog work can be filed in one sitting.
+
+Lookups the workflow performs SHALL request only the data the workflow reads. Matching a board
+item needs its id, title, type and issue number; resolving a field needs that field's id and
+the id of the option being set. Requesting every field value of every board item, or every
+option of every field, is not permitted merely because a convenience command offers it.
+
+Reducing the cost SHALL NOT cost behaviour: a same-titled draft item on the board is still
+found and converted into the issue rather than duplicated.
+
+#### Scenario: Filing twenty issues in a row
+
+- **WHEN** twenty issues are filed one after another through the start-work script
+- **THEN** every one of them is created, placed on the board, and given Status and Priority
+- **AND** the hourly GraphQL budget is not exhausted
+
+#### Scenario: A same-titled draft is still reused
+
+- **WHEN** the board holds a draft item whose title matches the issue being filed
+- **THEN** that draft is converted into the issue
+- **AND** no second board item is created
+
+#### Scenario: The cost is visible
+
+- **WHEN** the script finishes a run
+- **THEN** it reports what that run cost against the GraphQL budget
+


### PR DESCRIPTION
Closes #331.

Filing one issue through `start_issue_flow.sh` cost 323 of the 5000 hourly GraphQL points, so
filing backlog work in a batch stopped after eleven issues and waited an hour — twice today.

Measured per call, reading `rate_limit` before and after:

| call | before | after |
|---|---|---|
| board walk (`gh project item-list --limit 200`) | 203 | 2 |
| project id + fields (`gh project view` + `field-list`) | 104 | ~8 |
| **full run** | **323** | **19** |

Both expensive calls asked for far more than the script reads: every field value of every
board item, and every option of every field. They are now direct queries for the four item
fields the matchers use and the two single-select field ids.

## Verified

- A real issue filed end to end: #332 landed on the board with Status Backlog and Priority
  Minor, confirmed by querying the item's field values.
- Re-running with the same title returned the existing #332 and its item id — no duplicate,
  10 points.
- The walk was diffed against `gh project item-list`: 156 items each, identical except #288,
  where the query returns the issue's current title and the CLI returns the stale one stored
  on the board.
- Draft items come back with their titles, so draft conversion still has its input. Converting
  a live draft was not exercised — that would have altered the board.
- `bash -n` passes. shellcheck is not installed in this environment, so that check did not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)