### PR TITLE
GH-355 let the Claude action push the fix it was asked for

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,41 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      # Write, not read: the agent is invoked to change the branch under review,
+      # and read-only access turns a request for a fix into a comment describing one.
+      contents: write
+      pull-requests: write
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          additional_permissions: |
+            actions: read

--- a/openspec/changes/archive/2026-08-16-claude-action-can-push-a-fix/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-16-claude-action-can-push-a-fix/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-with-adr
+created: 2026-08-16

--- a/openspec/changes/archive/2026-08-16-claude-action-can-push-a-fix/proposal.md
+++ b/openspec/changes/archive/2026-08-16-claude-action-can-push-a-fix/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+`/install-github-app` generated a Claude Code workflow whose job runs with `contents: read` and
+`pull-requests: read`. Mentioning `@claude` on a pull request therefore produces an answer and
+nothing else: the agent can read the diff and the CI results, but the branch it was asked to fix
+stays untouched, and the fix has to be copied out of a comment by hand. The workflow is not on
+`master` yet, so the permissions can be corrected before anyone relies on the read-only behaviour.
+
+## What Changes
+
+- Add `.github/workflows/claude.yml`, triggered by `@claude` in an issue body or title, an issue
+  comment, a pull request review, or a review comment.
+- Grant the job `contents: write` and `pull-requests: write` so it can commit to the branch under
+  review and update the pull request, instead of only reading them.
+- Keep `actions: read`, which is what lets the agent read CI results, and `id-token: write`, which
+  the action uses to authenticate.
+- Authenticate through the existing `CLAUDE_CODE_OAUTH_TOKEN` repository secret.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `repo-agent-infrastructure`: the repository already requires that the agent infrastructure its
+  own rules depend on is tracked. This adds the requirement that an agent invoked from GitHub is
+  granted the write access its task implies, so a review mention can end in a commit rather than a
+  comment describing one.
+
+## Impact
+
+- `.github/workflows/claude.yml` — new file, the only code touched.
+- Repository secret `CLAUDE_CODE_OAUTH_TOKEN` — already present, consumed by the workflow.
+- The delivery flow in `AGENTS.md` is unchanged: an agent triggered from GitHub pushes to the
+  branch of the pull request that invoked it and never to `master`, which stays protected.
+- Branch `add-claude-github-actions-1786896889717`, created by `/install-github-app` and linked to
+  no issue, is superseded by this change and is deleted with it.

--- a/openspec/changes/archive/2026-08-16-claude-action-can-push-a-fix/specs/repo-agent-infrastructure/spec.md
+++ b/openspec/changes/archive/2026-08-16-claude-action-can-push-a-fix/specs/repo-agent-infrastructure/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: An agent invoked from GitHub can commit what it was asked to fix
+
+The repository SHALL keep a workflow that runs the coding agent when it is mentioned on an issue
+or a pull request, and that workflow SHALL grant the agent write access to the repository contents
+and to pull requests, because the work it is invoked for is a change to the branch under review.
+Read-only access SHALL NOT be the granted level: it turns a request to fix something into a
+comment describing the fix, which a person then has to apply by hand.
+
+The write access SHALL reach the branch of the pull request that invoked the agent and no further;
+`master` stays protected and is changed only through a reviewed pull request, as it is for a human.
+
+The workflow SHALL authenticate through a repository secret and SHALL NOT carry a credential in
+its own text.
+
+#### Scenario: A review asks the agent for a fix
+
+- **WHEN** a comment on a pull request mentions the agent
+- **THEN** the job it starts holds write access to the repository contents and to pull requests
+- **AND** it can commit the fix to the branch under review instead of only describing it
+
+#### Scenario: The agent reads why the branch is failing
+
+- **WHEN** the agent is invoked on a pull request whose checks have run
+- **THEN** the job holds read access to Actions
+- **AND** the CI results are part of what it works from
+
+#### Scenario: The agent is not a way around review
+
+- **WHEN** the agent has pushed to the branch of the pull request that invoked it
+- **THEN** `master` is unchanged
+- **AND** the work reaches `master` only by that pull request being reviewed and merged
+
+#### Scenario: The workflow needs a credential
+
+- **WHEN** the workflow authenticates the agent
+- **THEN** it reads a repository secret
+- **AND** the workflow file itself contains no token

