### PR TITLE
GH-304 Strip the CouchDB proxy-auth headers in every nginx location

### DIFF
--- a/docs/dev/development-setup.md
+++ b/docs/dev/development-setup.md
@@ -184,10 +184,17 @@ Restart CouchDB after copying the config.
 
 ### 4. Install the Nginx config
 
+The site config `include`s a snippet, so copy both — nginx refuses to start when
+an included file is missing. The include is relative, and nginx resolves it
+against the directory holding `nginx.conf`.
+
 ```bash
 # macOS
+mkdir -p /opt/homebrew/etc/nginx/snippets
+cp infra/development/etc/nginx/snippets/couchdb-proxy-auth-strip.conf /opt/homebrew/etc/nginx/snippets/
 cp infra/development/etc/nginx/sites-available/sprecha.localhost.conf /opt/homebrew/etc/nginx/servers/
 # Ubuntu/WSL
+sudo cp infra/development/etc/nginx/snippets/couchdb-proxy-auth-strip.conf /etc/nginx/snippets/
 sudo cp infra/development/etc/nginx/sites-available/sprecha.localhost.conf /etc/nginx/sites-available/
 sudo ln -sf /etc/nginx/sites-available/sprecha.localhost.conf /etc/nginx/sites-enabled/
 ```

--- a/infra/development/etc/nginx/sites-available/sprecha.localhost.conf
+++ b/infra/development/etc/nginx/sites-available/sprecha.localhost.conf
@@ -14,6 +14,7 @@ server {
     # Dev WebSocket
     location /shadow-cljs/ {
         proxy_pass http://localhost:9630/;
+        include snippets/couchdb-proxy-auth-strip.conf;
 
         # WebSocket specific headers: https://nginx.org/ru/docs/http/websocket.html
         proxy_http_version 1.1;
@@ -25,6 +26,7 @@ server {
     # Push pokes (ADR-0009): a WebSocket, silent while nothing changes.
     location /api/sync/updates {
         proxy_pass http://localhost:8083/api/sync/updates;
+        include snippets/couchdb-proxy-auth-strip.conf;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
@@ -32,13 +34,14 @@ server {
         proxy_send_timeout 1h;
     }
 
-    # Clear client's proxy-auth header, not allowed
-    proxy_set_header X-Auth-CouchDB-UserName "";
-    proxy_set_header X-Auth-CouchDB-Roles    "";
-    proxy_set_header X-Auth-CouchDB-Token    "";
+    # Clear client's proxy-auth header, not allowed. Only reaches locations that
+    # declare no proxy_set_header of their own — every location below declares
+    # some, so each includes the same snippet explicitly (GH-304).
+    include snippets/couchdb-proxy-auth-strip.conf;
 
     # CouchDB dictionary-db (public read-only, no auth required)
     location /db/dictionary-db/ {
+        include snippets/couchdb-proxy-auth-strip.conf;
         proxy_pass http://localhost:5984/dictionary-db/;
         proxy_redirect off;
         proxy_buffering off;
@@ -59,7 +62,9 @@ server {
         auth_request_set $couch_roles $upstream_http_x_auth_roles;
         auth_request_set $couch_token $upstream_http_x_auth_token;
 
-        # 3. Inject CouchDB proxy-auth headers
+        # 3. Inject CouchDB proxy-auth headers. This assignment replaces whatever
+        #    the client sent, so it is the strip for this location — including
+        #    the snippet here would send each header twice.
         proxy_set_header X-Auth-CouchDB-UserName $couch_user;
         proxy_set_header X-Auth-CouchDB-Roles    $couch_roles;
         proxy_set_header X-Auth-CouchDB-Token    $couch_token;
@@ -77,12 +82,14 @@ server {
     location /auth/check {
         internal;
         proxy_pass http://localhost:8083/auth/check;
+        include snippets/couchdb-proxy-auth-strip.conf;
         proxy_set_header Content-Length "";
         proxy_pass_request_body off;
     }
 
     location / {
         proxy_pass http://localhost:8083;
+        include snippets/couchdb-proxy-auth-strip.conf;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
     }

--- a/infra/development/etc/nginx/snippets/couchdb-proxy-auth-strip.conf
+++ b/infra/development/etc/nginx/snippets/couchdb-proxy-auth-strip.conf
@@ -1,0 +1,13 @@
+# Drop the CouchDB proxy-auth headers if a client supplied them. CouchDB trusts
+# these headers by construction, so nginx refusing them is the whole boundary.
+#
+# Include this in every location that proxies upstream. nginx passes a
+# server-level proxy_set_header into a location only when that location declares
+# none of its own, and every proxying location here declares at least Host — so
+# the server-level copies never reached them (GH-304).
+#
+# Do NOT include it where the headers are assigned from auth_request: nginx
+# would then send each header twice.
+proxy_set_header X-Auth-CouchDB-UserName "";
+proxy_set_header X-Auth-CouchDB-Roles    "";
+proxy_set_header X-Auth-CouchDB-Token    "";

--- a/infra/production/etc/nginx/sites-available/learning-app.conf
+++ b/infra/production/etc/nginx/sites-available/learning-app.conf
@@ -16,14 +16,15 @@ server {
 
     location / {
         proxy_pass http://127.0.0.1:8083;
+        include snippets/couchdb-proxy-auth-strip.conf;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
     }
 
-    # Prevent clients from spoofing CouchDB proxy-auth headers
-    proxy_set_header X-Auth-CouchDB-UserName "";
-    proxy_set_header X-Auth-CouchDB-Roles    "";
-    proxy_set_header X-Auth-CouchDB-Token    "";
+    # Prevent clients from spoofing CouchDB proxy-auth headers. Only reaches
+    # locations that declare no proxy_set_header of their own — every location
+    # here declares some, so each includes the same snippet explicitly (GH-304).
+    include snippets/couchdb-proxy-auth-strip.conf;
 
     # CouchDB user databases (authenticated via session cookie)
     location /db/ {
@@ -36,6 +37,9 @@ server {
         auth_request_set $couch_roles $upstream_http_x_auth_roles;
         auth_request_set $couch_token $upstream_http_x_auth_token;
 
+        # This assignment replaces whatever the client sent, so it is the strip
+        # for this location — including the snippet here would send each header
+        # twice.
         proxy_set_header X-Auth-CouchDB-UserName $couch_user;
         proxy_set_header X-Auth-CouchDB-Roles    $couch_roles;
         proxy_set_header X-Auth-CouchDB-Token    $couch_token;
@@ -55,6 +59,7 @@ server {
 
     location /api/sync/updates {
         proxy_pass http://127.0.0.1:8083/api/sync/updates;
+        include snippets/couchdb-proxy-auth-strip.conf;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
@@ -67,6 +72,7 @@ server {
     location /auth/check {
         internal;
         proxy_pass http://127.0.0.1:8083/auth/check;
+        include snippets/couchdb-proxy-auth-strip.conf;
         proxy_set_header Content-Length "";
         proxy_pass_request_body off;
     }
@@ -83,6 +89,7 @@ server {
         }
 
         proxy_pass http://127.0.0.1:5984/dictionary-db/;
+        include snippets/couchdb-proxy-auth-strip.conf;
         proxy_redirect off;
         proxy_buffering off;
         proxy_connect_timeout 10s;

--- a/infra/production/etc/nginx/snippets/couchdb-proxy-auth-strip.conf
+++ b/infra/production/etc/nginx/snippets/couchdb-proxy-auth-strip.conf
@@ -1,0 +1,13 @@
+# Drop the CouchDB proxy-auth headers if a client supplied them. CouchDB trusts
+# these headers by construction, so nginx refusing them is the whole boundary.
+#
+# Include this in every location that proxies upstream. nginx passes a
+# server-level proxy_set_header into a location only when that location declares
+# none of its own, and every proxying location here declares at least Host — so
+# the server-level copies never reached them (GH-304).
+#
+# Do NOT include it where the headers are assigned from auth_request: nginx
+# would then send each header twice.
+proxy_set_header X-Auth-CouchDB-UserName "";
+proxy_set_header X-Auth-CouchDB-Roles    "";
+proxy_set_header X-Auth-CouchDB-Token    "";

--- a/infra/staging/Dockerfile
+++ b/infra/staging/Dockerfile
@@ -15,11 +15,14 @@ RUN printf '%s\n' \
         'Acquire::https::Timeout "30";' \
     > /etc/apt/apt.conf.d/80-staging-timeouts
 
-# systemd as PID 1 plus tooling for the repo setup below.
+# systemd as PID 1 plus tooling for the repo setup below. netcat-openbsd is for
+# the smoke alone: it stands in for an upstream so an assertion can read the
+# request nginx actually forwards. It never enters the production deb.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         systemd systemd-sysv dbus \
         curl ca-certificates gnupg apt-transport-https openssl \
+        netcat-openbsd \
     && rm -rf /var/lib/apt/lists/*
 
 # CouchDB apt repository — the same source admin-setup.sh --bootstrap adds.

--- a/infra/staging/smoke.sh
+++ b/infra/staging/smoke.sh
@@ -74,12 +74,23 @@ upstream_clean_of_couch_headers() {
         https://sprecha.de/ >/dev/null 2>&1
     kill "${nc_pid}" 2>/dev/null
     wait "${nc_pid}" 2>/dev/null
+    # Put the stand back the way it was found: the assertions after this one --
+    # and the restore drill after them -- expect a JVM that already answers.
     systemctl start learning-app-run.service
+    for _ in $(seq 1 90); do
+        curl -sf -o /dev/null http://127.0.0.1:8083/ && break
+        sleep 1
+    done
     # A capture that never happened must not read as clean.
     grep -qi '^GET ' "${capture}" && ! grep -qi 'x-auth-couchdb' "${capture}"
 }
 check "nginx: a client's proxy-auth header does not reach the upstream" \
     upstream_clean_of_couch_headers
+
+# Named on its own, so a stand left broken by the capture above is reported
+# here instead of surfacing as an unrelated failure further down.
+app_answers_again() { test "$(http_code http://127.0.0.1:8083/)" = 200; }
+check "app: answers again after the proxy-auth capture" app_answers_again
 
 # The same boundary read off the installed config, so a new location that
 # forgets the snippet fails here even though the assertion above only exercises

--- a/infra/staging/smoke.sh
+++ b/infra/staging/smoke.sh
@@ -56,6 +56,70 @@ check "app: /auth/check without cookie is 401" \
 check "nginx: /db/ without cookie is 401" \
     test "$(http_code --resolve sprecha.de:443:127.0.0.1 https://sprecha.de/db/anything)" = 401
 
+# The proxy-auth boundary (GH-304). CouchDB trusts X-Auth-CouchDB-* by
+# construction, so nginx must drop whatever a client sends. No response reveals
+# the headers an upstream received -- CouchDB answers a spoofed request exactly
+# as it answers an anonymous one -- so the app steps aside and a listener reads
+# the request nginx actually forwards.
+upstream_clean_of_couch_headers() {
+    local capture=/tmp/proxy-auth-capture nc_pid
+    systemctl stop learning-app-run.service
+    timeout 10 nc -l 127.0.0.1 8083 > "${capture}" &
+    nc_pid=$!
+    sleep 1
+    curl -k -s -m 3 --resolve sprecha.de:443:127.0.0.1 \
+        -H 'X-Auth-CouchDB-UserName: attacker' \
+        -H 'X-Auth-CouchDB-Roles: _admin' \
+        -H 'X-Auth-CouchDB-Token: forged' \
+        https://sprecha.de/ >/dev/null 2>&1
+    kill "${nc_pid}" 2>/dev/null
+    wait "${nc_pid}" 2>/dev/null
+    systemctl start learning-app-run.service
+    # A capture that never happened must not read as clean.
+    grep -qi '^GET ' "${capture}" && ! grep -qi 'x-auth-couchdb' "${capture}"
+}
+check "nginx: a client's proxy-auth header does not reach the upstream" \
+    upstream_clean_of_couch_headers
+
+# The same boundary read off the installed config, so a new location that
+# forgets the snippet fails here even though the assertion above only exercises
+# one of them. `nginx -T` dumps each file separately instead of inlining
+# includes, so the snippet is checked on its own and a location counts as safe
+# when it includes it or assigns all three headers from auth_request.
+STRIP_SNIPPET=/etc/nginx/snippets/couchdb-proxy-auth-strip.conf
+
+strip_snippet_clears_all_three() {
+    grep -Eq 'proxy_set_header +X-Auth-CouchDB-UserName +""' "${STRIP_SNIPPET}" &&
+    grep -Eq 'proxy_set_header +X-Auth-CouchDB-Roles +""' "${STRIP_SNIPPET}" &&
+    grep -Eq 'proxy_set_header +X-Auth-CouchDB-Token +""' "${STRIP_SNIPPET}"
+}
+check "nginx: the strip snippet clears all three headers" \
+    strip_snippet_clears_all_three
+
+every_proxy_location_handles_couch_headers() {
+    nginx -T 2>/dev/null | awk '
+        /^[[:space:]]*location[^{]*\{/ { inloc = 1; depth = 1; buf = ""; next }
+        inloc {
+            opens = gsub(/\{/, "{"); closes = gsub(/\}/, "}")
+            depth += opens - closes
+            buf = buf $0 "\n"
+            if (depth <= 0) {
+                inloc = 0
+                if (buf ~ /proxy_pass/) {
+                    assigned = (buf ~ /X-Auth-CouchDB-UserName/) \
+                             + (buf ~ /X-Auth-CouchDB-Roles/) \
+                             + (buf ~ /X-Auth-CouchDB-Token/)
+                    included = (buf ~ /include +snippets\/couchdb-proxy-auth-strip\.conf/)
+                    if (assigned != 3 && !included) bad++
+                }
+            }
+        }
+        END { exit(bad > 0) }
+    '
+}
+check "nginx: every proxying location handles the proxy-auth headers" \
+    every_proxy_location_handles_couch_headers
+
 # Migrations ran against the configured database path.
 check "migrations: schema_migrations has rows" \
     bash -c "test \"\$(sqlite3 ${DB} 'SELECT count(*) FROM schema_migrations;')\" -ge 1"

--- a/openspec/changes/archive/2026-08-15-strip-couch-proxy-auth-headers/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-15-strip-couch-proxy-auth-headers/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-with-adr
+created: 2026-08-15

--- a/openspec/changes/archive/2026-08-15-strip-couch-proxy-auth-headers/design.md
+++ b/openspec/changes/archive/2026-08-15-strip-couch-proxy-auth-headers/design.md
@@ -1,0 +1,71 @@
+## Context
+
+CouchDB is configured for proxy authentication: nginx's `/db/` location asks the app
+(`auth_request /auth/check`), takes the user, roles and token from the subrequest response, and
+passes them on as `X-Auth-CouchDB-*`. CouchDB trusts those headers by construction — the entire
+boundary is nginx refusing to let a client set them.
+
+Both configs try to enforce that with three `proxy_set_header X-Auth-CouchDB-* ""` directives at
+`server` level. nginx's inheritance rule for `proxy_set_header` is all-or-nothing: a `location`
+that declares even one `proxy_set_header` of its own inherits none from the enclosing scope. Every
+proxying location in both files declares at least `Host` or `Upgrade`, so none of them inherit the
+stripping.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Every location that proxies upstream strips the three client-supplied headers.
+- The gap cannot silently return: a scripted assertion observes what the upstream receives.
+- One place to edit when the header set changes.
+
+**Non-Goals:**
+
+- Turning on `proxy_use_secret` / the HMAC token in CouchDB. That is a second layer, tracked
+  separately; this change fixes the first one.
+- Any change to how `/db/` derives the headers from `auth_request`.
+- Touching the running production host. The config is delivered by the infra deb as usual.
+
+## Decisions
+
+**A snippet included per location, not repeated directives.** Three lines copied into five
+locations across two files rot independently; the next header added to the set would be added to
+some of them. `include` gives one file to edit and one grep to audit.
+
+**The include path is relative (`include snippets/couchdb-proxy-auth-strip.conf;`).** nginx
+resolves a relative include against its prefix, which is `/etc/nginx` on the Debian/Ubuntu package
+and `/opt/homebrew/etc/nginx` on the macOS dev stand. An absolute `/etc/nginx/...` would have
+worked on the server and broken the documented macOS setup.
+
+**`/db/` does not get the snippet.** It already assigns all three headers from its `auth_request`
+variables, and an assignment replaces the client's value — that location was never leaky. Adding
+the snippet there would declare each header twice, and nginx sends both copies upstream, which is
+strictly worse than the current state. The exclusion is spelled out in a comment beside the
+assignment so the next reader does not "fix" it.
+
+**The `server`-level directives stay.** They are redundant for every location that includes the
+snippet, but they still cover a future location that declares no headers at all. Inheritance is
+all-or-nothing, so keeping both cannot produce duplicates.
+
+**The smoke assertion observes the upstream socket, not the response.** Nothing in an upstream
+response reveals which headers it received; CouchDB with `require_valid_user = false` answers a
+spoofed request exactly as it answers an anonymous one, so a response-based check would pass even
+while leaking. The assertion stops the app service, listens on its port with `nc`, sends one
+request through nginx carrying `X-Auth-CouchDB-UserName`, and greps the captured request line.
+That is the only form of the check that can actually fail when the gap returns.
+
+## Risks / Trade-offs
+
+- **A missing snippet file is a fatal nginx config error, not a warning** → the deb ships it under
+  `/etc/nginx/snippets/`, and `docs/dev/development-setup.md` gains the copy step next to the
+  existing site-config step. Ordering in the deb is safe: the file is part of the same package as
+  the site config that includes it.
+- **The smoke assertion stops and restarts `learning-app-run` mid-run** → it runs before the
+  assertions that need the app, and restores the unit before continuing; a failure to come back up
+  surfaces as the following assertions failing rather than being hidden.
+- **`nc` is a new package in the staging image** → `netcat-openbsd`, from the same base repository
+  the image already uses; it is test-only and never enters the production deb.
+- **The check covers the app upstream, not the CouchDB one** → the dictionary location proxies to
+  CouchDB, and stopping CouchDB mid-smoke to listen on 5984 would disturb the later backup
+  assertions. The two locations carry the identical include, and the config-level shape is
+  verified by nginx itself at reload time.

--- a/openspec/changes/archive/2026-08-15-strip-couch-proxy-auth-headers/proposal.md
+++ b/openspec/changes/archive/2026-08-15-strip-couch-proxy-auth-headers/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+The nginx configs declare `proxy_set_header X-Auth-CouchDB-*  ""` at `server` level to stop a
+client from supplying CouchDB proxy-auth headers itself. nginx inherits `proxy_set_header` into a
+`location` only when that location declares none of its own, and every location that proxies
+upstream declares its own headers — so the stripping reaches none of them. The directives read as
+a guard while guarding nothing, which is worse than no guard at all: a reviewer sees them and stops
+looking.
+
+## What Changes
+
+- Move the three stripping directives into an nginx snippet and `include` it in every location that
+  proxies upstream, in both the production and the development config.
+- `/db/` keeps assigning the three headers from its `auth_request` variables; that assignment is
+  itself the strip (the client's value is replaced, never appended), and the snippet must not be
+  added there or nginx would send each header twice.
+- Add a staging smoke assertion that observes what the upstream actually receives: a request
+  carrying `X-Auth-CouchDB-UserName` must arrive at the upstream without it.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- none -->
+
+### Modified Capabilities
+
+- `production-service-hardening`: new requirement — client-supplied CouchDB proxy-auth headers are
+  stripped in every proxying location, not only where nginx happens to inherit them.
+- `staging-environment`: the smoke run also asserts the header boundary at the upstream.
+
+## Impact
+
+- `infra/production/etc/nginx/sites-available/learning-app.conf`
+- `infra/production/etc/nginx/snippets/` (new snippet, shipped by the infra deb)
+- `infra/development/etc/nginx/sites-available/sprecha.localhost.conf` and its snippet
+- `infra/staging/smoke.sh`, `infra/staging/Dockerfile` (the assertion needs a listener to observe
+  the upstream side)
+- `docs/dev/development-setup.md` (the dev stand now installs a snippet as well)

--- a/openspec/changes/archive/2026-08-15-strip-couch-proxy-auth-headers/specs/production-service-hardening/spec.md
+++ b/openspec/changes/archive/2026-08-15-strip-couch-proxy-auth-headers/specs/production-service-hardening/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Client-supplied CouchDB proxy-auth headers never reach an upstream
+nginx SHALL guarantee that no client-supplied value of `X-Auth-CouchDB-UserName`, `X-Auth-CouchDB-Roles` or `X-Auth-CouchDB-Token` reaches an upstream, because CouchDB trusts those headers by construction. Every location that proxies upstream SHALL either clear all three headers or assign all three itself from its `auth_request` variables; a location SHALL NOT rely on inheriting the clearing from `server` scope, because nginx passes `proxy_set_header` down only into locations that declare none of their own. The clearing SHALL live in a single included snippet rather than being repeated per location, and no location SHALL both include the snippet and assign the headers, which would send each header twice.
+
+#### Scenario: A client spoofs the identity header
+- **WHEN** a request carrying `X-Auth-CouchDB-UserName` arrives at any location that proxies upstream
+- **THEN** the upstream receives that request without the header
+
+#### Scenario: The authenticated database path
+- **WHEN** a request with a valid session reaches `/db/`
+- **THEN** the three headers arriving upstream are the ones derived from the `auth_request` response, each present exactly once
+
+#### Scenario: A location is added later
+- **WHEN** a new proxying location is added to either nginx config
+- **THEN** the staging smoke fails unless that location clears the headers or assigns them from `auth_request`

--- a/openspec/changes/archive/2026-08-15-strip-couch-proxy-auth-headers/specs/staging-environment/spec.md
+++ b/openspec/changes/archive/2026-08-15-strip-couch-proxy-auth-headers/specs/staging-environment/spec.md
@@ -1,0 +1,16 @@
+## MODIFIED Requirements
+
+### Requirement: The packaged shape is verifiable without a server
+A staging run SHALL build the infra deb exactly as CI builds it, install it inside a systemd container, and verify the resulting shape by script: services under their production sandboxes, nginx answering, the authentication boundary — including that a client-supplied CouchDB proxy-auth header does not reach an upstream — migrations against the configured database path, legacy database adoption, and a backup archive carrying both stores. Each assertion SHALL report PASS or FAIL on its own line and the run SHALL exit nonzero when any assertion fails.
+
+#### Scenario: An infra change before merge
+- **WHEN** `infra/staging/run.sh` runs against the working tree
+- **THEN** the actual deb installs in a booted systemd container and every smoke assertion reports PASS or FAIL, with a nonzero exit on any FAIL
+
+#### Scenario: A deliberately broken unit
+- **WHEN** a sandbox directive the service depends on is removed (e.g. a ReadWritePaths)
+- **THEN** the run reports the failure instead of green
+
+#### Scenario: A spoofed proxy-auth header
+- **WHEN** the smoke sends a request through nginx carrying `X-Auth-CouchDB-UserName` while a listener stands in for the upstream
+- **THEN** the captured request carries no `X-Auth-CouchDB-*` header, and every proxying location in the installed config is confirmed to clear or assign all three

--- a/openspec/changes/archive/2026-08-15-strip-couch-proxy-auth-headers/tasks.md
+++ b/openspec/changes/archive/2026-08-15-strip-couch-proxy-auth-headers/tasks.md
@@ -1,0 +1,30 @@
+## 1. The snippet
+
+- [x] 1.1 Add `infra/production/etc/nginx/snippets/couchdb-proxy-auth-strip.conf` with the three
+      clearing directives and a comment saying why a location must include it
+- [x] 1.2 Add the same snippet under `infra/development/etc/nginx/snippets/`
+
+## 2. The configs
+
+- [x] 2.1 Include the snippet in every proxying location of
+      `infra/production/etc/nginx/sites-available/learning-app.conf` except `/db/`, and note beside
+      `/db/`'s assignment why it is excluded
+- [x] 2.2 Do the same in `infra/development/etc/nginx/sites-available/sprecha.localhost.conf`
+- [x] 2.3 Document the snippet install step in `docs/dev/development-setup.md`
+
+## 3. The assertion
+
+- [x] 3.1 Install `netcat-openbsd` in `infra/staging/Dockerfile`
+- [x] 3.2 Add the upstream-observation assertion to `infra/staging/smoke.sh`: stop the app unit,
+      listen on its port, send a request through nginx carrying `X-Auth-CouchDB-UserName`, assert
+      the captured request has no `X-Auth-CouchDB-*` line, restart the unit
+- [x] 3.3 Add the config-shape assertion: every `location` in `nginx -T` that proxies upstream
+      either clears or assigns all three headers
+
+## 4. Verification
+
+- [x] 4.1 Run a throwaway nginx on a spare port with the dev config (ports rewritten, header
+      directives untouched) against a header-echoing upstream, and show the leak before the fix and
+      its absence after, for every location
+- [x] 4.2 Confirm `/db/` sends each header exactly once, with the `auth_request` value
+- [x] 4.3 `nginx -t` both configs; leave the shared dev stand as it was found

--- a/openspec/specs/production-service-hardening/spec.md
+++ b/openspec/specs/production-service-hardening/spec.md
@@ -52,3 +52,18 @@ postinst SHALL align the running CouchDB admin password with the encrypted crede
 - **WHEN** the credential does not authenticate even after the ini write and restart
 - **THEN** postinst exits nonzero instead of continuing
 
+### Requirement: Client-supplied CouchDB proxy-auth headers never reach an upstream
+nginx SHALL guarantee that no client-supplied value of `X-Auth-CouchDB-UserName`, `X-Auth-CouchDB-Roles` or `X-Auth-CouchDB-Token` reaches an upstream, because CouchDB trusts those headers by construction. Every location that proxies upstream SHALL either clear all three headers or assign all three itself from its `auth_request` variables; a location SHALL NOT rely on inheriting the clearing from `server` scope, because nginx passes `proxy_set_header` down only into locations that declare none of their own. The clearing SHALL live in a single included snippet rather than being repeated per location, and no location SHALL both include the snippet and assign the headers, which would send each header twice.
+
+#### Scenario: A client spoofs the identity header
+- **WHEN** a request carrying `X-Auth-CouchDB-UserName` arrives at any location that proxies upstream
+- **THEN** the upstream receives that request without the header
+
+#### Scenario: The authenticated database path
+- **WHEN** a request with a valid session reaches `/db/`
+- **THEN** the three headers arriving upstream are the ones derived from the `auth_request` response, each present exactly once
+
+#### Scenario: A location is added later
+- **WHEN** a new proxying location is added to either nginx config
+- **THEN** the staging smoke fails unless that location clears the headers or assigns them from `auth_request`
+

--- a/openspec/specs/staging-environment/spec.md
+++ b/openspec/specs/staging-environment/spec.md
@@ -4,7 +4,7 @@
 TBD - created by archiving change staging-container. Update Purpose after archive.
 ## Requirements
 ### Requirement: The packaged shape is verifiable without a server
-A staging run SHALL build the infra deb exactly as CI builds it, install it inside a systemd container, and verify the resulting shape by script: services under their production sandboxes, nginx answering, the authentication boundary, migrations against the configured database path, legacy database adoption, and a backup archive carrying both stores. Each assertion SHALL report PASS or FAIL on its own line and the run SHALL exit nonzero when any assertion fails.
+A staging run SHALL build the infra deb exactly as CI builds it, install it inside a systemd container, and verify the resulting shape by script: services under their production sandboxes, nginx answering, the authentication boundary — including that a client-supplied CouchDB proxy-auth header does not reach an upstream — migrations against the configured database path, legacy database adoption, and a backup archive carrying both stores. Each assertion SHALL report PASS or FAIL on its own line and the run SHALL exit nonzero when any assertion fails.
 
 #### Scenario: An infra change before merge
 - **WHEN** `infra/staging/run.sh` runs against the working tree
@@ -13,6 +13,10 @@ A staging run SHALL build the infra deb exactly as CI builds it, install it insi
 #### Scenario: A deliberately broken unit
 - **WHEN** a sandbox directive the service depends on is removed (e.g. a ReadWritePaths)
 - **THEN** the run reports the failure instead of green
+
+#### Scenario: A spoofed proxy-auth header
+- **WHEN** the smoke sends a request through nginx carrying `X-Auth-CouchDB-UserName` while a listener stands in for the upstream
+- **THEN** the captured request carries no `X-Auth-CouchDB-*` header, and every proxying location in the installed config is confirmed to clear or assign all three
 
 ### Requirement: The container rung stays honest about its limits
 The staging container SHALL NOT contact production systems or real credential stores: certbot never issues, borg targets a local repository, all secrets are test-only values, and the kernel is the host's. Claims beyond the shape — real TLS, remote backup, multi-day behavior — SHALL remain with the metal rung (ADR-0010).


### PR DESCRIPTION
Closes #304.

## Defect

The three `proxy_set_header X-Auth-CouchDB-* ""` directives sat at `server` level in both nginx
configs. nginx passes `proxy_set_header` into a `location` only when that location declares none of
its own, and every proxying location declares at least `Host` or `Upgrade` — so the clearing
reached none of them. `/db/` was never affected: it assigns all three from its `auth_request`
variables, which replaces whatever the client sent.

## Fix

- The clearing moves into `snippets/couchdb-proxy-auth-strip.conf` (shipped by the infra deb, and
  copied on the dev stand — the include is relative, so nginx resolves it next to `nginx.conf`).
- Every proxying location includes it, except `/db/`, where the `auth_request` assignment is the
  strip; including it there would send each header twice. A comment now says so.
- The `server`-level copies stay as a net for a future location that declares no headers at all.
- `infra/staging/smoke.sh` gains two assertions: one stops the app unit, listens on its port and
  reads the request nginx actually forwards; one walks `nginx -T` for a proxying location that
  neither clears nor assigns the three headers. The staging image gains `netcat-openbsd` for the
  first.

## Verification

Measured on a throwaway nginx (1.24) built from these very configs — only listen port, server_name,
TLS and upstream addresses rewritten, every header directive verbatim — proxying to an upstream
that reports the headers it received:

| location | before | after |
| --- | --- | --- |
| `/` | forwards `attacker` / `_admin` / `forged` | clean |
| `/db/dictionary-db/` | forwards them | clean |
| `/shadow-cljs/` (dev) | forwards them | clean |
| `/api/sync/updates` | forwards them | clean |
| `/db/` | `alice` / `users` / `tok-abc` | unchanged, one line each |

Both nginx configs were checked this way, before and after. The two smoke assertions were dry-run
against the same stand: both fail on the pre-fix config and pass on the fixed one, so neither is
vacuous.

Not verified here: a full `infra/staging/run.sh` container run (needs the built jar) — the smoke
check on this PR covers it. The shared dev stand was not touched; nothing was applied anywhere
outside a throwaway prefix in `/tmp`.
