### PR TITLE
GH-306 Make the example endpoint ask who is calling, and how often

### DIFF
--- a/infra/development/etc/nginx/sites-available/sprecha.localhost.conf
+++ b/infra/development/etc/nginx/sites-available/sprecha.localhost.conf
@@ -1,3 +1,15 @@
+# Example generation spends money at the LLM provider on every request. The
+# limit lives here as well as in production so it is exercised on the stand
+# instead of first being met by users.
+limit_req_zone $binary_remote_addr zone=examples:10m rate=30r/m;
+
+# `add_header ... always` fires on every response, so the value is emptied for
+# anything but a throttled one — nginx omits a header whose value is empty.
+map $status $examples_retry_after {
+    429     5;
+    default "";
+}
+
 # The dev stand. Plain http on purpose: browsers resolve *.localhost to
 # loopback themselves and treat it as a secure context, so Secure cookies
 # and the service worker work without certificates. The Cloudflare tunnel
@@ -20,6 +32,24 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";
         proxy_read_timeout 1h;
+    }
+
+    # Paid endpoint: throttled here, authenticated in the handler.
+    location /api/examples {
+        limit_req zone=examples burst=10 nodelay;
+        limit_req_status 429;
+        # The client reschedules its fetch task on Retry-After.
+        add_header Retry-After $examples_retry_after always;
+
+        proxy_pass http://localhost:8083;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+
+        # Declaring any proxy_set_header here stops the server-level stripping
+        # from being inherited (#304), so repeat it.
+        proxy_set_header X-Auth-CouchDB-UserName "";
+        proxy_set_header X-Auth-CouchDB-Roles    "";
+        proxy_set_header X-Auth-CouchDB-Token    "";
     }
 
     # Push pokes (ADR-0009): a WebSocket, silent while nothing changes.

--- a/infra/production/etc/nginx/sites-available/learning-app.conf
+++ b/infra/production/etc/nginx/sites-available/learning-app.conf
@@ -1,5 +1,18 @@
 limit_req_zone $binary_remote_addr zone=couchdb:10m rate=40r/s;
 
