### PR TITLE
GH-351 elect one dictionary holder instead of one per tab

### DIFF
--- a/adr/0002-dictionary-opfs-worker-first.md
+++ b/adr/0002-dictionary-opfs-worker-first.md
@@ -2,6 +2,7 @@
 
 - Status: accepted
 - Date: 2026-05-08
+- Superseded in part by: ADR-0012
 
 ## Context
 
@@ -17,4 +18,4 @@ The SQLite file is opened exclusively inside a dedicated Web Worker using `SyncA
 - `attach-translations` and `suggest` in `dictionary.cljs` become async `postMessage` shims — no semantic change for callers.
 - Cross-browser compatibility is ensured from the start without a future re-architecture.
 - sql.js adds ~60 MB heap pressure; acceptable on modern devices, monitored via telemetry.
-- WASM cold-start latency is off the critical path: the Worker initialises in the background on app boot.
+- ~~WASM cold-start latency is off the critical path: the Worker initialises in the background on app boot.~~ No longer holds — superseded by ADR-0012, which loads the engine on a tab's first turn with the dictionary rather than at app boot.

--- a/adr/0012-dictionary-belongs-to-the-visible-tab.md
+++ b/adr/0012-dictionary-belongs-to-the-visible-tab.md
@@ -40,9 +40,18 @@ The dictionary belongs to the tab being typed into. A tab takes the
 `sqlite-opfs-sahpool` lock when it comes to the foreground, opens the database and serves
 only itself; when it leaves the foreground it closes the database, pauses the pool and
 releases the lock. One stretch of holding that lock, from grant to release, is a *turn*; a
-tab has no database outside its turns. A tab waiting for one holds the queries asked of it
-until it starts — mostly its own, since the tab waiting is usually the one just brought to
-the front and already being typed into.
+tab has no database outside its turns. A tab waiting for one answers the queries asked of
+it with no completions and keeps nothing: the answer is what it has at that instant, and
+being asked again takes another keystroke.
+
+Not queueing them is a choice, and the measurements are what make it a cheap one. The
+windows a query can fall into are ~14 ms to take the lock back from the tab in front and
+~94 ms for a tab's first turn, against a 100 ms trailing suggest debounce and a keystroke
+every 120-180 ms — so on a warm start the turn has begun before the query is sent. The one
+window a user can actually see is a cold start, where the dictionary is still being
+downloaded and every keystroke until it lands gets an empty list. Holding queries buys that
+case and costs a mechanism to do it; the empty answer is accepted for now, and revisiting
+it is a separate decision.
 
 Foreground means on screen **and** holding the keyboard: `visibilityState === "visible" &&
 hasFocus()`. Visibility alone does not identify the tab being used — two tabs can be
@@ -81,8 +90,10 @@ database, and nothing here overturns a decision it did not make.
   moves as the user clicks between them. When the browser window itself is behind something
   else no tab holds it — there is nobody to ask, and the first tab to come back takes it in
   ~14 ms.
-- A tab that has not had a turn yet has no dictionary, and that is a state the UI must be
-  able to describe rather than show as an empty list (#312).
+- A tab that has not had a turn yet has no dictionary and says so by answering with no
+  completions, which is indistinguishable from a prefix that has none. Telling the two
+  apart is what `:dictionary/ready?` is on the port for, and describing it to the user is
+  #312.
 - Turns change hands more often than they would on visibility alone: a click in the address
   bar or in devtools is a `blur`, so it costs a round trip. ~14 ms per switch once a tab has
   had a turn, ~94 ms for its first. Both are far below the ~100 ms suggest debounce, and the

--- a/adr/0012-dictionary-belongs-to-the-visible-tab.md
+++ b/adr/0012-dictionary-belongs-to-the-visible-tab.md
@@ -1,0 +1,94 @@
+# 0012. The dictionary belongs to the visible tab
+
+- Status: accepted
+- Date: 2026-08-16
+- Supersedes: ADR-0002 (in part)
+
+## Context
+
+ADR-0002 put the dictionary in a dedicated Web Worker because `SyncAccessHandle` is
+Worker-only outside Chromium. That reasoning still holds; what it left unsaid is that
+`opfs-sahpool` takes exclusive access handles, so one worker per browsing context means one
+candidate holder per tab competing for a pool only one of them can have. The implementation
+made that explicit with a Web Lock taken `ifAvailable: true`, so the second tab lost
+immediately and had no dictionary at all (#351): observed with five tabs open on a phone,
+the OPFS database fully present, suggestions returning only after the extra tabs were
+closed.
+
+Two measurements decide what replaces it.
+
+A `SharedWorker` cannot be the owner. On Chrome 144, inside a `SharedWorkerGlobalScope`,
+`FileSystemFileHandle.prototype.createSyncAccessHandle` is `undefined`, so
+`installOpfsSAHPoolVfs` fails with `Missing required OPFS APIs`; `Worker` is `undefined`
+there too, so it cannot spawn a dedicated worker to hold the pool for it. A `ServiceWorker`
+is killed and restarted at the browser's discretion and would drop the pool mid-session.
+The pool is dedicated-worker territory, one holder at a time, and the application cannot
+negotiate that.
+
+A backgrounded tab cannot be the owner either. Android freezes a backgrounded tab whole —
+worker and message delivery together — about a minute after it leaves the screen. Measured
+with two tabs and one query every 10 s while the tab holding the database sat in the
+background: 12 ms, 14, 17, 22, 31, 31, and from 60 s on nothing at all, 14 consecutive
+timeouts until it was brought back. The failure is silent: no error, no state change, the
+promise never settles. So any arrangement that leaves the database behind a background tab
+— sharing it out from there, electing a long-lived holder — builds a dictionary that stops
+answering after a minute.
+
+## Decision
+
+The dictionary belongs to the tab being typed into. A tab takes the
+`sqlite-opfs-sahpool` lock when it comes to the foreground, opens the database and serves
+only itself; when it leaves the foreground it closes the database, pauses the pool and
+releases the lock. One stretch of holding that lock, from grant to release, is a *turn*; a
+tab has no database outside its turns. A tab waiting for one holds the queries asked of it
+until it starts — mostly its own, since the tab waiting is usually the one just brought to
+the front and already being typed into.
+
+Foreground means on screen **and** holding the keyboard: `visibilityState === "visible" &&
+hasFocus()`. Visibility alone does not identify the tab being used — two tabs can be
+visible at the same time in split screen or side-by-side windows, and `hidden` is false for
+both, so the database would go to whichever took the lock first rather than to the one the
+user is working in. The page computes the answer and reports it to its worker as a single
+boolean; the worker is never told how it was reached.
+
+There is no communication between tabs at all — no shared owner, no channel, no queries
+crossing a tab boundary — which is what makes the freeze irrelevant: the tab holding the
+database is by construction one the system is not about to freeze.
+
+`visibilitychange` and `blur` fire the moment a tab stops being the one in front, and the
+freeze lands 50-60 s later, so the handover has three orders of magnitude more time than it
+needs. A tab killed
+outright never runs its handler, and the browser releases its lock instead.
+
+Between turns a tab keeps its pool installed and paused rather than tearing it down.
+Measured: taking it back costs `unpauseVfs` 3-5 ms and opening the database 1-2 ms, against
+`installOpfsSAHPoolVfs` 13-27 ms plus a manifest fetch to build it again; giving it back
+costs 1 ms.
+
+The SQLite engine is loaded on a tab's first turn rather than at app boot, so a tab that
+never comes to the front never pays for it. This is the one part of ADR-0002 that no longer
+holds — its consequence "WASM cold-start latency is off the critical path: the Worker
+initialises in the background on app boot". Everything else in ADR-0002 stands: OPFS
+`SyncAccessHandle` is Worker-only outside Chromium, so the engine still runs in a Dedicated
+Worker and never on the main thread. ADR-0002 did not decide which context owns the
+database, and nothing here overturns a decision it did not make.
+
+## Consequences
+
+- Whoever is typing has the dictionary, and it answers in single-tab time because it is a
+  single-tab arrangement.
+- Two tabs visible at once get the dictionary in whichever one has the keyboard, and it
+  moves as the user clicks between them. When the browser window itself is behind something
+  else no tab holds it — there is nobody to ask, and the first tab to come back takes it in
+  ~14 ms.
+- A tab that has not had a turn yet has no dictionary, and that is a state the UI must be
+  able to describe rather than show as an empty list (#312).
+- Turns change hands more often than they would on visibility alone: a click in the address
+  bar or in devtools is a `blur`, so it costs a round trip. ~14 ms per switch once a tab has
+  had a turn, ~94 ms for its first. Both are far below the ~100 ms suggest debounce, and the
+  work happens in a worker that is not the one the user is waiting on.
+- The file is still downloaded and imported once per origin, because the OPFS pool outlives
+  every turn.
+- Nothing coordinates between tabs, so nothing has to be designed for concurrent clients —
+  but equally, anything the dictionary gains later that must be shared cannot lean on the
+  holder, because there is no long-lived one.

--- a/openspec/changes/archive/2026-08-16-dictionary-follows-focus/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-16-dictionary-follows-focus/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-with-adr
+created: 2026-08-16

--- a/openspec/changes/archive/2026-08-16-dictionary-follows-focus/proposal.md
+++ b/openspec/changes/archive/2026-08-16-dictionary-follows-focus/proposal.md
@@ -1,0 +1,96 @@
+## Why
+
+The dictionary is reachable from one browsing context at a time (#351). Each tab spawns its
+own worker, and `sqlite3-worker.js` takes the pool Web Lock with
+`ifAvailable: true` and holds it for the worker's whole life. Exactly one tab wins; every
+other tab is answered `{type: "error", code: "another-tab-open"}`, which the client only
+logs — and release builds log nothing. `adapters.dictionary/completions` then sees
+`ready? = false` and returns `[]`, so the user gets a silently empty suggestion list.
+
+Observed on a phone with five tabs open: the OPFS database was fully present (37 MB,
+`persisted: true`), so this is neither a download nor a storage failure. Suggestions
+returned as soon as the extra tabs were closed.
+
+`opfs-sahpool` takes exclusive access handles, so one context at a time really is the
+constraint. The question is only which context, and two measurements settle it.
+
+A `SharedWorker` cannot be the one. On Chrome 144, inside a `SharedWorkerGlobalScope`,
+`FileSystemFileHandle.prototype.createSyncAccessHandle` is `undefined`, so
+`installOpfsSAHPoolVfs` fails with `Missing required OPFS APIs`; `Worker` is `undefined`
+there too, so it cannot spawn a dedicated worker to hold the pool for it.
+
+A backgrounded tab cannot be the one either. Android freezes a backgrounded tab whole — its
+worker and its message delivery together — about a minute after it leaves the screen.
+Measured with two tabs and one query every 10 s while the tab holding the database sat in
+the background: 12 ms, 14, 17, 22, 31, 31, then nothing at all from 60 s on, 14 consecutive
+timeouts until it was brought back. The failure is silent: no error, no state change, the
+promise never settles.
+
+So the database belongs to the tab being typed into — which is not the same as any tab
+that happens to be on screen. Two tabs can be visible at once, split screen or side by
+side, and `document.hidden` is false for both; the one to serve is the one with the
+keyboard. The condition is `visibilityState === "visible" && hasFocus()`.
+
+## What Changes
+
+- A tab takes the `sqlite-opfs-sahpool` lock when it comes to the foreground, opens the
+  database and serves itself. When it leaves the foreground it closes the database, pauses
+  the pool and releases the lock. The lock is requested without `ifAvailable`, so a tab that
+  does not win waits its turn instead of failing.
+- A tab waiting its turn has no dictionary of its own and holds the queries asked of it
+  until it has one. Nothing is answered from another tab and nothing crosses a tab boundary.
+- The page tells its worker what it is, as one boolean: `visibilitychange`, `focus` and
+  `blur` are forwarded, and the current
+  state is sent once at startup so a tab that boots in the background never takes a database
+  it would be frozen holding.
+- Between turns a tab keeps its pool installed and paused. Measured: `unpauseVfs` 3-5 ms and
+  open 1-2 ms, against `installOpfsSAHPoolVfs` 13-27 ms plus a manifest fetch. Giving it back
+  costs 1 ms, and a whole focus switch ~14 ms.
+- The engine is loaded on a tab's first turn rather than at startup, so a tab that never
+  comes to the front never pays for it.
+- The readiness gate in front of the query goes, and `:dictionary/ready?` goes with it. A
+  caller has nothing to decide with it now that an early query is held rather than dropped,
+  and the accessor chain behind it — `adapters.dictionary/ready?`, `db.sqlite/ready?`, the
+  `:ready?` flag the lifecycle messages wrote, the `:state` entry the component exposed only
+  so that flag could be read — has no other reader.
+- Removed with it: the `another-tab-open` error and its user-facing message. There is no
+  losing tab left to describe.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `sqlite-dictionary-worker`: which browsing context holds the database, and what a context
+  without it does with a query.
+- `dictionary-storage`: the browser-side requirement naming what opens the OPFS file, and
+  what autocomplete does before it is open.
+- `client-runtime-dependencies`: the dictionary handle is callable at any point and the port
+  exposes no readiness predicate.
+
+### New Capabilities
+
+None.
+
+## Impact
+
+- `resources/public/js/sqlite3-dictionary.js` (new) — the lock, the pool, the turn, and the
+  queue of requests made between turns.
+- `resources/public/js/sqlite3-worker.js` — reduced to the page-facing host, carrying the
+  visibility message through.
+- `resources/public/js/sw.js` — the new file joins `PRECACHE_URLS`.
+- `src/client/db/sqlite.cljs` — forwards `visibilitychange` and the startup state; `attach`
+  split out of `init!` so the protocol can be driven where there is no `Worker`.
+- `src/client/adapters/dictionary.cljs`, `src/client/ports/dictionary.cljs`,
+  `src/client/pages/home/effects.cljs` — the readiness gate and the accessor behind it.
+- `test/client/db/sqlite_test.cljs` (new) and `test/client/pages/home_test.cljs` — the page
+  protocol under Node, where there is no worker to spawn.
+- `test/browser/dictionary-focus.spec.js` (new) — six scenarios for the rule.
+- ADR-0012, `src/client/README.md`, `test/browser/README.md`.
+
+Telemetry (`instrumentation/dictionary-*`, `?telemetry=1`) keeps working: `ready-ms` and the
+phase list are unaffected, and per-turn phases (`pause`, `unpause`) report alongside them.
+
+Two tabs visible at once still get one dictionary between them, but it is the one with the
+keyboard, and it follows the user as they click from pane to pane. When the browser window
+itself is behind something else, no tab holds the database: there is nobody to ask, and the
+first tab to come back takes it in ~14 ms.

--- a/openspec/changes/archive/2026-08-16-dictionary-follows-focus/proposal.md
+++ b/openspec/changes/archive/2026-08-16-dictionary-follows-focus/proposal.md
@@ -37,8 +37,9 @@ keyboard. The condition is `visibilityState === "visible" && hasFocus()`.
   database and serves itself. When it leaves the foreground it closes the database, pauses
   the pool and releases the lock. The lock is requested without `ifAvailable`, so a tab that
   does not win waits its turn instead of failing.
-- A tab waiting its turn has no dictionary of its own and holds the queries asked of it
-  until it has one. Nothing is answered from another tab and nothing crosses a tab boundary.
+- A tab waiting its turn has no dictionary of its own and answers the queries asked of it
+  with no completions, keeping nothing for later. Nothing is answered from another tab and
+  nothing crosses a tab boundary.
 - The page tells its worker what it is, as one boolean: `visibilitychange`, `focus` and
   `blur` are forwarded, and the current
   state is sent once at startup so a tab that boots in the background never takes a database
@@ -48,11 +49,10 @@ keyboard. The condition is `visibilityState === "visible" && hasFocus()`.
   costs 1 ms, and a whole focus switch ~14 ms.
 - The engine is loaded on a tab's first turn rather than at startup, so a tab that never
   comes to the front never pays for it.
-- The readiness gate in front of the query goes, and `:dictionary/ready?` goes with it. A
-  caller has nothing to decide with it now that an early query is held rather than dropped,
-  and the accessor chain behind it — `adapters.dictionary/ready?`, `db.sqlite/ready?`, the
-  `:ready?` flag the lifecycle messages wrote, the `:state` entry the component exposed only
-  so that flag could be read — has no other reader.
+- The readiness gate in front of the query goes: the worker answers empty by itself, so a
+  gate would re-decide one hop away what has already been decided. `:dictionary/ready?`
+  stays on the port as a reading — an empty answer alone cannot say whether the prefix has
+  no completions or this tab has no dictionary, and that is what #312 has to describe.
 - Removed with it: the `another-tab-open` error and its user-facing message. There is no
   losing tab left to describe.
 
@@ -73,8 +73,8 @@ None.
 
 ## Impact
 
-- `resources/public/js/sqlite3-dictionary.js` (new) — the lock, the pool, the turn, and the
-  queue of requests made between turns.
+- `resources/public/js/sqlite3-dictionary.js` (new) — the lock, the pool, the turn, and
+  what a request is answered with inside one and outside one.
 - `resources/public/js/sqlite3-worker.js` — reduced to the page-facing host, carrying the
   visibility message through.
 - `resources/public/js/sw.js` — the new file joins `PRECACHE_URLS`.

--- a/openspec/changes/archive/2026-08-16-dictionary-follows-focus/specs/client-runtime-dependencies/spec.md
+++ b/openspec/changes/archive/2026-08-16-dictionary-follows-focus/specs/client-runtime-dependencies/spec.md
@@ -2,17 +2,21 @@
 
 ### Requirement: Dictionary handle is ready before dictionary data
 The dictionary port MUST expose a stable handle before the dictionary data is fully ready,
-and that handle MUST be callable at any point after it exists. The port SHALL NOT expose a
-readiness predicate: a caller has nothing to decide with it, because a completion request
-made before the data is there is held by the dictionary worker and answered when it is.
+and that handle MUST be callable at any point after it exists. A completion request made
+before the data is there resolves with no completions, so no caller SHALL gate the request
+on readiness. The port SHALL expose `:dictionary/ready?` as a reading rather than a gate,
+because an empty answer alone cannot say whether the prefix has no completions or this
+context has no dictionary.
 
 #### Scenario: Autocomplete before dictionary data is ready
 - **WHEN** the router has started and the dictionary worker is still fetching, importing, or opening dictionary data
 - **THEN** the dictionary capability exists in capabilities
 - **AND** `:dictionary/completions` accepts the call rather than refusing it
-- **AND** the answer arrives once the data is there, or the call rejects if it never will be
+- **AND** it resolves with no completions, or rejects if this context failed to open the dictionary
+- **AND** `:dictionary/ready?` reports false meanwhile
 - **AND** page startup is not blocked by dictionary data readiness
 
 #### Scenario: Autocomplete after dictionary data is ready
 - **WHEN** the dictionary worker has opened the current SQLite dictionary
 - **THEN** `:dictionary/completions` queries the dictionary worker normally
+- **AND** `:dictionary/ready?` reports true

--- a/openspec/changes/archive/2026-08-16-dictionary-follows-focus/specs/client-runtime-dependencies/spec.md
+++ b/openspec/changes/archive/2026-08-16-dictionary-follows-focus/specs/client-runtime-dependencies/spec.md
@@ -1,0 +1,18 @@
+## MODIFIED Requirements
+
+### Requirement: Dictionary handle is ready before dictionary data
+The dictionary port MUST expose a stable handle before the dictionary data is fully ready,
+and that handle MUST be callable at any point after it exists. The port SHALL NOT expose a
+readiness predicate: a caller has nothing to decide with it, because a completion request
+made before the data is there is held by the dictionary worker and answered when it is.
+
+#### Scenario: Autocomplete before dictionary data is ready
+- **WHEN** the router has started and the dictionary worker is still fetching, importing, or opening dictionary data
+- **THEN** the dictionary capability exists in capabilities
+- **AND** `:dictionary/completions` accepts the call rather than refusing it
+- **AND** the answer arrives once the data is there, or the call rejects if it never will be
+- **AND** page startup is not blocked by dictionary data readiness
+
+#### Scenario: Autocomplete after dictionary data is ready
+- **WHEN** the dictionary worker has opened the current SQLite dictionary
+- **THEN** `:dictionary/completions` queries the dictionary worker normally

--- a/openspec/changes/archive/2026-08-16-dictionary-follows-focus/specs/dictionary-storage/spec.md
+++ b/openspec/changes/archive/2026-08-16-dictionary-follows-focus/specs/dictionary-storage/spec.md
@@ -38,8 +38,8 @@ The active home autocomplete flow SHALL query SQLite through the worker proxy an
 call the legacy PouchDB dictionary lookup path. Completion results SHALL include each
 suggestion's part of speech.
 
-A completion request issued while this context has no database SHALL be answered when it
-gets one, rather than resolving empty. The main thread SHALL NOT gate the request on
+A completion request issued while this context has no database SHALL resolve empty at once
+rather than being queued for a later turn. The main thread SHALL NOT gate the request on
 readiness.
 
 #### Scenario: Completion query resolves via the worker
@@ -51,5 +51,5 @@ readiness.
 #### Scenario: Query issued while this context is waiting its turn
 - **WHEN** the home suggest effect receives a non-empty German prefix and this context does not hold the database
 - **THEN** no PouchDB fallback query is attempted
-- **AND** the request waits in the worker and is answered when this context takes its turn
+- **AND** the worker resolves the request with no completions instead of holding it
 - **AND** the home page shows the answer only if the input still matches the queried value

--- a/openspec/changes/archive/2026-08-16-dictionary-follows-focus/specs/dictionary-storage/spec.md
+++ b/openspec/changes/archive/2026-08-16-dictionary-follows-focus/specs/dictionary-storage/spec.md
@@ -1,0 +1,55 @@
+## MODIFIED Requirements
+
+### Requirement: Dictionary worker opens SQLite via OPFS
+The browser SHALL include a Dedicated Worker that downloads the content-addressed SQLite
+file, imports it into `opfs-sahpool`, and opens it with official SQLite WASM for query
+execution. At most one browsing context SHALL have it open at a time, and that context
+SHALL be the one in the foreground — on screen and holding the keyboard: a context takes
+the `sqlite-opfs-sahpool` Web Lock when it comes to the foreground and releases it when it
+leaves.
+
+The download and the import SHALL happen once for the origin rather than once per context
+or once per turn, because the OPFS pool outlives every turn.
+
+#### Scenario: Worker initialises on first boot
+- **WHEN** a foreground context takes its turn and no OPFS pool file exists for the current hash
+- **THEN** it downloads `dict.{hash12}.sqlite` from the server
+- **AND** imports it into `opfs-sahpool`
+- **AND** opens the database with `sqlite3.oo1.DB`
+- **AND** posts a `{type: "ready"}` message to its page
+
+#### Scenario: Worker uses cached file on subsequent boots
+- **WHEN** a foreground context takes its turn and the current hash file already exists in the OPFS pool
+- **THEN** it opens the existing file without re-downloading
+- **AND** posts a `{type: "ready"}` message to its page
+
+#### Scenario: A second context takes over without re-importing
+- **WHEN** the context holding the database leaves the foreground and another context takes its turn
+- **THEN** no download or import happens
+- **AND** the second context opens the same OPFS file
+
+#### Scenario: Worker removes stale dictionary files
+- **WHEN** a context has opened the current hash file
+- **THEN** it removes older `dict.*.sqlite` files from the OPFS pool
+- **AND** reduces pool capacity so the pool does not grow unbounded
+
+### Requirement: Main-thread autocomplete routes lookups through the worker
+The active home autocomplete flow SHALL query SQLite through the worker proxy and SHALL NOT
+call the legacy PouchDB dictionary lookup path. Completion results SHALL include each
+suggestion's part of speech.
+
+A completion request issued while this context has no database SHALL be answered when it
+gets one, rather than resolving empty. The main thread SHALL NOT gate the request on
+readiness.
+
+#### Scenario: Completion query resolves via the worker
+- **WHEN** the home suggest effect receives a non-empty German prefix and this context holds the database
+- **THEN** it calls the dictionary port completions function
+- **AND** SQL is executed through the SQLite worker proxy
+- **AND** the result contains ranked completion maps with lemma text, translations, exact-match flag, and part of speech
+
+#### Scenario: Query issued while this context is waiting its turn
+- **WHEN** the home suggest effect receives a non-empty German prefix and this context does not hold the database
+- **THEN** no PouchDB fallback query is attempted
+- **AND** the request waits in the worker and is answered when this context takes its turn
+- **AND** the home page shows the answer only if the input still matches the queried value

--- a/openspec/changes/archive/2026-08-16-dictionary-follows-focus/specs/sqlite-dictionary-worker/spec.md
+++ b/openspec/changes/archive/2026-08-16-dictionary-follows-focus/specs/sqlite-dictionary-worker/spec.md
@@ -38,7 +38,7 @@ it, and SHALL load the SQLite engine on its first turn rather than at startup.
 - **WHEN** a context is visible but is not the one in the foreground, or another context holds the lock
 - **THEN** it waits its turn
 - **AND** it does not open, download or import anything
-- **AND** it shows no completions until its turn comes
+- **AND** it answers the queries asked of it with no completions
 
 #### Scenario: Context killed without warning
 - **WHEN** the context holding the database is closed rather than backgrounded
@@ -60,9 +60,12 @@ it, and SHALL load the SQLite engine on its first turn rather than at startup.
 The system SHALL provide a worker proxy on the main thread that sends SQL exec messages to
 its own worker and returns Promises resolved by matching request id.
 
-A worker SHALL hold a request made while it has no database and SHALL settle it when its
-turn comes. A request SHALL NOT be discarded for arriving early, and the main thread SHALL
-NOT gate a request on readiness.
+A worker SHALL answer every request from what its context has at that moment, and SHALL
+NOT queue one for later. A request made while it has no database SHALL be answered with an
+empty result, in the shape a real empty answer has; a request made after the context failed
+to open the database SHALL be rejected with that failure, so a broken dictionary stays
+distinguishable from a prefix with no completions. The main thread SHALL NOT gate a request
+on readiness.
 
 #### Scenario: Exec call over RPC
 - **WHEN** the dictionary repo needs completions for a prefix
@@ -71,9 +74,9 @@ NOT gate a request on readiness.
 
 #### Scenario: Query asked while waiting for a turn
 - **WHEN** a completion request is made in a context that does not hold the database
-- **THEN** the worker holds it
-- **AND** answers it when that context takes its turn, with no further prompting from the page
-- **AND** the home page discards the answer if the input has changed since
+- **THEN** the worker answers it at once with an empty result
+- **AND** it does not keep the request, so the answer is not repeated when the turn comes
+- **AND** the next keystroke is what asks again
 
 #### Scenario: Query when the database cannot be opened
 - **WHEN** a completion request is issued and this context failed to open the database

--- a/openspec/changes/archive/2026-08-16-dictionary-follows-focus/specs/sqlite-dictionary-worker/spec.md
+++ b/openspec/changes/archive/2026-08-16-dictionary-follows-focus/specs/sqlite-dictionary-worker/spec.md
@@ -1,8 +1,5 @@
-# sqlite-dictionary-worker Specification
+## MODIFIED Requirements
 
-## Purpose
-TBD - created by archiving change replicant-nexus-migration. Update Purpose after archive.
-## Requirements
 ### Requirement: Dictionary SQLite runs in a Dedicated Worker
 The system SHALL run the SQLite dictionary (`opfs-sahpool` VFS) inside a Dedicated Worker;
 the main thread SHALL NOT access SQLite synchronously. Every browsing context SHALL have a
@@ -82,29 +79,3 @@ NOT gate a request on readiness.
 - **WHEN** a completion request is issued and this context failed to open the database
 - **THEN** the request is rejected with that failure rather than left pending
 - **AND** the suggest effect logs it and shows no suggestions
-
-### Requirement: Worker completion result supports home autocomplete
-The system SHALL return completion rows that the home add-word form can render and use to prefill translation.
-
-#### Scenario: Non-empty completion result
-- **WHEN** the input matches entries in the SQLite dictionary
-- **THEN** the resolved value is a sequence of completion maps
-- **AND** each result map contains lemma text, translations, and exact-match flag
-
-#### Scenario: No-match completion result
-- **WHEN** the input matches no entries
-- **THEN** the resolved value is empty
-
-### Requirement: Completion query cost scales with the answer, not the prefix range
-The completions SQL SHALL select the ten winning lemmas before joining translations or computing the exact-match flag, so that per-row aggregation work is bounded by the result limit rather than by the number of surface forms matching the prefix.
-
-#### Scenario: Short prefix costs the same order as a long one
-- **WHEN** completions run for a one-letter prefix matching tens of thousands of surface forms
-- **THEN** translations are aggregated only for the ten returned lemmas
-- **AND** the query does not build grouping or concatenation structures over the full prefix range
-
-#### Scenario: Rewritten query returns identical rows
-- **WHEN** the rewritten query runs for any prefix
-- **THEN** its rows, columns, ordering, and limit match the previous grouping query exactly
-- **AND** `has_exact` still reflects whether the lemma has a surface form equal to the normalized input
-

--- a/openspec/changes/archive/2026-08-16-dictionary-follows-focus/tasks.md
+++ b/openspec/changes/archive/2026-08-16-dictionary-follows-focus/tasks.md
@@ -1,0 +1,38 @@
+## 1. Find out which context can hold the pool
+
+- [x] 1.1 Probe `createSyncAccessHandle`, `Worker`, `getDirectory` and `navigator.locks` inside a `SharedWorkerGlobalScope`, and record the result in the proposal and ADR-0012.
+- [x] 1.2 Measure what a backgrounded holder does over time on a real Android device, and record the numbers.
+
+## 2. Ownership follows visibility
+
+- [x] 2.1 Move the pool, the manifest, the import and `db.exec` out of `resources/public/js/sqlite3-worker.js` into a new `resources/public/js/sqlite3-dictionary.js`.
+- [x] 2.2 Take `sqlite-opfs-sahpool` — without `ifAvailable` — when the page reports itself in the foreground, and give it back when it reports itself out of it.
+- [x] 2.3 Forward `visibilitychange` from `src/client/db/sqlite.cljs`, and send the current state once at startup so a tab that boots in the background takes nothing.
+- [x] 2.4 Hold queries made while this tab has no database; settle them when its turn comes.
+- [x] 2.5 Keep the pool installed and paused between turns; load the engine on the first turn rather than at startup.
+- [x] 2.6 Add `/js/sqlite3-dictionary.js` to `PRECACHE_URLS` in `resources/public/js/sw.js`.
+
+## 3. The awkward moments
+
+- [x] 3.1 Hidden while the database is still opening: close it and give the lock straight back.
+- [x] 3.2 Visible again while the previous turn is still being wound up: request another turn once the wind-up finishes.
+- [x] 3.3 Failed to open: pause the pool before releasing the lock, so no other tab is blocked by this one.
+- [x] 3.4 Hidden while queued but not yet granted: take nothing when the turn arrives.
+
+## 4. No readiness gate, and no readiness accessor
+
+- [x] 4.1 Drop the gate from `adapters.dictionary/completions` and from the suggest effect in `pages/home/effects.cljs`.
+- [x] 4.2 Drop `:dictionary/ready?` from the port, and with it `adapters.dictionary/ready?`, `db.sqlite/ready?`, the `:ready?` flag and the `:state` entry that existed only to be read through them.
+- [x] 4.3 Split `db.sqlite/attach` out of `init!` so the page protocol can be driven where there is no `Worker`.
+
+## 5. Verification
+
+- [x] 5.1 Measure both handover paths — pool kept and paused, versus installed again — and choose on the numbers.
+- [x] 5.2 Node unit tests for the page protocol: id matching, lifecycle messages leaving the response matcher alone, exec resolution and rejection, and a query issued with no readiness message received.
+- [x] 5.3 Browser spec: visible tab has it, waiting tab does not, a query asked while waiting is answered when the turn comes, the tab that goes away gives it back, rapid switching leaves the visible tab working, all tabs away then one returns, closing the holder releases it.
+- [x] 5.4 Node test build and the full browser suite against a local stand with the fixture dictionary.
+
+## 6. Documentation
+
+- [x] 6.1 ADR-0012, superseding ADR-0002.
+- [x] 6.2 `src/client/README.md` and `test/browser/README.md`, including what the visibility shim in the spec does and does not prove.

--- a/openspec/changes/archive/2026-08-16-dictionary-follows-focus/tasks.md
+++ b/openspec/changes/archive/2026-08-16-dictionary-follows-focus/tasks.md
@@ -22,14 +22,14 @@
 ## 4. No readiness gate, and no readiness accessor
 
 - [x] 4.1 Drop the gate from `adapters.dictionary/completions` and from the suggest effect in `pages/home/effects.cljs`.
-- [x] 4.2 Drop `:dictionary/ready?` from the port, and with it `adapters.dictionary/ready?`, `db.sqlite/ready?`, the `:ready?` flag and the `:state` entry that existed only to be read through them.
+- [x] 4.2 Keep `:dictionary/ready?` on the port as a reading rather than a gate: it is the only thing that separates an empty answer from a missing dictionary (#312).
 - [x] 4.3 Split `db.sqlite/attach` out of `init!` so the page protocol can be driven where there is no `Worker`.
 
 ## 5. Verification
 
 - [x] 5.1 Measure both handover paths — pool kept and paused, versus installed again — and choose on the numbers.
 - [x] 5.2 Node unit tests for the page protocol: id matching, lifecycle messages leaving the response matcher alone, exec resolution and rejection, and a query issued with no readiness message received.
-- [x] 5.3 Browser spec: visible tab has it, waiting tab does not, a query asked while waiting is answered when the turn comes, the tab that goes away gives it back, rapid switching leaves the visible tab working, all tabs away then one returns, closing the holder releases it.
+- [x] 5.3 Browser spec: visible tab has it, waiting tab does not, a query asked while waiting comes back empty and is not replayed, the tab that goes away gives it back, rapid switching leaves the visible tab working, all tabs away then one returns, closing the holder releases it.
 - [x] 5.4 Node test build and the full browser suite against a local stand with the fixture dictionary.
 
 ## 6. Documentation

--- a/openspec/specs/client-runtime-dependencies/spec.md
+++ b/openspec/specs/client-runtime-dependencies/spec.md
@@ -74,20 +74,24 @@ The client runtime MUST start dependencies in declared order and stop them in re
 
 ### Requirement: Dictionary handle is ready before dictionary data
 The dictionary port MUST expose a stable handle before the dictionary data is fully ready,
-and that handle MUST be callable at any point after it exists. The port SHALL NOT expose a
-readiness predicate: a caller has nothing to decide with it, because a completion request
-made before the data is there is held by the dictionary worker and answered when it is.
+and that handle MUST be callable at any point after it exists. A completion request made
+before the data is there resolves with no completions, so no caller SHALL gate the request
+on readiness. The port SHALL expose `:dictionary/ready?` as a reading rather than a gate,
+because an empty answer alone cannot say whether the prefix has no completions or this
+context has no dictionary.
 
 #### Scenario: Autocomplete before dictionary data is ready
 - **WHEN** the router has started and the dictionary worker is still fetching, importing, or opening dictionary data
 - **THEN** the dictionary capability exists in capabilities
 - **AND** `:dictionary/completions` accepts the call rather than refusing it
-- **AND** the answer arrives once the data is there, or the call rejects if it never will be
+- **AND** it resolves with no completions, or rejects if this context failed to open the dictionary
+- **AND** `:dictionary/ready?` reports false meanwhile
 - **AND** page startup is not blocked by dictionary data readiness
 
 #### Scenario: Autocomplete after dictionary data is ready
 - **WHEN** the dictionary worker has opened the current SQLite dictionary
 - **THEN** `:dictionary/completions` queries the dictionary worker normally
+- **AND** `:dictionary/ready?` reports true
 
 ### Requirement: Public dependencies are small capabilities
 The capabilities map MUST expose small app capabilities instead of implementation-specific globals.

--- a/openspec/specs/client-runtime-dependencies/spec.md
+++ b/openspec/specs/client-runtime-dependencies/spec.md
@@ -73,19 +73,21 @@ The client runtime MUST start dependencies in declared order and stop them in re
 - **AND** cleanup is best-effort so one cleanup failure does not prevent later cleanup attempts
 
 ### Requirement: Dictionary handle is ready before dictionary data
-The dictionary port MUST expose a stable handle before the dictionary data is fully ready.
+The dictionary port MUST expose a stable handle before the dictionary data is fully ready,
+and that handle MUST be callable at any point after it exists. The port SHALL NOT expose a
+readiness predicate: a caller has nothing to decide with it, because a completion request
+made before the data is there is held by the dictionary worker and answered when it is.
 
 #### Scenario: Autocomplete before dictionary data is ready
 - **WHEN** the router has started and the dictionary worker is still fetching, importing, or opening dictionary data
 - **THEN** the dictionary capability exists in capabilities
-- **AND** `:dictionary/ready?` reports false
-- **AND** `:dictionary/completions` returns an empty result or otherwise no-ops safely
+- **AND** `:dictionary/completions` accepts the call rather than refusing it
+- **AND** the answer arrives once the data is there, or the call rejects if it never will be
 - **AND** page startup is not blocked by dictionary data readiness
 
 #### Scenario: Autocomplete after dictionary data is ready
 - **WHEN** the dictionary worker has opened the current SQLite dictionary
-- **THEN** `:dictionary/ready?` reports true
-- **AND** `:dictionary/completions` queries the dictionary worker normally
+- **THEN** `:dictionary/completions` queries the dictionary worker normally
 
 ### Requirement: Public dependencies are small capabilities
 The capabilities map MUST expose small app capabilities instead of implementation-specific globals.

--- a/openspec/specs/dictionary-storage/spec.md
+++ b/openspec/specs/dictionary-storage/spec.md
@@ -78,38 +78,58 @@ The server SHALL expose a manifest endpoint and a content-addressed SQLite artif
 - **THEN** the server responds with HTTP 404
 
 ### Requirement: Dictionary worker opens SQLite via OPFS
-The browser SHALL include a Dedicated Worker that downloads the content-addressed SQLite file, imports it into `opfs-sahpool`, and opens it with official SQLite WASM for query execution.
+The browser SHALL include a Dedicated Worker that downloads the content-addressed SQLite
+file, imports it into `opfs-sahpool`, and opens it with official SQLite WASM for query
+execution. At most one browsing context SHALL have it open at a time, and that context
+SHALL be the one in the foreground — on screen and holding the keyboard: a context takes
+the `sqlite-opfs-sahpool` Web Lock when it comes to the foreground and releases it when it
+leaves.
+
+The download and the import SHALL happen once for the origin rather than once per context
+or once per turn, because the OPFS pool outlives every turn.
 
 #### Scenario: Worker initialises on first boot
-- **WHEN** the Worker starts and no OPFS pool file exists for the current hash
-- **THEN** the Worker downloads `dict.{hash12}.sqlite` from the server
+- **WHEN** a foreground context takes its turn and no OPFS pool file exists for the current hash
+- **THEN** it downloads `dict.{hash12}.sqlite` from the server
 - **AND** imports it into `opfs-sahpool`
 - **AND** opens the database with `sqlite3.oo1.DB`
-- **AND** posts a `{type: "ready"}` message to the main thread
+- **AND** posts a `{type: "ready"}` message to its page
 
 #### Scenario: Worker uses cached file on subsequent boots
-- **WHEN** the Worker starts and the current hash file already exists in the OPFS pool
-- **THEN** the Worker opens the existing file without re-downloading
-- **AND** posts a `{type: "ready"}` message to the main thread
+- **WHEN** a foreground context takes its turn and the current hash file already exists in the OPFS pool
+- **THEN** it opens the existing file without re-downloading
+- **AND** posts a `{type: "ready"}` message to its page
+
+#### Scenario: A second context takes over without re-importing
+- **WHEN** the context holding the database leaves the foreground and another context takes its turn
+- **THEN** no download or import happens
+- **AND** the second context opens the same OPFS file
 
 #### Scenario: Worker removes stale dictionary files
-- **WHEN** the Worker has opened the current hash file
+- **WHEN** a context has opened the current hash file
 - **THEN** it removes older `dict.*.sqlite` files from the OPFS pool
 - **AND** reduces pool capacity so the pool does not grow unbounded
 
 ### Requirement: Main-thread autocomplete routes lookups through the worker
-The active home autocomplete flow SHALL query SQLite through the worker proxy and SHALL NOT call the legacy PouchDB dictionary lookup path. Completion results SHALL include each suggestion's part of speech.
+The active home autocomplete flow SHALL query SQLite through the worker proxy and SHALL NOT
+call the legacy PouchDB dictionary lookup path. Completion results SHALL include each
+suggestion's part of speech.
 
-#### Scenario: Completion query resolves via Worker
-- **WHEN** the home suggest effect receives a non-empty German prefix and the dictionary worker is ready
+A completion request issued while this context has no database SHALL be answered when it
+gets one, rather than resolving empty. The main thread SHALL NOT gate the request on
+readiness.
+
+#### Scenario: Completion query resolves via the worker
+- **WHEN** the home suggest effect receives a non-empty German prefix and this context holds the database
 - **THEN** it calls the dictionary port completions function
 - **AND** SQL is executed through the SQLite worker proxy
 - **AND** the result contains ranked completion maps with lemma text, translations, exact-match flag, and part of speech
 
-#### Scenario: Worker not ready returns no completions
-- **WHEN** the home suggest effect runs before the dictionary worker is ready
+#### Scenario: Query issued while this context is waiting its turn
+- **WHEN** the home suggest effect receives a non-empty German prefix and this context does not hold the database
 - **THEN** no PouchDB fallback query is attempted
-- **AND** no completions are shown
+- **AND** the request waits in the worker and is answered when this context takes its turn
+- **AND** the home page shows the answer only if the input still matches the queried value
 
 ### Requirement: PouchDB progress storage is retained while dictionary lookup is isolated
 The system SHALL keep PouchDB user/device databases in place for user progress. The active dictionary autocomplete flow SHALL NOT replicate dictionary documents through the old `dictionary-sync` flow. Legacy PouchDB dictionary lookup code MAY remain temporarily isolated, but it SHALL NOT be on the active autocomplete path.
@@ -161,3 +181,4 @@ The dictionary materializer SHALL exclude Kaikki form entries whose tags identif
 - **WHEN** a noun lemma has form entries with inflectional tags (e.g. "Hundes" tagged `genitive`, `singular`)
 - **THEN** those forms are indexed in `surface_forms` normally
 - **AND** searching for their prefix returns the lemma
+

--- a/openspec/specs/dictionary-storage/spec.md
+++ b/openspec/specs/dictionary-storage/spec.md
@@ -115,8 +115,8 @@ The active home autocomplete flow SHALL query SQLite through the worker proxy an
 call the legacy PouchDB dictionary lookup path. Completion results SHALL include each
 suggestion's part of speech.
 
-A completion request issued while this context has no database SHALL be answered when it
-gets one, rather than resolving empty. The main thread SHALL NOT gate the request on
+A completion request issued while this context has no database SHALL resolve empty at once
+rather than being queued for a later turn. The main thread SHALL NOT gate the request on
 readiness.
 
 #### Scenario: Completion query resolves via the worker
@@ -128,7 +128,7 @@ readiness.
 #### Scenario: Query issued while this context is waiting its turn
 - **WHEN** the home suggest effect receives a non-empty German prefix and this context does not hold the database
 - **THEN** no PouchDB fallback query is attempted
-- **AND** the request waits in the worker and is answered when this context takes its turn
+- **AND** the worker resolves the request with no completions instead of holding it
 - **AND** the home page shows the answer only if the input still matches the queried value
 
 ### Requirement: PouchDB progress storage is retained while dictionary lookup is isolated

--- a/openspec/specs/sqlite-dictionary-worker/spec.md
+++ b/openspec/specs/sqlite-dictionary-worker/spec.md
@@ -41,7 +41,7 @@ it, and SHALL load the SQLite engine on its first turn rather than at startup.
 - **WHEN** a context is visible but is not the one in the foreground, or another context holds the lock
 - **THEN** it waits its turn
 - **AND** it does not open, download or import anything
-- **AND** it shows no completions until its turn comes
+- **AND** it answers the queries asked of it with no completions
 
 #### Scenario: Context killed without warning
 - **WHEN** the context holding the database is closed rather than backgrounded
@@ -63,9 +63,12 @@ it, and SHALL load the SQLite engine on its first turn rather than at startup.
 The system SHALL provide a worker proxy on the main thread that sends SQL exec messages to
 its own worker and returns Promises resolved by matching request id.
 
-A worker SHALL hold a request made while it has no database and SHALL settle it when its
-turn comes. A request SHALL NOT be discarded for arriving early, and the main thread SHALL
-NOT gate a request on readiness.
+A worker SHALL answer every request from what its context has at that moment, and SHALL
+NOT queue one for later. A request made while it has no database SHALL be answered with an
+empty result, in the shape a real empty answer has; a request made after the context failed
+to open the database SHALL be rejected with that failure, so a broken dictionary stays
+distinguishable from a prefix with no completions. The main thread SHALL NOT gate a request
+on readiness.
 
 #### Scenario: Exec call over RPC
 - **WHEN** the dictionary repo needs completions for a prefix
@@ -74,9 +77,9 @@ NOT gate a request on readiness.
 
 #### Scenario: Query asked while waiting for a turn
 - **WHEN** a completion request is made in a context that does not hold the database
-- **THEN** the worker holds it
-- **AND** answers it when that context takes its turn, with no further prompting from the page
-- **AND** the home page discards the answer if the input has changed since
+- **THEN** the worker answers it at once with an empty result
+- **AND** it does not keep the request, so the answer is not repeated when the turn comes
+- **AND** the next keystroke is what asks again
 
 #### Scenario: Query when the database cannot be opened
 - **WHEN** a completion request is issued and this context failed to open the database

--- a/resources/public/js/sqlite3-dictionary.js
+++ b/resources/public/js/sqlite3-dictionary.js
@@ -11,15 +11,12 @@
 // turns it has no database at all.
 //
 // Coming to the foreground and having the database are not the same instant,
-// and queries asked in the gap wait for it. A tab's first turn has to load the
-// engine and install the pool (~94 ms); a later one waits for the tab in front
-// to hand the lock back (~14 ms). The user is typing through all of it — this
-// is the tab they are looking at — so what waits is mostly the *active* tab's
-// own keystrokes, not some background tab hoarding work. A tab that has just
-// left the foreground can add a straggler or two, where a query was in flight
-// or the suggest debounce ticked over after it left. Either way the request
-// waits for the turn and is never dropped — see `request` for why that matters
-// more than it looks.
+// and a query asked in the gap is answered with what the tab has at that
+// instant: nothing. Nothing is queued and nothing is replayed — see `request`.
+// A tab's first turn has to load the engine and install the pool (~94 ms); a
+// later one waits for the tab in front to hand the lock back (~14 ms). Both
+// are shorter than the 100 ms debounce in front of the query, so a warm start
+// has almost always finished before the first query arrives.
 //
 // On screen alone is not enough. Two tabs can be visible at the same time —
 // split screen, two windows side by side — and only one of them is being
@@ -79,16 +76,9 @@ let yieldTurn = null;
 
 // Where this worker is, as the message its page is sent. `loading` covers both
 // "starting up" and "waiting for another tab to finish", because from the
-// page's side they are the same thing: no dictionary yet, ask anyway.
+// page's side they are the same thing: no dictionary here, so no completions
+// from here either.
 let lifecycle = { type: "loading" };
-
-// One promise that every request waiting for a turn awaits, and the resolve
-// that fires it. Shared on purpose: a second request arriving while the first
-// is still waiting joins the same promise instead of adding another, so
-// `announceSettled` always belongs to the `settling` currently in hand and
-// there is never a second one to overwrite it.
-let settling = null;
-let announceSettled = null;
 
 let broadcast = () => {};
 
@@ -186,7 +176,7 @@ async function close() {
 }
 
 
-function answer(msg) {
+function answer(db, msg) {
   try {
     return { id: msg.id, result: db.exec(msg) };
   } catch (err) {
@@ -195,44 +185,42 @@ function answer(msg) {
 }
 
 
-// What to say to one request, or null if this tab cannot say anything yet.
-// Only the decision — who receives it, and when, is the caller's business.
-function respond(msg) {
-  if (db) return answer(msg);
+// What to say to one request, given what this tab has. An empty result is the
+// same shape a real empty answer has — `resultRows` is an array — so the page
+// reads it as a prefix with no completions. An error is not flattened into
+// one: a dictionary this tab could not open has to stay distinguishable from
+// a word it does not contain (#312).
+function respond(db, lifecycle, msg) {
+  if (db) return answer(db, msg);
   if (lifecycle.type === "error") return { id: msg.id, error: lifecycle.message };
-  return null;
+  return { id: msg.id, result: [] };
 }
 
 
-// What everything waiting for a turn blocks on, created on first demand.
-function whenSettled() {
-  if (!settling) settling = new Promise((resolve) => { announceSettled = resolve; });
-  return settling;
+// The response to one request, decided from what this tab has at that instant.
+// Nothing is queued and nothing is replayed: without a turn the answer is an
+// empty list, and being asked again takes another keystroke.
+//
+// What that loses is bounded by the debounce in front of it. Taking the lock
+// back from the tab in front costs ~14 ms and a first turn ~94 ms, against a
+// 100 ms trailing debounce and a keystroke every 120-180 ms, so on a warm
+// start the turn has begun before the query is sent. A cold start is the one
+// window a user actually sees: the dictionary is still downloading, and every
+// keystroke until it lands gets an empty list. Holding those queries buys
+// that one case and costs a mechanism to do it; the empty answer is accepted
+// for now, and #312 is where "the dictionary is not here" stops looking like
+// "no such word".
+function request(msg) {
+  return respond(db, lifecycle, msg);
 }
 
 
-// The response to one request: given straight back if this tab has a turn,
-// otherwise awaited until it gets one and asked again. Never dropped —
-// answering early with an empty list looks exactly like a word the dictionary
-// does not have.
-async function request(msg) {
-  const now = respond(msg);
-  if (now) return now;
-  await whenSettled();
-  return respond(msg);
-}
-
-
-// Call only with a decided state — `ready` or `error`. Everything waiting
-// wakes and asks `respond` again, so a `loading` passed here would hand those
-// requests an answer that does not exist yet.
-function settle(state) {
+// Where this worker is, told to the page. It feeds the page's log and its
+// instrumentation and nothing here waits on it, so `loading` is as reportable
+// as `ready` and `error`.
+function report(state) {
   lifecycle = state;
   broadcast(state);
-  const wake = announceSettled;
-  announceSettled = null;
-  settling = null;
-  if (wake) wake();
 }
 
 
@@ -258,23 +246,22 @@ function acquire() {
       } catch (ignored) { /* nothing better to try */ }
       // Released by returning: this tab could not open the database, and the
       // next one — online where this one was not, say — deserves its turn.
-      settle({ type: "error", message: String(err) });
+      report({ type: "error", message: String(err) });
       return;
     }
     // Left the foreground while the database was opening. Nothing has been
     // promised to the page yet, so it just goes straight back.
     if (foreground) {
-      settle({ type: "ready" });
+      report({ type: "ready" });
       // Assigned with no await in between, so no report from the page can
       // slip past between the check above and this handle existing.
       await new Promise((done) => { yieldTurn = done; });
       yieldTurn = null;
     }
     await close();
-    // Back to waiting: queries asked from here on are held, not answered from
-    // a database this tab no longer has.
-    lifecycle = { type: "loading" };
-    broadcast(lifecycle);
+    // Back to waiting: queries asked from here on are answered empty, not
+    // from a database this tab no longer has.
+    report({ type: "loading" });
     // In front again already — the tab came back while this turn was being
     // wound up. The request queues behind this callback and is granted as
     // soon as it returns, so nothing is lost to the gap.

--- a/resources/public/js/sqlite3-dictionary.js
+++ b/resources/public/js/sqlite3-dictionary.js
@@ -1,0 +1,315 @@
+// The dictionary belongs to the tab being typed into.
+//
+// `opfs-sahpool` takes exclusive sync access handles over its pool files, so
+// one browsing context at a time can have the database open. Which one should
+// it be? The foreground tab: on screen and holding the keyboard. A tab takes
+// the `sqlite-opfs-sahpool` lock when it comes to the foreground and gives it
+// back when it leaves.
+//
+// A *turn* is one stretch of holding that lock, from the grant to the release.
+// Everything this file does with the database happens inside a turn; between
+// turns it has no database at all.
+//
+// Coming to the foreground and having the database are not the same instant,
+// and queries asked in the gap wait for it. A tab's first turn has to load the
+// engine and install the pool (~94 ms); a later one waits for the tab in front
+// to hand the lock back (~14 ms). The user is typing through all of it — this
+// is the tab they are looking at — so what waits is mostly the *active* tab's
+// own keystrokes, not some background tab hoarding work. A tab that has just
+// left the foreground can add a straggler or two, where a query was in flight
+// or the suggest debounce ticked over after it left. Either way the request
+// waits for the turn and is never dropped — see `request` for why that matters
+// more than it looks.
+//
+// On screen alone is not enough. Two tabs can be visible at the same time —
+// split screen, two windows side by side — and only one of them is being
+// typed into; `document.hidden` is false for both, so it would hand the
+// database to whichever tab happened to take the lock first rather than the
+// one the user is working in. Focus is what distinguishes them, so the page
+// reports `visibilityState === "visible" && hasFocus()`, and this file is
+// told the answer as one boolean without being told how it was reached.
+//
+// The visibility half is not a preference, it is what Android leaves us.
+// Measured with two tabs and one query every 10 s while the tab holding the
+// database sat in the background: 12 ms, 14, 17, 22, 31, 31 — and from 60 s
+// on, nothing at all, 14 consecutive timeouts until it was brought back to
+// the front. A backgrounded tab is frozen whole, worker and message delivery
+// together, so anything that leaves the database behind a backgrounded tab
+// has built a dictionary that stops answering after a minute.
+//
+// `visibilitychange` and `blur` both fire the moment the tab stops being the
+// one in front, and the freeze lands 50-60 s later, so the handover has three
+// orders of magnitude more time than it needs. If a tab is killed outright
+// instead, the browser releases its lock and the next tab takes over — the
+// same path as closing one.
+//
+// When no tab is in the foreground — the whole browser window is behind
+// something else — no tab holds the database. There is nobody to ask, and the
+// first tab to come back takes it in ~14 ms.
+
+const SAH_POOL_LOCK = "sqlite-opfs-sahpool";
+
+const workerParams = new URL(self.location.href).searchParams;
+const telemetry = workerParams.has("telemetry");
+
+// The engine, loaded once for the worker's life. The pool and the open
+// database come and go with the lock; this does not.
+let sqlite3 = null;
+let engine = null;
+
+// Installed on this tab's first turn and kept, paused, between turns:
+// `unpauseVfs` costs a third of a fresh install and asks the disk for nothing
+// the pool already knows.
+let pool = null;
+let poolFile = null;
+
+// Set only while this tab holds the lock. Its presence is what "this tab has
+// the dictionary" means everywhere below.
+let db = null;
+
+// What the page last said about itself: on screen and holding the keyboard.
+// Nothing is taken before it says anything, so a tab that boots in the
+// background never takes a database it would be frozen holding.
+let foreground = false;
+
+// The lock: `queued` while waiting for a turn, `yieldTurn` set while holding
+// one — calling it ends the turn, which is how the lock is given back.
+let queued = false;
+let yieldTurn = null;
+
+// Where this worker is, as the message its page is sent. `loading` covers both
+// "starting up" and "waiting for another tab to finish", because from the
+// page's side they are the same thing: no dictionary yet, ask anyway.
+let lifecycle = { type: "loading" };
+
+// One promise that every request waiting for a turn awaits, and the resolve
+// that fires it. Shared on purpose: a second request arriving while the first
+// is still waiting joins the same promise instead of adding another, so
+// `announceSettled` always belongs to the `settling` currently in hand and
+// there is never a second one to overwrite it.
+let settling = null;
+let announceSettled = null;
+
+let broadcast = () => {};
+
+
+// Every phase the page's instrumentation reports, startup and per-turn alike.
+// Nothing is accumulated here — the page keeps the list, this only reports.
+async function measure(phase, fn, extras) {
+  if (!telemetry) return fn();
+  const t0 = performance.now();
+  try {
+    const result = await fn();
+    const msg = { type: "phase", phase, status: "ok", durationMs: Math.round(performance.now() - t0) };
+    if (extras) Object.assign(msg, extras(result));
+    broadcast(msg);
+    return result;
+  } catch (err) {
+    broadcast({ type: "phase", phase, status: "error",
+                durationMs: Math.round(performance.now() - t0), reason: String(err) });
+    throw err;
+  }
+}
+
+
+// Loaded on this tab's first turn, not at startup: a tab that never comes to
+// the front never pays for the engine, and a phone with several tabs open is
+// exactly where that matters. Kept afterwards, so later turns cost only the
+// pool and the database.
+function loadEngine() {
+  if (engine) return engine;
+  engine = (async () => {
+    const dir = workerParams.get("sqlite3.dir");
+    importScripts(dir ? `${dir}/sqlite3.js` : "sqlite3.js");
+    sqlite3 = await measure("wasm-init", () => sqlite3InitModule());
+  })();
+  return engine;
+}
+
+
+async function installPool() {
+  pool = await measure("pool-install", () =>
+    sqlite3.installOpfsSAHPoolVfs({ name: "opfs-sahpool", initialCapacity: 3 }));
+
+  const manifest = await measure("manifest", () =>
+    fetch("/dictionary/manifest").then(r => r.json()));
+  const hash12 = manifest.hash.slice(0, 12);
+  poolFile = `/dict.${hash12}.sqlite`;
+
+  // Unlink stale versions first so their handles become available for import.
+  for (const name of pool.getFileNames()) {
+    if (name !== poolFile && name.startsWith("/dict.") && name.endsWith(".sqlite"))
+      pool.unlink(name);
+  }
+
+  if (!pool.getFileNames().includes(poolFile)) {
+    const buffer = await measure("download",
+      () => fetch(`/dictionary/${manifest.filename}`).then(r => r.arrayBuffer()),
+      ab => ({ bytes: ab.byteLength }));
+    await measure("import", () => pool.importDb(poolFile, new Uint8Array(buffer)));
+  } else if (telemetry) {
+    broadcast({ type: "phase", phase: "cache-hit", status: "ok", durationMs: 0, hash12 });
+  }
+
+  await measure("cleanup", () => pool.reduceCapacity(1));
+}
+
+
+async function open() {
+  await loadEngine();
+  if (pool) await measure("unpause", () => pool.unpauseVfs());
+  else await measure("init", installPool);
+  db = await measure("db-open", () =>
+    new sqlite3.oo1.DB({ filename: poolFile, vfs: "opfs-sahpool" }));
+}
+
+
+// Hands the file handles back so the next tab can take them. `pauseVfs` throws
+// while any connection is open, so the close is not optional.
+//
+// `db` is dropped before anything that can throw, and the throw is swallowed,
+// because `db` is what tells the rest of this file that the lock is ours. If
+// `close()` rejected, the lock callback would reject with it: the lock would
+// go to the next tab while `request()` kept calling `exec` on a pool this tab
+// no longer owns. Recovery is the next turn, not a retry — `unpauseVfs` on a
+// pool that was never paused is a no-op — and under telemetry `measure` has
+// already reported the failed `pause`, so nothing is lost by not rethrowing.
+async function close() {
+  const closing = db;
+  db = null;
+  try {
+    await measure("pause", () => {
+      closing.close();
+      pool.pauseVfs();
+    });
+  } catch (ignored) { /* the turn ends either way */ }
+}
+
+
+function answer(msg) {
+  try {
+    return { id: msg.id, result: db.exec(msg) };
+  } catch (err) {
+    return { id: msg.id, error: String(err) };
+  }
+}
+
+
+// What to say to one request, or null if this tab cannot say anything yet.
+// Only the decision — who receives it, and when, is the caller's business.
+function respond(msg) {
+  if (db) return answer(msg);
+  if (lifecycle.type === "error") return { id: msg.id, error: lifecycle.message };
+  return null;
+}
+
+
+// What everything waiting for a turn blocks on, created on first demand.
+function whenSettled() {
+  if (!settling) settling = new Promise((resolve) => { announceSettled = resolve; });
+  return settling;
+}
+
+
+// The response to one request: given straight back if this tab has a turn,
+// otherwise awaited until it gets one and asked again. Never dropped —
+// answering early with an empty list looks exactly like a word the dictionary
+// does not have.
+async function request(msg) {
+  const now = respond(msg);
+  if (now) return now;
+  await whenSettled();
+  return respond(msg);
+}
+
+
+// Call only with a decided state — `ready` or `error`. Everything waiting
+// wakes and asks `respond` again, so a `loading` passed here would hand those
+// requests an answer that does not exist yet.
+function settle(state) {
+  lifecycle = state;
+  broadcast(state);
+  const wake = announceSettled;
+  announceSettled = null;
+  settling = null;
+  if (wake) wake();
+}
+
+
+function acquire() {
+  if (db || queued || yieldTurn) return;
+  queued = true;
+  navigator.locks.request(SAH_POOL_LOCK, async () => {
+    queued = false;
+    // Left the foreground while waiting its turn. Returning frees the lock
+    // for the next tab at once; nothing was opened, so nothing is closed.
+    if (!foreground) return;
+    try {
+      await open();
+    } catch (err) {
+      // A pool left unpaused would poison every other tab, so it goes back
+      // before the lock does, whatever went wrong above. `db` is dropped
+      // first for the same reason as in `close()`.
+      try {
+        const opened = db;
+        db = null;
+        if (opened) opened.close();
+        if (pool && !pool.isPaused()) pool.pauseVfs();
+      } catch (ignored) { /* nothing better to try */ }
+      // Released by returning: this tab could not open the database, and the
+      // next one — online where this one was not, say — deserves its turn.
+      settle({ type: "error", message: String(err) });
+      return;
+    }
+    // Left the foreground while the database was opening. Nothing has been
+    // promised to the page yet, so it just goes straight back.
+    if (foreground) {
+      settle({ type: "ready" });
+      // Assigned with no await in between, so no report from the page can
+      // slip past between the check above and this handle existing.
+      await new Promise((done) => { yieldTurn = done; });
+      yieldTurn = null;
+    }
+    await close();
+    // Back to waiting: queries asked from here on are held, not answered from
+    // a database this tab no longer has.
+    lifecycle = { type: "loading" };
+    broadcast(lifecycle);
+    // In front again already — the tab came back while this turn was being
+    // wound up. The request queues behind this callback and is granted as
+    // soon as it returns, so nothing is lost to the gap.
+    if (foreground) acquire();
+  });
+}
+
+
+// The page reporting on itself: on screen and holding the keyboard, as one
+// boolean. Called with the truth at startup and whenever either half of it
+// changes, so the first thing this worker hears is whether it may take the
+// dictionary at all.
+//
+// Repeated reports of the same value cost nothing, which matters because the
+// page has three events feeding this and they overlap: leaving for another
+// application fires `blur` and `visibilitychange` both.
+function pageIsForeground(next) {
+  if (next === foreground) return;
+  foreground = next;
+  if (foreground) acquire();
+  // Given back at once rather than after a grace period. Focus flickers
+  // more than visibility does — a click in the address bar, a glance at
+  // devtools — and a grace timer would be the wrong answer to it twice
+  // over: in a backgrounded tab timers are throttled, and the one thing that
+  // must not happen is being frozen while still holding the lock. A round
+  // trip costs ~14 ms of worker time and never blocks the tab that has the
+  // keyboard. A tab queued but not yet granted needs nothing here — the
+  // callback checks `foreground` when its turn comes.
+  else if (yieldTurn) yieldTurn();
+}
+
+
+function start(emit) {
+  broadcast = emit;
+}
+
+
+self.dictionary = { pageIsForeground, request, start };

--- a/resources/public/js/sqlite3-worker.js
+++ b/resources/public/js/sqlite3-worker.js
@@ -1,8 +1,7 @@
 // The page's end of the dictionary. Every tab has one of these and they never
 // speak to each other; which of them has the database open is decided by the
-// browser's lock manager, and one without the lock holds its queries until
-// its turn comes. Neither this file nor the page can tell the two apart —
-// that is the point of #351.
+// browser's lock manager, and one without the lock answers with no
+// completions rather than queueing the query.
 //
 // The page does have to say one thing about itself: whether it is the tab in
 // front. Only that tab may hold the database — a backgrounded one is frozen
@@ -18,5 +17,5 @@ self.addEventListener("message", (e) => {
     dictionary.pageIsForeground(e.data.foreground);
     return;
   }
-  dictionary.request(e.data).then((response) => self.postMessage(response));
+  self.postMessage(dictionary.request(e.data));
 });

--- a/resources/public/js/sqlite3-worker.js
+++ b/resources/public/js/sqlite3-worker.js
@@ -1,95 +1,22 @@
-let db = null;
+// The page's end of the dictionary. Every tab has one of these and they never
+// speak to each other; which of them has the database open is decided by the
+// browser's lock manager, and one without the lock holds its queries until
+// its turn comes. Neither this file nor the page can tell the two apart —
+// that is the point of #351.
+//
+// The page does have to say one thing about itself: whether it is the tab in
+// front. Only that tab may hold the database — a backgrounded one is frozen
+// with it, and a merely visible one is not necessarily the one being typed
+// into. How the page decides is the page's business; here it is one boolean.
 
-const telemetry = new URL(self.location.href).searchParams.has("telemetry");
+importScripts("sqlite3-dictionary.js");
 
-async function measure(phase, fn, extras) {
-  if (!telemetry) return fn();
-  const t0 = performance.now();
-  try {
-    const result = await fn();
-    const msg = { type: "phase", phase, status: "ok", durationMs: Math.round(performance.now() - t0) };
-    if (extras) Object.assign(msg, extras(result));
-    self.postMessage(msg);
-    return result;
-  } catch (err) {
-    self.postMessage({ type: "phase", phase, status: "error",
-                       durationMs: Math.round(performance.now() - t0), reason: String(err) });
-    throw err;
+dictionary.start((msg) => self.postMessage(msg));
+
+self.addEventListener("message", (e) => {
+  if (e.data.type === "foreground") {
+    dictionary.pageIsForeground(e.data.foreground);
+    return;
   }
-}
-
-// Hold the OPFS SAH pool lock for the worker's entire lifetime.
-// `ifAvailable: true` makes a second tab fail fast instead of hanging:
-// it gets null and we report a clear "another tab open" error.
-async function withSahPoolLock(initFn) {
-  return navigator.locks.request(
-    "sprecha-sqlite-opfs-sahpool",
-    { ifAvailable: true },
-    async (lock) => {
-      if (lock === null) {
-        self.postMessage({
-          type:    "error",
-          code:    "another-tab-open",
-          message: "Приложение уже открыто в другой вкладке. Закройте её и обновите страницу."
-        });
-        return;
-      }
-      try {
-        await initFn();
-        self.postMessage({ type: "ready" });
-      } catch (err) {
-        self.postMessage({ type: "error", message: String(err) });
-        return;
-      }
-      // Keep the lock alive for the rest of the worker's life;
-      // the browser releases it automatically when the worker terminates.
-      await new Promise(() => {});
-    });
-}
-
-
-async function init() {
-  const params = new URL(self.location.href).searchParams;
-  const dir = params.get("sqlite3.dir");
-  importScripts(dir ? `${dir}/sqlite3.js` : "sqlite3.js");
-
-  const sqlite3 = await measure("wasm-init", () => sqlite3InitModule());
-  const pool    = await measure("pool-install", () =>
-    sqlite3.installOpfsSAHPoolVfs({ name: "opfs-sahpool", initialCapacity: 3 }));
-
-  const manifest = await measure("manifest", () =>
-    fetch("/dictionary/manifest").then(r => r.json()));
-  const hash12   = manifest.hash.slice(0, 12);
-  const poolFile = `/dict.${hash12}.sqlite`;
-
-  // Unlink stale versions first so their handles become available for import.
-  for (const name of pool.getFileNames()) {
-    if (name !== poolFile && name.startsWith("/dict.") && name.endsWith(".sqlite"))
-      pool.unlink(name);
-  }
-
-  if (!pool.getFileNames().includes(poolFile)) {
-    const buffer = await measure("download",
-      () => fetch(`/dictionary/${manifest.filename}`).then(r => r.arrayBuffer()),
-      ab => ({ bytes: ab.byteLength }));
-    await measure("import", () => pool.importDb(poolFile, new Uint8Array(buffer)));
-  } else {
-    if (telemetry) self.postMessage({ type: "phase", phase: "cache-hit", status: "ok", durationMs: 0, hash12 });
-  }
-
-  await measure("cleanup", () => pool.reduceCapacity(1));
-
-  db = await measure("db-open", () =>
-    new sqlite3.oo1.DB({ filename: poolFile, vfs: "opfs-sahpool" }));
-}
-
-self.addEventListener("message", e => {
-  const msg = e.data;
-  try {
-    self.postMessage({ id: msg.id, result: db.exec(msg) });
-  } catch (err) {
-    self.postMessage({ id: msg.id, error: String(err) });
-  }
+  dictionary.request(e.data).then((response) => self.postMessage(response));
 });
-
-withSahPoolLock(() => measure("init", init));

--- a/resources/public/js/sw.js
+++ b/resources/public/js/sw.js
@@ -56,6 +56,7 @@ const PRECACHE_URLS = [
   "/icons/ue-dev-192.png",
   "/icons/ue-dev-512.png",
   "/js/app/main.js",
+  "/js/sqlite3-dictionary.js",
   "/js/sqlite3-worker.js",
   "/js/sqlite3.js",
   "/js/sqlite3.wasm",

--- a/src/client/README.md
+++ b/src/client/README.md
@@ -52,7 +52,7 @@ src/client/
 
 **Dictionary worker** — SQLite WASM runs in a dedicated Web Worker (`resources/public/`). `ports/dictionary.cljs` exposes the app-facing capability; `adapters/dictionary.cljs` executes SQL through the worker proxy. Never query the dictionary from the main thread directly.
 
-Every tab has a worker, but the dictionary belongs to the tab being typed into: `opfs-sahpool` admits a single holder, so a tab takes the `sqlite-opfs-sahpool` Web Lock when it comes to the foreground — on screen *and* holding the keyboard — and gives it back when it leaves (`sqlite3-dictionary.js`, ADR-0012). Visibility alone would not do: two tabs can be visible side by side and only one is being used. A tab holds the queries asked of it until its turn starts, which is normally the tab you just switched to, still loading, with the user already typing — so never gate a call on readiness; just ask.
+Every tab has a worker, but the dictionary belongs to the tab being typed into: `opfs-sahpool` admits a single holder, so a tab takes the `sqlite-opfs-sahpool` Web Lock when it comes to the foreground — on screen *and* holding the keyboard — and gives it back when it leaves (`sqlite3-dictionary.js`, ADR-0012). Visibility alone would not do: two tabs can be visible side by side and only one is being used. A tab without a turn answers the queries asked of it with no completions and keeps nothing, so never gate a call on readiness — just ask, and read `:dictionary/ready?` if you have to say *why* a list is empty (#312).
 
 **IndexedDB** — lessons, retention scores, and vocabulary lists. Migrations run at startup via `db_migrations.cljs`. `lib/db` macros abstract the IDB API.
 

--- a/src/client/README.md
+++ b/src/client/README.md
@@ -52,6 +52,8 @@ src/client/
 
 **Dictionary worker** — SQLite WASM runs in a dedicated Web Worker (`resources/public/`). `ports/dictionary.cljs` exposes the app-facing capability; `adapters/dictionary.cljs` executes SQL through the worker proxy. Never query the dictionary from the main thread directly.
 
+Every tab has a worker, but the dictionary belongs to the tab being typed into: `opfs-sahpool` admits a single holder, so a tab takes the `sqlite-opfs-sahpool` Web Lock when it comes to the foreground — on screen *and* holding the keyboard — and gives it back when it leaves (`sqlite3-dictionary.js`, ADR-0012). Visibility alone would not do: two tabs can be visible side by side and only one is being used. A tab holds the queries asked of it until its turn starts, which is normally the tab you just switched to, still loading, with the user already typing — so never gate a call on readiness; just ask.
+
 **IndexedDB** — lessons, retention scores, and vocabulary lists. Migrations run at startup via `db_migrations.cljs`. `lib/db` macros abstract the IDB API.
 
 **Service worker** — plain JS (`resources/public/`). Caches static assets; does not run ClojureScript.

--- a/src/client/adapters/dictionary.cljs
+++ b/src/client/adapters/dictionary.cljs
@@ -42,31 +42,31 @@
    ORDER BY top.rank DESC, lemma ASC")
 
 
-(defn ready?
-  [db]
-  (sqlite/ready? db))
-
-
 (defn ^:async completions
-  "Returns a vec of completion maps {:lemma :translations :exact? :pos} from SQLite."
+  "Returns a vec of completion maps {:lemma :translations :exact? :pos} from SQLite.
+
+   No readiness gate in front of the query. This tab's worker holds a request
+   that arrives before it has the database open and answers it when its turn
+   comes, so an early keystroke waits instead of resolving to an empty list
+   that looks exactly like a word the dictionary does not have (#351). The
+   caller drops answers the user has typed past."
   [db prefix]
-  (if (ready? db)
-    (let [prefix-start (utils/normalize-german (or prefix ""))]
-      (if (empty? prefix-start)
-        []
-        (let [prefix-end (str prefix-start \z)
-              rows       (js->clj
-                          (await
-                           (sqlite/exec db
-                                        #js {:sql         completions-sql
-                                             :bind        #js [prefix-start prefix-end prefix-start]
-                                             :returnValue "resultRows"
-                                             :rowMode     "object"}))
-                          :keywordize-keys
-                          true)]
-          (for [{:keys [lemma translations has_exact pos]} rows]
-            {:lemma        lemma
-             :pos          pos
-             :translations (str/split (or translations "") #",")
-             :exact?       (pos? has_exact)}))))
-    []))
+  (let [prefix-start (utils/normalize-german (or prefix ""))]
+    (if (empty? prefix-start)
+      []
+      (let [prefix-end (str prefix-start \z)
+            rows       (js->clj
+                        (await
+                         (sqlite/exec db
+                                      #js {:sql         completions-sql
+                                           :bind        #js [prefix-start prefix-end prefix-start]
+                                           :returnValue "resultRows"
+                                           :rowMode     "object"}))
+                        :keywordize-keys
+                        true)]
+        (mapv (fn [{:keys [lemma translations has_exact pos]}]
+                {:exact?       (pos? has_exact)
+                 :lemma        lemma
+                 :pos          pos
+                 :translations (str/split (or translations "") #",")})
+              rows)))))

--- a/src/client/adapters/dictionary.cljs
+++ b/src/client/adapters/dictionary.cljs
@@ -42,14 +42,20 @@
    ORDER BY top.rank DESC, lemma ASC")
 
 
+(defn ready?
+  "Whether this tab has the dictionary right now, for a caller that has to say
+   so. Nothing on the query path reads it."
+  [db]
+  (sqlite/ready? db))
+
+
 (defn ^:async completions
   "Returns a vec of completion maps {:lemma :translations :exact? :pos} from SQLite.
 
-   No readiness gate in front of the query. This tab's worker holds a request
-   that arrives before it has the database open and answers it when its turn
-   comes, so an early keystroke waits instead of resolving to an empty list
-   that looks exactly like a word the dictionary does not have (#351). The
-   caller drops answers the user has typed past."
+   No readiness gate in front of the query: a tab without the database answers
+   with no rows on its own, so a gate here would only duplicate the decision
+   (#351). An empty vec therefore means either — `ready?` is what separates
+   them. The caller drops answers the user has typed past."
   [db prefix]
   (let [prefix-start (utils/normalize-german (or prefix ""))]
     (if (empty? prefix-start)

--- a/src/client/db/sqlite.cljs
+++ b/src/client/db/sqlite.cljs
@@ -1,16 +1,23 @@
 (ns db.sqlite
+  "The page's half of the dictionary protocol.
+
+   Every tab has a worker of its own and the workers never speak to each
+   other; which of them has the SQLite file open is decided by the browser's
+   lock manager, and a worker without the lock holds its queries until its
+   turn comes (#351). So nothing here can tell the two apart, and nothing
+   here should try."
   (:require
    [instrumentation :as instrumentation]
    [lambdaisland.glogi :as log]))
 
 
 (defn- make-exec-proxy
-  [worker state]
+  [worker requests]
   #js {:exec
        (fn [^js opts]
          (js/Promise.
           (fn [resolve reject]
-            (let [id  (:next-id (swap! state update :next-id inc))
+            (let [id  (:next-id (swap! requests update :next-id inc))
                   msg (doto (js/Object.assign #js {} opts) (aset "id" id))]
               (..
                worker
@@ -31,47 +38,84 @@
   (.exec (:proxy db) opts))
 
 
-(defn ready?
-  [db]
-  (:ready? @(:state db)))
+(defn- handle-lifecycle!
+  "Where the worker is and what its startup cost. A tab waiting for another
+   one to give the database up says nothing at all meanwhile; when its turn
+   comes, what arrives is its own phases and its own ready.
+
+   Nothing on this side keeps the state: a query is sent whatever the worker
+   says, because the worker holds one it cannot answer yet. What these
+   messages feed is the measurement and the log."
+  [^js e]
+  (case (.. e -data -type)
+    "ready" (when goog/DEBUG
+              (instrumentation/dictionary-ready!))
+    "error" (log/error :dbs/sqlite3-worker-error {:message (.. e -data -message)})
+    "phase" (let [d   (.. e -data)
+                  ph  (.-phase d)
+                  ms  (.-durationMs d)
+                  ok? (= "ok" (.-status d))]
+              (when goog/DEBUG
+                (instrumentation/dictionary-phase! ph ms (.-status d)))
+              (if ok?
+                (log/info (keyword "dict-worker" ph) {:duration-ms ms})
+                (log/error (keyword "dict-worker" ph) {:duration-ms ms :reason (.-reason d)})))
+    nil))
+
+
+(defn attach
+  "Builds the `:db/sqlite` component around a worker. Split out of `init!` so
+   the protocol can be driven from a test, in a runtime with no workers to
+   spawn."
+  [worker]
+  ;; The atom is the request counter and nothing else — it is not in the
+  ;; returned component because nobody outside the proxy has anything to read
+  ;; from it.
+  (let [requests (atom {:next-id 0})]
+    (.addEventListener worker "message" handle-lifecycle!)
+    (.addEventListener worker
+                       "error"
+                       (fn [^js e]
+                         (log/error :dbs/sqlite3-worker-crashed {:error (str e)})))
+    {:proxy  (make-exec-proxy worker requests)
+     :worker worker}))
+
+
+(defn- foreground?
+  "Whether this is the tab being typed into: on screen and holding the
+   keyboard. On screen alone is not enough — two tabs can be visible at once,
+   side by side or in split screen, and `hidden` is false for both, so the
+   database would go to whichever took the lock first rather than to the one
+   the user is working in."
+  []
+  (and (= "visible" (.-visibilityState js/document))
+       (.hasFocus js/document)))
+
+
+(defn- publish-foreground!
+  "Tells the worker whether it is allowed to hold the database. A worker
+   cannot see the document, and only the foreground tab may hold it: a
+   backgrounded one is frozen holding it and stops answering (#351). The
+   worker is given the answer, never the reasoning."
+  [worker]
+  (.postMessage worker #js {:type "foreground" :foreground (foreground?)}))
 
 
 (defn init!
   [_deps]
   (when goog/DEBUG
     (instrumentation/dictionary-start!))
-  (let [state  (atom {:ready? false :next-id 0})
-        worker (js/Worker. (str "/js/sqlite3-worker.js?sqlite3.dir=/js"
+  (let [worker (js/Worker. (str "/js/sqlite3-worker.js?sqlite3.dir=/js"
                                 (when goog/DEBUG "&telemetry=1")))
-        proxy  (make-exec-proxy worker state)]
-    (..
-     worker
-     (addEventListener
-      "message"
-      (fn [^js e]
-        (case (.. e -data -type)
-          "ready" (do
-                    (swap! state assoc :ready? true)
-                    (when goog/DEBUG
-                      (instrumentation/dictionary-ready!)))
-          "error" (log/error :dbs/sqlite3-worker-error {:message (.. e -data -message)})
-          "phase" (let [d   (.. e -data)
-                        ph  (.-phase d)
-                        ms  (.-durationMs d)
-                        ok? (= "ok" (.-status d))]
-                    (when goog/DEBUG
-                      (instrumentation/dictionary-phase! ph ms (.-status d)))
-                    (if ok?
-                      (log/info (keyword "dict-worker" ph) {:duration-ms ms})
-                      (log/error (keyword "dict-worker" ph) {:duration-ms ms :reason (.-reason d)})))
-          nil))))
-    (..
-     worker
-     (addEventListener
-      "error"
-      (fn [^js e]
-        (log/error :dbs/sqlite3-worker-crashed {:error (str e)})
-        (swap! state assoc :ready? false))))
-    {:proxy  proxy
-     :state  state
-     :worker worker}))
+        report #(publish-foreground! worker)]
+    ;; Posted before the worker's script has run — the message waits for it —
+    ;; so the first thing it hears is whether it may take the database at all.
+    (report)
+    ;; Three events for two conditions, and they overlap: leaving for another
+    ;; application fires `blur` and `visibilitychange` both. The worker
+    ;; ignores a report that repeats the value it already has, so the overlap
+    ;; costs nothing and neither condition can be missed.
+    (js/document.addEventListener "visibilitychange" report)
+    (js/window.addEventListener "focus" report)
+    (js/window.addEventListener "blur" report)
+    (attach worker)))

--- a/src/client/db/sqlite.cljs
+++ b/src/client/db/sqlite.cljs
@@ -3,9 +3,9 @@
 
    Every tab has a worker of its own and the workers never speak to each
    other; which of them has the SQLite file open is decided by the browser's
-   lock manager, and a worker without the lock holds its queries until its
-   turn comes (#351). So nothing here can tell the two apart, and nothing
-   here should try."
+   lock manager (#351). A worker without it answers with no completions, so
+   the answer alone cannot say whether the prefix has none or the dictionary
+   is elsewhere — `ready?` is what tells those apart."
   (:require
    [instrumentation :as instrumentation]
    [lambdaisland.glogi :as log]))
@@ -38,28 +38,41 @@
   (.exec (:proxy db) opts))
 
 
-(defn- handle-lifecycle!
-  "Where the worker is and what its startup cost. A tab waiting for another
-   one to give the database up says nothing at all meanwhile; when its turn
-   comes, what arrives is its own phases and its own ready.
+(defn ready?
+  "Whether this tab has the dictionary right now. Not a gate in front of a
+   query — the worker answers either way — but the only thing that can tell an
+   empty answer from a prefix with no completions (#312)."
+  [db]
+  @(:holding? db))
 
-   Nothing on this side keeps the state: a query is sent whatever the worker
-   says, because the worker holds one it cannot answer yet. What these
-   messages feed is the measurement and the log."
-  [^js e]
+
+(defn- handle-lifecycle!
+  "Where the worker is: it takes the database on every turn and gives it back
+   when the tab leaves the foreground, and says so each time.
+
+   Queries are sent whatever it says — nothing here gates them, because a
+   worker without the database answers empty by itself. What is kept is the
+   reading `ready?` returns, for a caller that has to describe the difference
+   (#312); the rest feeds the measurement and the log."
+  [holding? ^js e]
   (case (.. e -data -type)
-    "ready" (when goog/DEBUG
-              (instrumentation/dictionary-ready!))
-    "error" (log/error :dbs/sqlite3-worker-error {:message (.. e -data -message)})
-    "phase" (let [d   (.. e -data)
-                  ph  (.-phase d)
-                  ms  (.-durationMs d)
-                  ok? (= "ok" (.-status d))]
-              (when goog/DEBUG
-                (instrumentation/dictionary-phase! ph ms (.-status d)))
-              (if ok?
-                (log/info (keyword "dict-worker" ph) {:duration-ms ms})
-                (log/error (keyword "dict-worker" ph) {:duration-ms ms :reason (.-reason d)})))
+    "loading" (reset! holding? false)
+    "ready"   (do
+                (reset! holding? true)
+                (when goog/DEBUG
+                  (instrumentation/dictionary-ready!)))
+    "error"   (do
+                (reset! holding? false)
+                (log/error :dbs/sqlite3-worker-error {:message (.. e -data -message)}))
+    "phase"   (let [d   (.. e -data)
+                    ph  (.-phase d)
+                    ms  (.-durationMs d)
+                    ok? (= "ok" (.-status d))]
+                (when goog/DEBUG
+                  (instrumentation/dictionary-phase! ph ms (.-status d)))
+                (if ok?
+                  (log/info (keyword "dict-worker" ph) {:duration-ms ms})
+                  (log/error (keyword "dict-worker" ph) {:duration-ms ms :reason (.-reason d)})))
     nil))
 
 
@@ -68,17 +81,20 @@
    the protocol can be driven from a test, in a runtime with no workers to
    spawn."
   [worker]
-  ;; The atom is the request counter and nothing else — it is not in the
-  ;; returned component because nobody outside the proxy has anything to read
-  ;; from it.
-  (let [requests (atom {:next-id 0})]
-    (.addEventListener worker "message" handle-lifecycle!)
+  ;; Two atoms because they answer to two different things: `requests` is the
+  ;; id counter the proxy needs and nobody outside it reads, `holding?` is the
+  ;; reading `ready?` hands out.
+  (let [requests (atom {:next-id 0})
+        holding? (atom false)]
+    (.addEventListener worker "message" (partial handle-lifecycle! holding?))
     (.addEventListener worker
                        "error"
                        (fn [^js e]
+                         (reset! holding? false)
                          (log/error :dbs/sqlite3-worker-crashed {:error (str e)})))
-    {:proxy  (make-exec-proxy worker requests)
-     :worker worker}))
+    {:holding? holding?
+     :proxy    (make-exec-proxy worker requests)
+     :worker   worker}))
 
 
 (defn- foreground?

--- a/src/client/instrumentation.cljs
+++ b/src/client/instrumentation.cljs
@@ -114,20 +114,34 @@
 
 
 (defn dictionary-ready!
-  "Closes the readiness interval. Records a User Timing measure, so the
-   interval shows up in a performance trace, and keeps its duration."
+  "Closes the readiness interval, and only the first one.
+
+   The worker reports ready on every turn it takes, not just its first: the
+   dictionary belongs to the visible tab, so a tab that is left and returned
+   to opens the database again and says so again. This interval is measured
+   from a mark laid once at page load, so a second reading would not be what
+   the dictionary cost — it would be how long the page had been open when the
+   user came back. The first reading is the one that answers the question, and
+   `:phases` carries what each later turn cost."
   []
-  (let [^js measure (try
-                      (.measure js/performance "dictionary-ready" "dictionary-start")
-                      (catch :default _ nil))]
-    (when measure
-      (swap! metrics assoc-in [:dictionary :ready-ms] (.-duration measure)))))
+  (when-not (get-in @metrics [:dictionary :ready-ms])
+    (let [^js measure (try
+                        (.measure js/performance "dictionary-ready" "dictionary-start")
+                        (catch :default _ nil))]
+      (when measure
+        (swap! metrics assoc-in [:dictionary :ready-ms] (.-duration measure))))))
 
 
 (defn dictionary-phase!
-  "Keeps one startup phase the worker reported. The worker already times
-   every phase for the log; this only carries the numbers into the metrics.
-   `cache-hit` among them is what separates a warm start from a cold one."
+  "Keeps one phase the worker reported. The worker already times every phase
+   for the log; this only carries the numbers into the metrics. `cache-hit`
+   among them is what separates a warm start from a cold one.
+
+   Startup and per-turn phases land here together and the list accumulates:
+   the startup ones (`wasm-init`, `pool-install`, `download`, `import`) happen
+   once per tab, and `pause` and `unpause` repeat every time the dictionary
+   changes tabs. Both are wanted — the per-turn pair is what the cost of a
+   focus change is read from."
   [phase duration-ms status]
   (swap! metrics update-in
     [:dictionary :phases]

--- a/src/client/pages/home/effects.cljs
+++ b/src/client/pages/home/effects.cljs
@@ -18,8 +18,12 @@
    (fn ^:async suggest!
      [dispatch dictionary value]
      (try
-       (when-let [completions (when ((:dictionary/ready? dictionary))
-                                (await ((:dictionary/completions dictionary) value)))]
+       ;; No readiness check: this tab's worker holds a query asked before it
+       ;; has the database open and answers it when its turn comes, so the
+       ;; first keystrokes of a cold start get suggestions late instead of
+       ;; never (#351). A worker that could not open it rejects, which the
+       ;; catch below reports.
+       (let [completions (await ((:dictionary/completions dictionary) value))]
          ;; The queried value rides along so the action can drop answers that
          ;; arrive after further typing (stale list, stale translation prefill).
          (dispatch [[:action/update-suggestions {:completions completions :value value}]]))

--- a/src/client/pages/home/effects.cljs
+++ b/src/client/pages/home/effects.cljs
@@ -11,18 +11,22 @@
 ;; Measured end to end (#195): past the debounce, worker + SQLite + render
 ;; cost 9-44 ms (one-letter prefix worst). And since the list now keeps its
 ;; previous answer until the next one arrives (#178), a mid-burst answer
-;; replaces smoothly instead of flashing. 100 ms still coalesces fast typing
-;; (120-180 ms per key) and puts suggestions ~110-145 ms after the pause.
+;; replaces smoothly instead of flashing. 100 ms does not coalesce typing at
+;; the measured cadence — 120-180 ms per key is longer than the wait, so a
+;; trailing debounce expires between keys and every keystroke gets a query of
+;; its own. What it does buy is the burst faster than that, and suggestions
+;; ~110-145 ms after the typing stops.
 (def ^:private suggest!
   (gfn/debounce
    (fn ^:async suggest!
      [dispatch dictionary value]
      (try
-       ;; No readiness check: this tab's worker holds a query asked before it
-       ;; has the database open and answers it when its turn comes, so the
-       ;; first keystrokes of a cold start get suggestions late instead of
-       ;; never (#351). A worker that could not open it rejects, which the
-       ;; catch below reports.
+       ;; No readiness check, and none is coming back: the worker answers
+       ;; with what this tab has — the database if it holds it, no rows if it
+       ;; does not (#351) — so a gate here would only re-decide what has
+       ;; already been decided one hop away. `:dictionary/ready?` stays on the
+       ;; port as the reading #312 needs to say why a list is empty. A worker
+       ;; that could not open the database rejects, which the catch reports.
        (let [completions (await ((:dictionary/completions dictionary) value))]
          ;; The queried value rides along so the action can drop answers that
          ;; arrive after further typing (stale list, stale translation prefill).

--- a/src/client/ports/dictionary.cljs
+++ b/src/client/ports/dictionary.cljs
@@ -7,4 +7,10 @@
   [{:keys [db]}]
   {:dictionary/completions (fn completions
                              [prefix]
-                             (dictionary/completions db prefix))})
+                             (dictionary/completions db prefix))
+   ;; A reading, not a gate: completions are asked for whatever this says. It
+   ;; is here so a caller can tell an empty answer from a missing dictionary
+   ;; (#312).
+   :dictionary/ready?      (fn ready?
+                             []
+                             (dictionary/ready? db))})

--- a/src/client/ports/dictionary.cljs
+++ b/src/client/ports/dictionary.cljs
@@ -7,7 +7,4 @@
   [{:keys [db]}]
   {:dictionary/completions (fn completions
                              [prefix]
-                             (dictionary/completions db prefix))
-   :dictionary/ready?      (fn ready?
-                             []
-                             (dictionary/ready? db))})
+                             (dictionary/completions db prefix))})

--- a/test/browser/README.md
+++ b/test/browser/README.md
@@ -45,6 +45,22 @@ the fixture's words too — but slowly, and
 `add-form-stability.mobile.spec.js` fails on its match count, which is there
 to say so out loud.
 
+### Several tabs at once
+
+`dictionary-focus.spec.js` opens more than one page in the same context on
+purpose: only one tab can hold `opfs-sahpool`, and which one it is follows
+visibility (#351, ADR-0012). Pages of *different* contexts share nothing —
+separate storage, separate lock — so they prove nothing here.
+
+Playwright cannot hide a page: every page reports `visible`,
+`bringToFront()` does not change that, and
+`Emulation.setPageVisibilityOverride` is gone from the protocol. All three
+were checked against this Chrome. So that spec shims `document.hidden` and
+dispatches the real `visibilitychange`, which drives the whole app path —
+page listener, worker message, lock, pool, database. It does not reproduce
+Android freezing a backgrounded tab, which is the reason the rule exists;
+nothing here covers that.
+
 ## CI
 
 The `Browser Tests` job in `.github/workflows/integration.yml` runs the same
@@ -56,6 +72,13 @@ uploads `test-results/` (traces) and the backend log as an artifact.
 
 - Role- and label-based locators (`getByRole`, `getByLabel`) with auto-waiting
   assertions. No `waitForTimeout`, no CSS-class locators.
+  - One exception, and it needs the reason stated at the call site:
+    asserting that something *never* appears. Auto-waiting expresses "wait
+    until true", so there is nothing for it to wait for, and the only way to
+    establish a negative is to let time pass first. `dictionary-focus.spec.js`
+    does this through a named `nothingHappensFor` helper — a bare
+    `waitForTimeout` before a positive assertion is still a flake waiting to
+    happen and still banned.
 - Each test gets a fresh browser context, so client-side storage starts empty
   and tests are order-independent.
 - Geometry and performance specs additionally read `boundingBox()` and

--- a/test/browser/add-form-stability.mobile.spec.js
+++ b/test/browser/add-form-stability.mobile.spec.js
@@ -102,11 +102,11 @@ test('typing a word does not move the form under the cursor', async ({ page }) =
   // returning to its resting y is the end of the collapse — so the measured
   // window starts with the page genuinely at rest.
   //
-  // Deliberately no reload in between: sqlite3-worker.js holds the
-  // `sprecha-sqlite-opfs-sahpool` web lock with `ifAvailable` for the worker's
-  // whole life, and a reload races the old worker's teardown against the new
-  // worker's request. Losing that race answers "another tab open" and the
-  // dictionary never becomes ready.
+  // Deliberately no reload in between: it costs a fresh worker and another
+  // trip through the pool lock for nothing this spec measures. (It used to
+  // cost more — the lock was taken `ifAvailable`, so a reload racing the old
+  // worker's teardown answered "another tab open" and the dictionary never
+  // became ready. That is #351, fixed.)
   await field.pressSequentially(PROBE);
   await expect(options(page).first()).toBeVisible();
   await field.fill('');

--- a/test/browser/dictionary-focus.spec.js
+++ b/test/browser/dictionary-focus.spec.js
@@ -4,8 +4,9 @@ const { test, expect } = require('@playwright/test');
 //
 // `opfs-sahpool` admits one holder, so a tab takes the pool lock when it comes
 // to the foreground — on screen and holding the keyboard — and gives it back
-// when it leaves. A tab waiting its turn has no dictionary and holds the
-// queries asked of it until it does.
+// when it leaves. A tab waiting its turn has no dictionary, and a query asked
+// of it then is answered with no completions and forgotten; getting an answer
+// after the turn arrives takes another keystroke.
 //
 // How the foreground is driven here, and what that costs in confidence:
 // Playwright can reproduce neither half. Every page reports `visible` and
@@ -34,6 +35,10 @@ const TURN_MS = 20000;
 // Long enough that a dictionary that was going to answer would have, but not
 // so long that the spec pays for it when the answer never comes.
 const SILENCE_MS = 3000;
+
+// One attempt: the 100 ms suggest debounce, the round trip and the render.
+// Measured at 9-44 ms past the debounce (#195), so this is loose on purpose.
+const ANSWER_MS = 1000;
 
 const valueField = (page) => page.getByLabel('Слово (немецкий)');
 const options = (page) => page.getByRole('option');
@@ -93,10 +98,26 @@ const suggestions = (page, word) => options(page).filter({ hasText: word });
 // establish.
 const nothingHappensFor = (page, ms) => page.waitForTimeout(ms);
 
+// A query is answered from what the tab has when it arrives, and nothing is
+// kept: one sent while the turn is still being taken comes back empty and is
+// never replayed. A user looking at an empty list types the word again, and so
+// does this — until the answer comes or the turn never does.
+const typeUntilAnswered = async (page, word, count) => {
+  const deadline = Date.now() + TURN_MS;
+  for (;;) {
+    await type(page, word);
+    try {
+      await expect(suggestions(page, word)).toHaveCount(count, { timeout: ANSWER_MS });
+      return;
+    } catch (error) {
+      if (Date.now() >= deadline) throw error;
+    }
+  }
+};
+
 test('the foreground tab has the dictionary and a background one does not', async ({ context }) => {
   const first = await openHome(context);
-  await type(first, 'Fenster');
-  await expect(suggestions(first, 'Fenster')).toHaveCount(FIXTURE_FENSTER_MATCHES, { timeout: TURN_MS });
+  await typeUntilAnswered(first, 'Fenster', FIXTURE_FENSTER_MATCHES);
 
   // The second tab opens in front, so the first steps aside and the second
   // takes over. Then the keyboard goes back, and the second is left visible
@@ -116,39 +137,45 @@ test('two visible tabs: the one with the keyboard gets the dictionary', async ({
   const right = await openHome(context);
 
   await focusOnly(left, right);
-  await type(left, 'Fenster');
-  await expect(suggestions(left, 'Fenster')).toHaveCount(FIXTURE_FENSTER_MATCHES, { timeout: TURN_MS });
+  await typeUntilAnswered(left, 'Fenster', FIXTURE_FENSTER_MATCHES);
   await type(right, 'Frage');
   await nothingHappensFor(right, SILENCE_MS);
   await expect(options(right)).toHaveCount(0);
 
   // The user clicks into the other pane. Nothing changed about what is on
-  // screen; the dictionary still has to move.
+  // screen; the dictionary still has to move, and the word has to be asked
+  // again — the answer given while the pane was idle was an empty one.
   await focusOnly(right, left);
-  await expect(suggestions(right, 'Frage')).toHaveCount(1, { timeout: TURN_MS });
+  await typeUntilAnswered(right, 'Frage', 1);
 });
 
-test('the query asked while waiting is answered when the turn comes', async ({ context }) => {
+test('the query asked while waiting comes back empty and is not replayed', async ({ context }) => {
   const first = await openHome(context);
-  await type(first, 'Fenster');
-  await expect(suggestions(first, 'Fenster')).toHaveCount(FIXTURE_FENSTER_MATCHES, { timeout: TURN_MS });
+  await typeUntilAnswered(first, 'Fenster', FIXTURE_FENSTER_MATCHES);
 
   const second = await openHome(context);
   await focusOnly(first, second);
+
+  // Asked of a tab with no turn: answered, and answered with nothing. The
+  // wait is what says it was answered rather than left pending — a held query
+  // would land here once the turn came.
   await type(second, 'Fenster');
+  await nothingHappensFor(second, SILENCE_MS);
   await expect(options(second)).toHaveCount(0);
 
-  // No further typing after this point. The query the second tab already sent
-  // has to survive the wait and be answered once it has a database.
+  // The turn arrives with nothing waiting for it. No typing since, so nothing
+  // is asked again and the list stays as it was.
   await focusOnly(second, first);
+  await nothingHappensFor(second, SILENCE_MS);
+  await expect(options(second)).toHaveCount(0);
 
-  await expect(suggestions(second, 'Fenster')).toHaveCount(FIXTURE_FENSTER_MATCHES, { timeout: TURN_MS });
+  // Typing is what asks, and now there is a dictionary to answer.
+  await typeUntilAnswered(second, 'Fenster', FIXTURE_FENSTER_MATCHES);
 });
 
 test('the tab that leaves the foreground gives the dictionary back', async ({ context }) => {
   const first = await openHome(context);
-  await type(first, 'Fenster');
-  await expect(suggestions(first, 'Fenster')).toHaveCount(FIXTURE_FENSTER_MATCHES, { timeout: TURN_MS });
+  await typeUntilAnswered(first, 'Fenster', FIXTURE_FENSTER_MATCHES);
 
   const second = await openHome(context);
 
@@ -156,22 +183,19 @@ test('the tab that leaves the foreground gives the dictionary back', async ({ co
   await hide(first);
   await blur(first);
   await focus(second);
-  await type(second, 'Frage');
-  await expect(suggestions(second, 'Frage')).toHaveCount(1, { timeout: TURN_MS });
+  await typeUntilAnswered(second, 'Frage', 1);
 
   // And back again: the first tab returns, the second steps aside.
   await hide(second);
   await blur(second);
   await show(first);
   await focus(first);
-  await type(first, 'Fehler');
-  await expect(suggestions(first, 'Fehler')).toHaveCount(1, { timeout: TURN_MS });
+  await typeUntilAnswered(first, 'Fehler', 1);
 });
 
 test('focus flickering back and forth leaves the foreground tab working', async ({ context }) => {
   const first = await openHome(context);
-  await type(first, 'Fenster');
-  await expect(suggestions(first, 'Fenster')).toHaveCount(FIXTURE_FENSTER_MATCHES, { timeout: TURN_MS });
+  await typeUntilAnswered(first, 'Fenster', FIXTURE_FENSTER_MATCHES);
   const second = await openHome(context);
   await focusOnly(first, second);
 
@@ -186,14 +210,12 @@ test('focus flickering back and forth leaves the foreground tab working', async 
     await focus(first);
   }
 
-  await type(first, 'Haus');
-  await expect(suggestions(first, 'Haus')).toHaveCount(1, { timeout: TURN_MS });
+  await typeUntilAnswered(first, 'Haus', 1);
 });
 
 test('with no tab in the foreground, the first one back takes the dictionary', async ({ context }) => {
   const first = await openHome(context);
-  await type(first, 'Fenster');
-  await expect(suggestions(first, 'Fenster')).toHaveCount(FIXTURE_FENSTER_MATCHES, { timeout: TURN_MS });
+  await typeUntilAnswered(first, 'Fenster', FIXTURE_FENSTER_MATCHES);
   const second = await openHome(context);
 
   // The whole browser window goes behind something else: both tabs still
@@ -204,8 +226,7 @@ test('with no tab in the foreground, the first one back takes the dictionary', a
   await nothingHappensFor(second, 500);
 
   await focus(second);
-  await type(second, 'Hund');
-  await expect(suggestions(second, 'Hund')).toHaveCount(1, { timeout: TURN_MS });
+  await typeUntilAnswered(second, 'Hund', 1);
 });
 
 // What this pins is the outcome, not the mechanism: a tab that was never in
@@ -229,19 +250,17 @@ test('a tab that boots in the background has no dictionary until it is looked at
 
   await show(page);
   await focus(page);
-  await expect(suggestions(page, 'Fenster')).toHaveCount(FIXTURE_FENSTER_MATCHES, { timeout: TURN_MS });
+  await typeUntilAnswered(page, 'Fenster', FIXTURE_FENSTER_MATCHES);
 });
 
 test('closing the tab that holds the dictionary releases it', async ({ context }) => {
   const holder = await openHome(context);
-  await type(holder, 'Fenster');
-  await expect(suggestions(holder, 'Fenster')).toHaveCount(FIXTURE_FENSTER_MATCHES, { timeout: TURN_MS });
+  await typeUntilAnswered(holder, 'Fenster', FIXTURE_FENSTER_MATCHES);
 
   const successor = await openHome(context);
   // Killed rather than backgrounded: no handler of ours runs, and the lock has
   // to come back from the browser.
   await holder.close();
 
-  await type(successor, 'Fenster');
-  await expect(suggestions(successor, 'Fenster')).toHaveCount(FIXTURE_FENSTER_MATCHES, { timeout: TURN_MS });
+  await typeUntilAnswered(successor, 'Fenster', FIXTURE_FENSTER_MATCHES);
 });

--- a/test/browser/dictionary-focus.spec.js
+++ b/test/browser/dictionary-focus.spec.js
@@ -1,0 +1,247 @@
+const { test, expect } = require('@playwright/test');
+
+// The dictionary belongs to the tab being typed into (GH-351).
+//
+// `opfs-sahpool` admits one holder, so a tab takes the pool lock when it comes
+// to the foreground — on screen and holding the keyboard — and gives it back
+// when it leaves. A tab waiting its turn has no dictionary and holds the
+// queries asked of it until it does.
+//
+// How the foreground is driven here, and what that costs in confidence:
+// Playwright can reproduce neither half. Every page reports `visible` and
+// `hasFocus() === true`, `bringToFront()` changes neither, no `focus`/`blur`
+// event fires from it, and `Emulation.setPageVisibilityOverride` is gone from
+// the protocol — all checked against this Chrome, headless and headed. So
+// `document.hidden`, `document.visibilityState` and `document.hasFocus` are
+// shimmed and the real `visibilitychange`, `focus` and `blur` events are
+// dispatched, which drives the app's own path end to end: page listener,
+// worker message, lock, pool, database.
+//
+// What that does NOT reproduce: Android freezing a backgrounded tab, which is
+// why the visibility half exists, and real OS focus, which is why the focus
+// half does. Neither is covered by any test here.
+//
+// The dictionary is the fixture the backend serves from
+// LEARNING_APP__DICTIONARY_DIR (see README.md); "Fenster" matching exactly two
+// lemmas is what tells it apart from the shipped file.
+
+const FIXTURE_FENSTER_MATCHES = 2;
+
+// A tab taking its first turn loads the engine, installs the pool and opens
+// the database — 94 ms measured on this machine. Later turns cost ~14 ms.
+const TURN_MS = 20000;
+
+// Long enough that a dictionary that was going to answer would have, but not
+// so long that the spec pays for it when the answer never comes.
+const SILENCE_MS = 3000;
+
+const valueField = (page) => page.getByLabel('Слово (немецкий)');
+const options = (page) => page.getByRole('option');
+
+const PAGE_STATE_SHIM = ({ hidden, focused }) => {
+  let isHidden = hidden;
+  let isFocused = focused;
+  Object.defineProperty(document, 'hidden', { configurable: true, get: () => isHidden });
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    get: () => (isHidden ? 'hidden' : 'visible'),
+  });
+  document.hasFocus = () => isFocused;
+  window.__setHidden = (value) => {
+    isHidden = value;
+    document.dispatchEvent(new Event('visibilitychange'));
+  };
+  window.__setFocused = (value) => {
+    isFocused = value;
+    window.dispatchEvent(new Event(value ? 'focus' : 'blur'));
+  };
+};
+
+// A new tab opens in front, which in a real browser takes the keyboard off
+// whichever tab had it. Nothing here knows about the other pages, so callers
+// that care say so with `focusOnly`.
+const openHome = async (context, { hidden = false, focused = true } = {}) => {
+  const page = await context.newPage();
+  await page.addInitScript(PAGE_STATE_SHIM, { hidden, focused });
+  await page.goto('/home');
+  await expect(valueField(page)).toBeVisible();
+  return page;
+};
+
+const show = (page) => page.evaluate(() => window.__setHidden(false));
+const hide = (page) => page.evaluate(() => window.__setHidden(true));
+const blur = (page) => page.evaluate(() => window.__setFocused(false));
+const focus = (page) => page.evaluate(() => window.__setFocused(true));
+
+// One tab has the keyboard at a time. Blurring the others first is the order a
+// real browser uses, and it is the order that keeps the lock uncontended.
+const focusOnly = async (page, ...others) => {
+  for (const other of others) await blur(other);
+  await focus(page);
+};
+
+const type = async (page, word) => {
+  await valueField(page).fill('');
+  await valueField(page).fill(word);
+};
+
+// Matching on the text, so a list left over from a previous word cannot pass.
+const suggestions = (page, word) => options(page).filter({ hasText: word });
+
+// A plain wait, named so the reason is visible at the call site: these
+// assertions are that nothing appears, and nothing appearing takes time to
+// establish.
+const nothingHappensFor = (page, ms) => page.waitForTimeout(ms);
+
+test('the foreground tab has the dictionary and a background one does not', async ({ context }) => {
+  const first = await openHome(context);
+  await type(first, 'Fenster');
+  await expect(suggestions(first, 'Fenster')).toHaveCount(FIXTURE_FENSTER_MATCHES, { timeout: TURN_MS });
+
+  // The second tab opens in front, so the first steps aside and the second
+  // takes over. Then the keyboard goes back, and the second is left visible
+  // but not in front — which is where a tab has no dictionary.
+  const second = await openHome(context);
+  await focusOnly(first, second);
+
+  await type(second, 'Fenster');
+  await nothingHappensFor(second, SILENCE_MS);
+  await expect(options(second)).toHaveCount(0);
+});
+
+test('two visible tabs: the one with the keyboard gets the dictionary', async ({ context }) => {
+  // Neither tab is hidden at any point here — this is the split-screen case,
+  // where `document.hidden` is false for both and cannot decide between them.
+  const left = await openHome(context);
+  const right = await openHome(context);
+
+  await focusOnly(left, right);
+  await type(left, 'Fenster');
+  await expect(suggestions(left, 'Fenster')).toHaveCount(FIXTURE_FENSTER_MATCHES, { timeout: TURN_MS });
+  await type(right, 'Frage');
+  await nothingHappensFor(right, SILENCE_MS);
+  await expect(options(right)).toHaveCount(0);
+
+  // The user clicks into the other pane. Nothing changed about what is on
+  // screen; the dictionary still has to move.
+  await focusOnly(right, left);
+  await expect(suggestions(right, 'Frage')).toHaveCount(1, { timeout: TURN_MS });
+});
+
+test('the query asked while waiting is answered when the turn comes', async ({ context }) => {
+  const first = await openHome(context);
+  await type(first, 'Fenster');
+  await expect(suggestions(first, 'Fenster')).toHaveCount(FIXTURE_FENSTER_MATCHES, { timeout: TURN_MS });
+
+  const second = await openHome(context);
+  await focusOnly(first, second);
+  await type(second, 'Fenster');
+  await expect(options(second)).toHaveCount(0);
+
+  // No further typing after this point. The query the second tab already sent
+  // has to survive the wait and be answered once it has a database.
+  await focusOnly(second, first);
+
+  await expect(suggestions(second, 'Fenster')).toHaveCount(FIXTURE_FENSTER_MATCHES, { timeout: TURN_MS });
+});
+
+test('the tab that leaves the foreground gives the dictionary back', async ({ context }) => {
+  const first = await openHome(context);
+  await type(first, 'Fenster');
+  await expect(suggestions(first, 'Fenster')).toHaveCount(FIXTURE_FENSTER_MATCHES, { timeout: TURN_MS });
+
+  const second = await openHome(context);
+
+  // Backgrounded, not merely blurred: both halves of the rule release it.
+  await hide(first);
+  await blur(first);
+  await focus(second);
+  await type(second, 'Frage');
+  await expect(suggestions(second, 'Frage')).toHaveCount(1, { timeout: TURN_MS });
+
+  // And back again: the first tab returns, the second steps aside.
+  await hide(second);
+  await blur(second);
+  await show(first);
+  await focus(first);
+  await type(first, 'Fehler');
+  await expect(suggestions(first, 'Fehler')).toHaveCount(1, { timeout: TURN_MS });
+});
+
+test('focus flickering back and forth leaves the foreground tab working', async ({ context }) => {
+  const first = await openHome(context);
+  await type(first, 'Fenster');
+  await expect(suggestions(first, 'Fenster')).toHaveCount(FIXTURE_FENSTER_MATCHES, { timeout: TURN_MS });
+  const second = await openHome(context);
+  await focusOnly(first, second);
+
+  // Focus is lost far more often than visibility — a click in the address
+  // bar, a glance at devtools — so this is the flicker that matters now.
+  // Twelve changes with nothing waited on in between, so each take and give
+  // overlaps the next. The lock serialises them; nothing is left half-held.
+  for (let i = 0; i < 3; i++) {
+    await blur(first);
+    await focus(second);
+    await blur(second);
+    await focus(first);
+  }
+
+  await type(first, 'Haus');
+  await expect(suggestions(first, 'Haus')).toHaveCount(1, { timeout: TURN_MS });
+});
+
+test('with no tab in the foreground, the first one back takes the dictionary', async ({ context }) => {
+  const first = await openHome(context);
+  await type(first, 'Fenster');
+  await expect(suggestions(first, 'Fenster')).toHaveCount(FIXTURE_FENSTER_MATCHES, { timeout: TURN_MS });
+  const second = await openHome(context);
+
+  // The whole browser window goes behind something else: both tabs still
+  // visible, neither holding the keyboard. Nobody holds the pool and nobody
+  // needs it — a resting state, not a fault.
+  await blur(first);
+  await blur(second);
+  await nothingHappensFor(second, 500);
+
+  await focus(second);
+  await type(second, 'Hund');
+  await expect(suggestions(second, 'Hund')).toHaveCount(1, { timeout: TURN_MS });
+});
+
+// What this pins is the outcome, not the mechanism: a tab that was never in
+// front shows nothing, and shows something once it is. Which of the two guards
+// produced that — the startup value of `foreground`, or the
+// `if (!foreground) return` at the top of the lock callback — is not
+// observable from out here, and this test deliberately does not claim to say.
+//
+// Measured, because the distinction is tempting to assert and would be wrong:
+// a build that starts `foreground = true` and calls `acquire()` from `start()`
+// passes this too. Its lock request is granted a task later than the page's
+// first report is delivered, so the early return catches it. The contract
+// worth locking is the behaviour; nothing else in this file covers a tab that
+// boots out of the foreground at all.
+test('a tab that boots in the background has no dictionary until it is looked at', async ({ context }) => {
+  const page = await openHome(context, { hidden: true, focused: false });
+
+  await type(page, 'Fenster');
+  await nothingHappensFor(page, SILENCE_MS);
+  await expect(options(page)).toHaveCount(0);
+
+  await show(page);
+  await focus(page);
+  await expect(suggestions(page, 'Fenster')).toHaveCount(FIXTURE_FENSTER_MATCHES, { timeout: TURN_MS });
+});
+
+test('closing the tab that holds the dictionary releases it', async ({ context }) => {
+  const holder = await openHome(context);
+  await type(holder, 'Fenster');
+  await expect(suggestions(holder, 'Fenster')).toHaveCount(FIXTURE_FENSTER_MATCHES, { timeout: TURN_MS });
+
+  const successor = await openHome(context);
+  // Killed rather than backgrounded: no handler of ours runs, and the lock has
+  // to come back from the browser.
+  await holder.close();
+
+  await type(successor, 'Fenster');
+  await expect(suggestions(successor, 'Fenster')).toHaveCount(FIXTURE_FENSTER_MATCHES, { timeout: TURN_MS });
+});

--- a/test/client/db/sqlite_test.cljs
+++ b/test/client/db/sqlite_test.cljs
@@ -84,10 +84,10 @@
           (is (= "Missing required OPFS APIs." (ex-message err))))))))
 
 
-(deftest completions-are-queried-before-the-dictionary-is-ready
-  (async-testing "GH-351: the query goes out with no readiness message received, and its answer is used"
-    ;; Nothing has said "ready" and nothing here would have listened if it
-    ;; had: the query is sent regardless and the worker holds it.
+(deftest completions-are-queried-with-no-readiness-message
+  (async-testing "GH-351: the query goes out before anything says ready, and its answer is used"
+    ;; Nothing has said "ready" and nothing here would have gated on it: the
+    ;; worker answers with whatever it has, so the query is always sent.
     (let [{:keys [deliver! posted target]} (stub-worker)
           db     (sut/attach target)
           answer (dictionary/completions db "Hund")]
@@ -101,6 +101,33 @@
                :pos          "noun"
                :translations ["собака" "пёс"]}]
              (await answer))))))
+
+
+(deftest a-tab-without-the-dictionary-answers-no-completions
+  (async-testing "GH-351: no rows is an ordinary answer, not a rejection and not a wait"
+    (let [{:keys [deliver! target]} (stub-worker)
+          db     (sut/attach target)
+          answer (dictionary/completions db "Hund")]
+      (await (pending-work))
+      (deliver! {:id 1 :result []})
+      (is (= [] (await answer))))))
+
+
+(deftest ready-reports-whether-this-tab-has-the-dictionary
+  (async-testing "GH-351: a turn taken and given back, read through the port's predicate"
+    (let [{:keys [crash! deliver! target]} (stub-worker)
+          db (sut/attach target)]
+      (is (false? (dictionary/ready? db)) "nothing has said ready yet")
+      (deliver! {:type "ready"})
+      (is (true? (dictionary/ready? db)) "this tab took its turn")
+      (deliver! {:type "loading"})
+      (is (false? (dictionary/ready? db)) "and gave it back")
+      (deliver! {:type "ready"})
+      (deliver! {:message "Missing required OPFS APIs." :type "error"})
+      (is (false? (dictionary/ready? db)) "a context that could not open it has nothing")
+      (deliver! {:type "ready"})
+      (crash!)
+      (is (false? (dictionary/ready? db)) "and neither has a crashed worker"))))
 
 
 (deftest an-empty-prefix-asks-the-worker-nothing

--- a/test/client/db/sqlite_test.cljs
+++ b/test/client/db/sqlite_test.cljs
@@ -1,0 +1,111 @@
+(ns client.db.sqlite-test
+  "The page's half of the dictionary protocol, driven against a stub worker.
+   Node has no `Worker`, which is why `db.sqlite/attach` takes one instead of
+   making it."
+  (:require-macros
+   [client.support.test :refer [async-testing]])
+  (:require
+   [adapters.dictionary :as dictionary]
+   [cljs.test :refer-macros [deftest is]]
+   [db.sqlite :as sut]))
+
+
+(defn- stub-worker
+  "A message target with the two halves a test needs: `posted` collects what
+   the page sent, `deliver!` plays a message back from the worker."
+  []
+  (let [listeners (atom {})
+        posted    (atom [])
+        target    #js {:addEventListener
+                       (fn [event handler]
+                         (swap! listeners update event (fnil conj []) handler))
+                       :removeEventListener
+                       (fn [event handler]
+                         (swap! listeners update event (fn [hs] (vec (remove #{handler} hs)))))
+                       :postMessage
+                       (fn [msg]
+                         (swap! posted conj msg))}]
+    {:crash!   (fn []
+                 (doseq [handler (get @listeners "error")]
+                   (handler #js {})))
+     :deliver! (fn [message]
+                 (doseq [handler (get @listeners "message")]
+                   (handler #js {:data (clj->js message)})))
+     :posted   posted
+     :target   target}))
+
+
+(defn- pending-work
+  "A promise that settles after everything already queued. `completions` is an
+   async function, so its first statement runs a microtask deep and the query
+   it sends has not left yet when the caller gets the promise back."
+  []
+  (js/Promise. (fn [resolve] (js/setTimeout resolve 0))))
+
+
+(deftest lifecycle-messages-leave-the-request-protocol-alone
+  (async-testing "loading, phases, ready, error and a crash all pass through, and the answer still lands"
+    (let [{:keys [crash! deliver! target]} (stub-worker)
+          db     (sut/attach target)
+          answer (sut/exec db #js {:sql "SELECT 1"})]
+      ;; These carry no `id`, so the response matcher must ignore them rather
+      ;; than read `undefined` and resolve the wrong promise.
+      (deliver! {:type "loading"})
+      (deliver! {:durationMs 12 :phase "db-open" :status "ok" :type "phase"})
+      (deliver! {:type "ready"})
+      (deliver! {:message "Missing required OPFS APIs." :type "error"})
+      (crash!)
+      (deliver! {:id 1 :result [{:lemma "Hund"}]})
+      (is (= [{:lemma "Hund"}] (js->clj (await answer) :keywordize-keys true))))))
+
+
+(deftest exec-resolves-the-response-with-the-matching-id
+  (async-testing "an answer for another request is ignored, the matching one resolves"
+    (let [{:keys [deliver! posted target]} (stub-worker)
+          db     (sut/attach target)
+          answer (sut/exec db #js {:sql "SELECT 1"})]
+      (is (= 1 (count @posted)))
+      (is (= 1 (.-id (first @posted))))
+      (deliver! {:id 99 :result [{:wrong true}]})
+      (deliver! {:id 1 :result [{:lemma "Hund"}]})
+      (is (= [{:lemma "Hund"}] (js->clj (await answer) :keywordize-keys true))))))
+
+
+(deftest exec-rejects-when-the-worker-reports-an-error
+  (async-testing "the failure reaches the caller instead of an empty answer"
+    (let [{:keys [deliver! target]} (stub-worker)
+          db     (sut/attach target)
+          answer (sut/exec db #js {:sql "SELECT 1"})]
+      (deliver! {:error "Missing required OPFS APIs." :id 1})
+      (try
+        (await answer)
+        (is false "should have rejected")
+        (catch :default err
+          (is (= "Missing required OPFS APIs." (ex-message err))))))))
+
+
+(deftest completions-are-queried-before-the-dictionary-is-ready
+  (async-testing "GH-351: the query goes out with no readiness message received, and its answer is used"
+    ;; Nothing has said "ready" and nothing here would have listened if it
+    ;; had: the query is sent regardless and the worker holds it.
+    (let [{:keys [deliver! posted target]} (stub-worker)
+          db     (sut/attach target)
+          answer (dictionary/completions db "Hund")]
+      (await (pending-work))
+      (is (= 1 (count @posted))
+          "no readiness gate swallowed the query")
+      (deliver! {:id     1
+                 :result [{:has_exact 1 :lemma "Hund" :pos "noun" :translations "собака,пёс"}]})
+      (is (= [{:exact?       true
+               :lemma        "Hund"
+               :pos          "noun"
+               :translations ["собака" "пёс"]}]
+             (await answer))))))
+
+
+(deftest an-empty-prefix-asks-the-worker-nothing
+  (async-testing "an emptied input answers [] without a round trip"
+    (let [{:keys [posted target]} (stub-worker)
+          db (sut/attach target)]
+      (is (= [] (await (dictionary/completions db ""))))
+      (is (= [] @posted)))))

--- a/test/client/pages/home_test.cljs
+++ b/test/client/pages/home_test.cljs
@@ -55,8 +55,7 @@
   [completions-by-prefix]
   {:store        (atom {})
    :capabilities {:collections {:collections/active-id (fn [] nil)}
-                  :dictionary  {:dictionary/ready?      (fn [] true)
-                                :dictionary/completions (fn [prefix]
+                  :dictionary  {:dictionary/completions (fn [prefix]
                                                           (js/Promise.resolve
                                                            (get completions-by-prefix prefix [])))}}})
 


### PR DESCRIPTION
Closes #351.

## Defect

`sqlite3-worker.js` took the `sprecha-sqlite-opfs-sahpool` Web Lock with
`ifAvailable: true` and held it for the worker's life. One tab won; every other
tab was answered `{type: "error", code: "another-tab-open"}`, which the client
only logged — and release builds log nothing — so `completions` returned `[]`
and the suggestion list was silently empty.

## Not a SharedWorker

The issue proposed moving the owner into a `SharedWorker`. That was built first
and measured on Chrome 144:

| API inside `SharedWorkerGlobalScope` | value |
|---|---|
| `navigator.storage.getDirectory` | `function` |
| `FileSystemFileHandle` | `function` |
| `FileSystemFileHandle.prototype.createSyncAccessHandle` | `undefined` |
| `Worker` | `undefined` |
| `navigator.locks` | `object` |

`installOpfsSAHPoolVfs` fails there with `Missing required OPFS APIs`, and the
obvious repair — a shared worker spawning a dedicated worker to hold the pool —
is closed off by `Worker` being undefined. The pool is dedicated-worker
territory, one holder at a time. A backgrounded tab cannot hold it either:
Android freezes one whole about a minute after it leaves the screen — two tabs,
one query every 10 s, database behind the backgrounded one: 12 ms, 14, 17, 22,
31, 31, then nothing from 60 s on, 14 consecutive timeouts, no error and no
rejected promise.

## What this does instead

The dictionary belongs to the tab being typed into. A tab takes the
`sqlite-opfs-sahpool` lock (no `ifAvailable`) when it comes to the foreground,
opens the database, serves only itself, and closes and releases when it leaves.
One stretch of holding the lock is a *turn*; outside its turns a tab has no
database.

- Foreground is `visibilityState === "visible" && hasFocus()`, computed by the
  page and reported to the worker as one boolean. Visibility alone cannot pick
  between two tabs visible side by side.
- No tab-to-tab traffic at all: no shared owner, no channel, no query crossing
  a tab boundary. That is what makes the freeze irrelevant — the tab holding
  the database is one the system is not about to freeze.
- **A query asked without a turn is answered, not queued.** It comes back with
  an empty result — the same shape a real empty answer has — and is not
  replayed when the turn arrives; the next keystroke is what asks again. An
  open failure is still returned as an error, so a broken dictionary stays
  distinguishable from a word the dictionary does not have.
  The windows this gives up are ~14 ms to take the lock back and ~94 ms for a
  tab's first turn, against a 100 ms trailing suggest debounce and a keystroke
  every 120-180 ms, so a warm start has its turn before the query is sent. A
  cold start is the visible case: the dictionary is still downloading and those
  keystrokes get an empty list. Accepted for now rather than kept behind a
  queueing mechanism.
- `:dictionary/ready?` stays on the port as a reading, not a gate — an empty
  answer alone cannot say whether the prefix has no completions or this tab has
  no dictionary. #312 is what has to describe that to the user.
- Between turns the pool stays installed and paused: `unpauseVfs` 3-5 ms plus
  open 1-2 ms, against `installOpfsSAHPoolVfs` 13-27 ms plus a manifest fetch.
  The engine loads on a tab's first turn, not at boot.
- Gone: the `another-tab-open` error and its user-facing message. There is no
  losing tab left to describe.

ADR-0012 supersedes ADR-0002 in part (WASM cold start is no longer off the
critical path). OpenSpec change `dictionary-follows-focus` is archived in this
branch.

## Verified

- `test/browser/dictionary-focus.spec.js`, eight specs: the foreground tab has
  it and a background one does not; two visible tabs, the one with the keyboard
  gets it; a query asked while waiting comes back empty and is not replayed;
  the tab that leaves gives it back; focus flickering leaves the foreground tab
  working; no tab in front is a resting state and the first one back takes it;
  a tab that boots in the background has nothing until it is looked at; closing
  the holder releases it.
- The "not replayed" spec **fails on the queueing worker** — at the assertion
  that the arriving turn delivers no old answer — and passes here.
- Full browser suite 26/26 (desktop + mobile), node tests 191/191, including
  unit tests for the page protocol in `test/client/db/sqlite_test.cljs`: the
  query goes out with no readiness message, no rows is an ordinary answer, an
  error rejects, and `ready?` follows the turns.

## Not proven here

- Cold start on the full dictionary, and behaviour on a phone. The suite runs
  the ~28 KB fixture in headless Chrome on localhost, so the one window where
  an empty answer is visible to a user is not measured by any test.
- Playwright reproduces neither half of the foreground: every page reports
  `visible` and `hasFocus() === true`, `bringToFront()` changes neither, and
  `Emulation.setPageVisibilityOverride` is gone. Both halves are shimmed at the
  document and the real events dispatched, which drives the whole app path —
  but the Android freeze and real OS focus are covered by no test.
- Offline: the suite asserts nothing about the service worker.
  `/js/sqlite3-dictionary.js` is precached, but whether the SW intercepts a
  worker's `importScripts` was not measured — same exposure as the existing
  `importScripts("sqlite3.js")`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