--- a/openspec/changes/archive/2026-08-16-claude-action-can-push-a-fix/tasks.md
+++ b/openspec/changes/archive/2026-08-16-claude-action-can-push-a-fix/tasks.md
@@ -1,0 +1,18 @@
+## 1. Workflow
+
+- [x] 1.1 Add `.github/workflows/claude.yml` with the `@claude` triggers on issues, issue
+      comments, pull request reviews and review comments
+- [x] 1.2 Grant the job `contents: write` and `pull-requests: write`, keeping `actions: read` and
+      `id-token: write`
+- [x] 1.3 Authenticate through the `CLAUDE_CODE_OAUTH_TOKEN` secret, with no token in the file
+
+## 2. Verification
+
+- [x] 2.1 Confirm the workflow parses as YAML and its permission block reads as intended
+- [x] 2.2 Confirm `CLAUDE_CODE_OAUTH_TOKEN` exists in the repository secrets
+- [x] 2.3 Confirm `master` is protected, so the granted write access cannot bypass review
+
+## 3. Closeout
+
+- [ ] 3.1 Delete the superseded branch `add-claude-github-actions-1786896889717`
+- [ ] 3.2 Archive the change and open the pull request

--- a/openspec/specs/repo-agent-infrastructure/spec.md
+++ b/openspec/specs/repo-agent-infrastructure/spec.md
@@ -168,3 +168,41 @@ or a failed lookup SHALL end in the normal permission flow rather than a refusal
 - **THEN** the call proceeds through the normal permission flow, because a guard that denies
   on its own error is a guard that gets removed
 
+### Requirement: An agent invoked from GitHub can commit what it was asked to fix
+
+The repository SHALL keep a workflow that runs the coding agent when it is mentioned on an issue
+or a pull request, and that workflow SHALL grant the agent write access to the repository contents
+and to pull requests, because the work it is invoked for is a change to the branch under review.
+Read-only access SHALL NOT be the granted level: it turns a request to fix something into a
+comment describing the fix, which a person then has to apply by hand.
+
+The write access SHALL reach the branch of the pull request that invoked the agent and no further;
+`master` stays protected and is changed only through a reviewed pull request, as it is for a human.
+
+The workflow SHALL authenticate through a repository secret and SHALL NOT carry a credential in
+its own text.
+
+#### Scenario: A review asks the agent for a fix
+
+- **WHEN** a comment on a pull request mentions the agent
+- **THEN** the job it starts holds write access to the repository contents and to pull requests
+- **AND** it can commit the fix to the branch under review instead of only describing it
+
+#### Scenario: The agent reads why the branch is failing
+
+- **WHEN** the agent is invoked on a pull request whose checks have run
+- **THEN** the job holds read access to Actions
+- **AND** the CI results are part of what it works from
+
+#### Scenario: The agent is not a way around review
+
+- **WHEN** the agent has pushed to the branch of the pull request that invoked it
+- **THEN** `master` is unchanged
+- **AND** the work reaches `master` only by that pull request being reviewed and merged
+
+#### Scenario: The workflow needs a credential
+
+- **WHEN** the workflow authenticates the agent
+- **THEN** it reads a repository secret
+- **AND** the workflow file itself contains no token
+


### PR DESCRIPTION
Closes #355.

`/install-github-app` generated `.github/workflows/claude.yml` with `contents: read` and `pull-requests: read`. A `@claude` mention could read the diff and the CI results and answer in a comment, but not commit to the branch it was asked to fix — the fix had to be copied out of a comment by hand. This lands the workflow with `contents: write` and `pull-requests: write` instead.

Against the generated file: those two permissions read to write, a comment recording why, and the trailing block of commented-out optional settings dropped. Everything else as generated. The superseded branch `add-claude-github-actions-1786896889717` is deleted with this.

Verified by reading configuration, not by triggering the action:

- YAML parses; the job's permissions are `contents: write`, `pull-requests: write`, `issues: read`, `id-token: write`, `actions: read`.
- No token in the file; it reads the `CLAUDE_CODE_OAUTH_TOKEN` secret, which exists.
- `master` is protected: three required status checks, strict, admins included, no force pushes, no deletions. So the token cannot push to `master`.

Not proven: nothing has been triggered from GitHub yet, so the write access is proven by configuration only. Separately, `master` carries no `required_pull_request_reviews`, so branch protection guarantees the checks and the pull request path, not a human approval — that part stays convention.