+# Example generation spends money at the LLM provider on every request, so it
+# gets its own budget instead of sharing the replication zone: 40r/s is sized
+# for _changes and _bulk_get bursts, and replication would eat the allowance.
+limit_req_zone $binary_remote_addr zone=examples:10m rate=30r/m;
+
+# `add_header ... always` fires on every response, so the value is emptied for
+# anything but a throttled one — nginx omits a header whose value is empty.
+# Without the map, successful answers would carry Retry-After too.
+map $status $examples_retry_after {
+    429     5;
+    default "";
+}
+
 server {
     listen 80;
     server_name sprecha.de www.sprecha.de;
@@ -51,6 +64,25 @@ server {
 
         limit_req zone=couchdb burst=120;
         limit_req_status 429;
+    }
+
+    # Paid endpoint: throttled here, authenticated in the handler.
+    location /api/examples {
+        limit_req zone=examples burst=10 nodelay;
+        limit_req_status 429;
+        # The client reschedules its fetch task on Retry-After; without the
+        # header it retries on its own timetable.
+        add_header Retry-After $examples_retry_after always;
+
+        proxy_pass http://127.0.0.1:8083;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+
+        # Declaring any proxy_set_header here stops the server-level stripping
+        # from being inherited (#304), so repeat it.
+        proxy_set_header X-Auth-CouchDB-UserName "";
+        proxy_set_header X-Auth-CouchDB-Roles    "";
+        proxy_set_header X-Auth-CouchDB-Token    "";
     }
 
     location /api/sync/updates {

--- a/openspec/changes/archive/2026-08-15-authenticate-and-throttle-examples/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-15-authenticate-and-throttle-examples/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-with-adr
+created: 2026-08-15

--- a/openspec/changes/archive/2026-08-15-authenticate-and-throttle-examples/proposal.md
+++ b/openspec/changes/archive/2026-08-15-authenticate-and-throttle-examples/proposal.md
@@ -1,0 +1,59 @@
+## Why
+
+`GET /api/examples` is the only route in the router that never reads the session cookie
+(`src/backend/core.clj:491`), and it is the one route that spends money: every request runs
+`examples/generate-one!` into the paid OpenRouter provider (`src/backend/examples/provider.clj`).
+`/auth/check`, `/api/sync/updates` and `/api/identity/account` all resolve a token first; this one
+answers anybody. At the edge the picture matches: the only `limit_req_zone` is `couchdb`, applied to
+`/db/` and `/db/dictionary-db/`, while `/api/examples` falls through to `location /` with no limit at
+all. Anyone who knows the URL can bill the owner for as many completions as their connection allows.
+
+## What Changes
+
+- The handler resolves the bearer cookie through `authenticated-user-id`, exactly as `/auth/check`
+  does, and answers `401` before any argument is parsed and before the provider is touched. An
+  unauthenticated caller cannot even reach the `400` for a missing `word`, because a validation
+  message is more than an unauthenticated caller should learn.
+- A dedicated `limit_req_zone examples` is added to the production and development nginx configs, with
+  a `location /api/examples` that applies it and answers `429`. Sharing the `couchdb` zone would be
+  wrong twice over: it is sized for replication bursts at 40r/s, and replication traffic would eat the
+  budget of a paid endpoint.
+- The `429` carries `Retry-After`, so the throttled client backs off instead of hammering. The client
+  already reads that header (`retry-after-ms`, `src/client/adapters/examples.cljs:25`) and reschedules
+  the fetch task; without the header it would retry on its own timetable.
+- The single client caller, `fetch-one` (`src/client/adapters/examples.cljs:36`), issues a relative
+  same-origin request, so the browser already attaches the `auth-token` cookie under the default
+  `same-origin` credentials mode. It is made explicit at the call site so the guarantee survives a
+  future edit that moves the URL to an absolute origin — the failure mode otherwise is silent: every
+  example fetch starts answering 401 and the feature dies quietly.
+
+Out of scope: throttling inside the backend. The edge is where the request budget belongs, and it is
+where every other limit in this repo already lives.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `examples`: gains a requirement that generating an example needs an authenticated session — today
+  the spec covers only how examples are stored and when fetch tasks are created, and says nothing
+  about who may ask for one.
+- `production-service-hardening`: gains a requirement that an endpoint which spends money on an
+  upstream provider is rate limited at the edge in its own zone.
+
+## Impact
+
+- `src/backend/core.clj` — the `/api/examples` route.
+- `infra/production/etc/nginx/sites-available/learning-app.conf` — new zone, new location.
+- `infra/development/etc/nginx/sites-available/sprecha.localhost.conf` — the same, so the limit is
+  exercised on the dev stand rather than first met in production.
+- `src/client/adapters/examples.cljs` — explicit credentials on the one caller.
+- `test/backend/core_test.clj` — an end-to-end assertion over the real router: no cookie → 401 and the
+  provider is never called; valid cookie → 200.
+
+Note for review: issue #304 edits the same two nginx files (moving the proxy-auth header stripping
+into an include). The edits touch different lines, but whichever lands second will want a look at the
+merge.

--- a/openspec/changes/archive/2026-08-15-authenticate-and-throttle-examples/specs/examples/spec.md
+++ b/openspec/changes/archive/2026-08-15-authenticate-and-throttle-examples/specs/examples/spec.md
@@ -1,21 +1,4 @@
-# examples Specification
-
-## Purpose
-Define how example sentences are generated and stored for vocabulary words, including task creation for fetching examples.
-## Requirements
-### Requirement: Example documents are stored
-The system SHALL store example documents defined in `specs/data-model/spec.md`. Per-collection scoping rules are defined in `specs/examples-schema/spec.md`.
-
-#### Scenario: Store example document
-- **WHEN** an example is fetched for a word
-- **THEN** an example document is created matching the example document shape in `specs/data-model/spec.md`
-
-### Requirement: Example fetch tasks are created on word creation
-The system SHALL create an example-fetch task whenever a word is created, carrying the active collection context (see `specs/examples-schema/spec.md`).
-
-#### Scenario: Word creation triggers example-fetch task
-- **WHEN** a word is added
-- **THEN** an example-fetch task document is persisted for that word via the examples module
+## ADDED Requirements
 
 ### Requirement: Generating an example needs an authenticated session
 
@@ -73,4 +56,3 @@ outcome of that race decides whether the first example of the boot is answered o
 - **WHEN** the app starts with an example fetch task already in the queue
 - **THEN** the task runner does not start until the session cookie has been written
 - **AND** the request it issues authenticates like any other
-

--- a/openspec/changes/archive/2026-08-15-authenticate-and-throttle-examples/specs/production-service-hardening/spec.md
+++ b/openspec/changes/archive/2026-08-15-authenticate-and-throttle-examples/specs/production-service-hardening/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: An endpoint that spends money upstream is rate limited at its own edge zone
+
+Every endpoint whose requests cost money at a third-party provider SHALL be rate limited by the
+reverse proxy in a zone of its own, keyed by client address. It SHALL NOT share a zone with bulk
+database traffic: the replication zone is sized for `_changes` and `_bulk_get` bursts, so sharing it
+would let ordinary replication spend the paid endpoint's budget, and would size the paid endpoint's
+budget for replication.
+
+A throttled response SHALL be `429` and SHALL carry `Retry-After`, so a client backs off on the
+server's timetable instead of its own.
+
+The limit SHALL be present in the development proxy config as well as production, so the behaviour is
+exercised on the stand rather than first met in production.
+
+#### Scenario: A burst from one client
+
+- **WHEN** one client sends example requests faster than the configured rate, beyond the configured
+  burst
+- **THEN** the excess requests are answered `429` with a `Retry-After` header
+- **AND** those requests never reach the application, so nothing is spent on them
+
+#### Scenario: Ordinary use
+
+- **WHEN** a client requests examples within the configured rate and burst
+- **THEN** every request is proxied and answered normally
+
+#### Scenario: Replication traffic
+
+- **WHEN** database replication produces a burst against `/db/`
+- **THEN** it is accounted against the replication zone only, and leaves the example endpoint's
+  allowance untouched

--- a/openspec/changes/archive/2026-08-15-authenticate-and-throttle-examples/tasks.md
+++ b/openspec/changes/archive/2026-08-15-authenticate-and-throttle-examples/tasks.md
@@ -1,0 +1,44 @@
+## 1. Backend
+
+- [x] 1.1 `/api/examples` resolves the cookie through `authenticated-user-id` and answers `401`
+      before parsing parameters and before calling `examples/generate-one!`
+- [x] 1.2 Confirm the route sees parsed cookies — the router-wide `cookie-interceptor` already
+      supplies `:cookies`, so no per-route wiring is needed
+
+## 2. Edge
+
+- [x] 2.1 Production conf: `limit_req_zone $binary_remote_addr zone=examples:10m rate=30r/m` and a
+      `location /api/examples` applying it with `burst=10 nodelay`, `limit_req_status 429` and a
+      `Retry-After` header
+- [x] 2.2 Development conf: the same zone and location, so the limit is exercised on the stand
+- [x] 2.3 The new location strips the three `X-Auth-CouchDB-*` client headers itself — a location
+      that declares its own `proxy_set_header` stops inheriting the server-level stripping (#304)
+- [x] 2.4 `Retry-After` only on the throttled answer: `add_header ... always` fires on every
+      response, so a `map $status` empties the value elsewhere and nginx omits the header
+- [x] 2.5 Both configs load in nginx
+
+## 3. Client
+
+- [x] 3.1 `fetch-one` declares its credentials mode explicitly instead of relying on the same-origin
+      default
+- [x] 3.2 Confirm there is no second caller of `/api/examples` anywhere in `src/client` — `fetch-one`
+      is the only one, reached from the `example-fetch` task handler
+- [x] 3.3 Confirm nothing re-issues the request without credentials — the service worker's fetch
+      handler ignores `/api/` entirely (no branch matches, so it never calls `respondWith`), and the
+      branches that do fire pass the original `Request` to `fetch`
+- [x] 3.4 Start the task runner after the component that writes the auth cookie: both sat in the same
+      dependency layer, so a queued example fetch could beat the cookie and be refused
+
+## 4. Verification
+
+- [x] 4.1 Backend test over the real router: no cookie → `401`, and the provider is never called
+- [x] 4.2 Backend test: a cookie whose token matches an account → `200` with a generated example
+- [x] 4.3 Run the backend suite — nothing runs `test/backend/**` in CI today (#323), so run it by
+      hand: 25 tests, 59 assertions, 0 failures
+- [x] 4.4 Negative control: with the handler reverted, the same test reports `200` for anonymous
+      requests and two provider calls that should never have happened
+- [x] 4.5 Throttling proven against a running nginx carrying these exact directives: 11 answered,
+      the rest `429` with `Retry-After: 5`, and the upstream counted exactly the answered ones
+- [x] 4.6 Successful answers carry no `Retry-After`
+- [x] 4.7 Client tests still pass: 182 tests, 433 assertions, 0 failures
+- [x] 4.8 `openspec validate authenticate-and-throttle-examples --strict`

--- a/openspec/specs/production-service-hardening/spec.md
+++ b/openspec/specs/production-service-hardening/spec.md
@@ -52,3 +52,35 @@ postinst SHALL align the running CouchDB admin password with the encrypted crede
 - **WHEN** the credential does not authenticate even after the ini write and restart
 - **THEN** postinst exits nonzero instead of continuing
 
+### Requirement: An endpoint that spends money upstream is rate limited at its own edge zone
+
+Every endpoint whose requests cost money at a third-party provider SHALL be rate limited by the
+reverse proxy in a zone of its own, keyed by client address. It SHALL NOT share a zone with bulk
+database traffic: the replication zone is sized for `_changes` and `_bulk_get` bursts, so sharing it
+would let ordinary replication spend the paid endpoint's budget, and would size the paid endpoint's
+budget for replication.
+
+A throttled response SHALL be `429` and SHALL carry `Retry-After`, so a client backs off on the
+server's timetable instead of its own.
+
+The limit SHALL be present in the development proxy config as well as production, so the behaviour is
+exercised on the stand rather than first met in production.
+
+#### Scenario: A burst from one client
+
+- **WHEN** one client sends example requests faster than the configured rate, beyond the configured
+  burst
+- **THEN** the excess requests are answered `429` with a `Retry-After` header
+- **AND** those requests never reach the application, so nothing is spent on them
+
+#### Scenario: Ordinary use
+
+- **WHEN** a client requests examples within the configured rate and burst
+- **THEN** every request is proxied and answered normally
+
+#### Scenario: Replication traffic
+
+- **WHEN** database replication produces a burst against `/db/`
+- **THEN** it is accounted against the replication zone only, and leaves the example endpoint's
+  allowance untouched
+

--- a/src/backend/core.clj
+++ b/src/backend/core.clj
@@ -488,12 +488,19 @@
                  (response/header "X-Auth-Token" (hmac-sign (str user-id) db-auth-secret)))
              {:status 401})))}]
 
+     ;; Every answer here costs money at the provider, so the token is checked
+     ;; before the parameters are: an anonymous caller does not even get told
+     ;; which parameter it forgot.
      ["/api/examples"
       {:get
        (fn [request]
          (let [{:keys [context word translation]} (:params request)
                context (utils/non-blank context)]
            (cond
+             (nil? (on-connection [db db-spec]
+                     (authenticated-user-id db (request-token request))))
+             {:status 401 :body ""}
+
              (str/blank? word)
              {:status  400
               :headers {"Content-Type" "application/json"}

--- a/src/client/adapters/examples.cljs
+++ b/src/client/adapters/examples.cljs
@@ -45,7 +45,12 @@
         url      (if (utils/non-blank collection-name)
                    (str url "&context=" (js/encodeURIComponent collection-name))
                    url)
-        response (await (js/fetch url))]
+        ;; The endpoint authenticates by the session cookie, so the request
+        ;; must carry it. Relative and same-origin, the browser would attach it
+        ;; under the default anyway; "include" keeps it attached even if the URL
+        ;; ever gains an origin, where the default would silently stop sending
+        ;; it and every example would come back 401.
+        response (await (js/fetch url #js {:credentials "include"}))]
     (if (.-ok response)
       (let [json (try
                    (await (.json response))

--- a/src/client/main.cljs
+++ b/src/client/main.cljs
@@ -71,7 +71,12 @@
 
     :port/clock         {:start clock/start!}
 
-    :worker/task-runner {:requires {:db    :db/pouch
+    ;; After :sync/identity, not beside it: that component writes the auth
+    ;; cookie, and the first task off the queue may be an example fetch, which
+    ;; the backend answers 401 without it. Same layer meant that race was a
+    ;; coin toss on every boot.
+    :worker/task-runner {:after    [:sync/identity]
+                         :requires {:db    :db/pouch
                                     :clock :port/clock}
                          :start    task-queue/start!
                          :stop     task-queue/stop!}

--- a/test/backend/core_test.clj
+++ b/test/backend/core_test.clj
@@ -4,6 +4,7 @@
    [clojure.test :refer [deftest is testing]]
    [core :as sut]
    [db :as db]
+   [examples :as examples]
    [migrations :as migrations]
    [next.jdbc :as jdbc]
    [next.jdbc.result-set :as result-set]
@@ -122,6 +123,42 @@
           (is (nil? @sut/server))))
       (finally
        (sut/stop-server!)))))
+
+
+(deftest example-generation-answers-only-an-authenticated-session
+  (let [db (migrated-db)
+        generations (atom 0)]
+    (add-account! db 1 "token-of-one")
+    (with-redefs [sut/db-spec db
+                  examples/generate-one! (fn [_]
+                                           (swap! generations inc)
+                                           {:translation "У дома есть сад."
+                                            :value       "Das Haus hat einen Garten."})]
+      (sut/start-server! sut/app-handler 0)
+      (try
+        (let [port (server/server-port @sut/server)
+              ask  (fn [cookie query]
+                     @(client/request
+                       (cond-> {:method :get
+                                :url    (str "http://localhost:" port "/api/examples" query)}
+                         cookie (assoc :headers {"Cookie" (str "auth-token=" cookie)}))))]
+          (testing "a request with no session is refused"
+            (is (= 401 (:status (ask nil "?word=Haus")))))
+          (testing "a token nobody minted is refused"
+            (is (= 401 (:status (ask "invented" "?word=Haus")))))
+          (testing "an anonymous caller is not even told which parameter is missing"
+            (is (= 401 (:status (ask nil "")))))
+          (testing "nothing was generated for any of them"
+            (is (zero? @generations)))
+          (testing "the session that owns an account is served"
+            (let [response (ask "token-of-one" "?word=Haus")]
+              (is (= 200 (:status response)))
+              (is (str/includes? (:body response) "Das Haus hat einen Garten."))
+              (is (= 1 @generations))))
+          (testing "and an authenticated caller still gets its validation error"
+            (is (= 400 (:status (ask "token-of-one" ""))))))
+        (finally
+         (sut/stop-server!))))))
 
 
 (deftest the-build-and-the-server-agree-on-where-the-version-lives


### PR DESCRIPTION
Closes #306.

`GET /api/examples` was the only route in the router that never read the session cookie, and the only
one that spends money: each request runs a provider completion. At the edge, the single `limit_req_zone`
covered `/db/` only, so the endpoint fell through to `location /` unthrottled.

## What changed

- **Backend** — the handler resolves the cookie through `authenticated-user-id` and answers `401`
  before parsing parameters and before reaching the provider. An anonymous caller is not even told
  which parameter it forgot.
- **Edge** — an `examples` zone of its own (`30r/m`, `burst=10 nodelay`, `429`), in both the production
  and development configs. Sharing `couchdb` would be wrong twice: it is sized for replication bursts,
  and replication would eat a paid endpoint's budget. A `map $status` puts `Retry-After` on the
  throttled answer only — `add_header ... always` stamps every response otherwise. The new location
  repeats the `X-Auth-CouchDB-*` stripping, since declaring any `proxy_set_header` stops the
  server-level inheritance (#304).
- **Client** — `fetch-one` states its credentials mode instead of leaning on the same-origin default,
  and the task runner now starts *after* the component that writes the auth cookie. They shared a
  dependency layer, so a queued example fetch could beat the cookie and come back 401 — a coin toss on
  every boot, and exactly how this change could have broken examples instead of protecting them.

## Verified

- Backend test over the real router and a real socket: no cookie → `401`, unknown token → `401`,
  missing `word` without a session → `401` (not `400`), valid session → `200`. Provider call count
  asserted: zero for the refused ones.
- **Negative control** — with the handler reverted, that same test reports `200` for anonymous requests
  and two provider calls. The test catches the defect, it does not merely pass.
- Backend suite by hand (nothing runs `test/backend/**` in CI — #323): 25 tests, 59 assertions, 0 failures.
- Throttling against a real nginx running these exact directives against a counting upstream:
  11 answered, the rest `429` with `Retry-After: 5`, upstream hit count exactly the 11. Successful
  answers carry no `Retry-After`.
- Both repo configs load in nginx (test certs and ports substituted for the production one).
- Client suite: 182 tests, 433 assertions, 0 failures.

## Not proven

- No end-to-end run in a browser against the stand: generating a real example spends provider money,
  so the client path is argued from code (single caller, relative URL, and the service worker's fetch
  handler ignores `/api/` entirely) plus the passing suite, not from a live 200.
- The throttle was proven in an isolated nginx, not on the shared dev stand, whose installed config is
  a root-owned copy. **Deploying it needs the owner**: copy `infra/development/...` into
  `/etc/nginx/sites-available/` and reload.
- `openspec` `design.md` was deliberately skipped; the reasoning is short enough to live in the proposal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)