### PR TITLE
GH-359 scope the word list empty state to the filter

### DIFF
--- a/openspec/changes/archive/2026-08-17-scope-word-list-empty-state-to-filter/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-17-scope-word-list-empty-state-to-filter/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-with-adr
+created: 2026-08-17

--- a/openspec/changes/archive/2026-08-17-scope-word-list-empty-state-to-filter/proposal.md
+++ b/openspec/changes/archive/2026-08-17-scope-word-list-empty-state-to-filter/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+Searching the word list for something that is not there renders the first-run
+empty state: "Слов пока нет" plus an invitation to add a first word, with the
+header, search box and lesson button gone. The vocabulary is full — only the
+filter matched nothing — so the message is wrong and the query cannot be edited
+or cleared without leaving the page (#359).
+
+## What Changes
+
+- The word list distinguishes an empty vocabulary from a filter that matched
+  nothing, and says which one it is.
+- With a filter active, the header, search box and footer stay on screen, so the
+  query can be corrected or cleared in place.
+- The first-run state keeps its current look and CTA when the vocabulary really
+  is empty.
+- The decision is made in `pages.words.presenter` and reaches the view as ready
+  props; the view stops comparing `items`, `search` and emptiness itself.
+
+## Capabilities
+
+### New Capabilities
+
+- `vocabulary-list-empty-states`: what the word list shows when it has no rows to
+  render — first-run invitation versus filter-with-no-matches — and which page
+  chrome survives in each case.
+
+### Modified Capabilities
+
+None. No existing spec describes the word list screen.
+
+## Impact
+
+- `src/client/pages/words/presenter.cljs` — new empty-state props.
+- `src/client/pages/words/actions.cljs` — stores the presented props in state.
+- `src/client/pages/words/view.cljs` — consumes them; loses its own predicates.
+- `test/client/presenter/vocabulary_test.cljs` — cases for the three outcomes.
+- No data model, storage or backend change.

--- a/openspec/changes/archive/2026-08-17-scope-word-list-empty-state-to-filter/specs/vocabulary-list-empty-states/spec.md
+++ b/openspec/changes/archive/2026-08-17-scope-word-list-empty-state-to-filter/specs/vocabulary-list-empty-states/spec.md
@@ -1,0 +1,56 @@
+## ADDED Requirements
+
+### Requirement: An empty vocabulary shows the first-run invitation
+
+The word list SHALL show the first-run state when the vocabulary in the active
+scope holds no words at all: the text "Слов пока нет", the hint "Добавьте
+первое слово на главной странице" and a call-to-action leading to the home
+page. Header, search box and lesson footer SHALL stay hidden, since there is
+nothing to search or study.
+
+#### Scenario: Vocabulary holds no words
+
+- **WHEN** the word list is rendered with no words in the active scope and no search query
+- **THEN** the first-run text, hint and call-to-action are shown
+- **AND** no search box, header or lesson button is rendered
+
+### Requirement: A filter with no matches says so and keeps the search box
+
+The word list SHALL show a message scoped to the filter — "Ничего не найдено"
+with the hint "Попробуйте другой запрос" — when the vocabulary in the active
+scope holds words but the active search query matches none of them, and SHALL
+NOT claim the vocabulary is empty or offer the first-run call-to-action. The header,
+search box and lesson footer SHALL remain on screen, with the current query in
+the search box, so it can be edited or cleared in place.
+
+#### Scenario: Search matches nothing
+
+- **WHEN** the word list is rendered with words in the active scope and a search query that matches none of them
+- **THEN** "Ничего не найдено" and "Попробуйте другой запрос" are shown
+- **AND** the first-run text and call-to-action are absent
+- **AND** the search box is still rendered, holding the current query
+
+#### Scenario: Clearing the filter restores the list
+
+- **WHEN** the user clears a search query that matched nothing
+- **THEN** the list of words returns without a page reload
+
+### Requirement: The presenter decides which empty state applies
+
+The word list view SHALL NOT compute the distinction between an empty
+vocabulary and a filtered-out list. `pages.words.presenter` SHALL derive it from
+the row count in the active scope and the rows left after filtering, and SHALL
+hand the view ready props: the list rows, the empty-state text, hint and
+call-to-action, and whether the page chrome applies.
+
+#### Scenario: Matching rows leave no empty state
+
+- **WHEN** the presenter is given rows that survived the filter
+- **THEN** it returns those rows and no empty-state props
+
+#### Scenario: Presenter distinguishes the two empty cases
+
+- **WHEN** the presenter is given no rows and a scope total of zero
+- **THEN** it returns the first-run empty-state props
+- **WHEN** the presenter is given no rows and a non-zero scope total
+- **THEN** it returns the no-matches empty-state props

--- a/openspec/changes/archive/2026-08-17-scope-word-list-empty-state-to-filter/tasks.md
+++ b/openspec/changes/archive/2026-08-17-scope-word-list-empty-state-to-filter/tasks.md
@@ -1,0 +1,15 @@
+## 1. Presenter
+
+- [x] 1.1 Add the empty-state props to `pages.words.presenter`: rows plus first-run / no-matches text, hint and CTA, derived from the scope total and the filtered rows
+- [x] 1.2 Have `:action/show-words` store the presented props in state
+
+## 2. View
+
+- [x] 2.1 Render the word list from the ready props: no `empty?`, `seq` or search comparison left in `pages.words.view`
+- [x] 2.2 Keep header, search box and lesson footer on screen whenever the vocabulary is not empty
+
+## 3. Verification
+
+- [x] 3.1 Presenter unit tests for the three outcomes: empty vocabulary, filter with no matches, filter with matches
+- [x] 3.2 `npx shadow-cljs node-test` green
+- [x] 3.3 Browser check of both empty states with screenshots

--- a/openspec/specs/vocabulary-list-empty-states/spec.md
+++ b/openspec/specs/vocabulary-list-empty-states/spec.md
@@ -1,0 +1,60 @@
+# vocabulary-list-empty-states Specification
+
+## Purpose
+TBD - created by archiving change scope-word-list-empty-state-to-filter. Update Purpose after archive.
+## Requirements
+### Requirement: An empty vocabulary shows the first-run invitation
+
+The word list SHALL show the first-run state when the vocabulary in the active
+scope holds no words at all: the text "Слов пока нет", the hint "Добавьте
+первое слово на главной странице" and a call-to-action leading to the home
+page. Header, search box and lesson footer SHALL stay hidden, since there is
+nothing to search or study.
+
+#### Scenario: Vocabulary holds no words
+
+- **WHEN** the word list is rendered with no words in the active scope and no search query
+- **THEN** the first-run text, hint and call-to-action are shown
+- **AND** no search box, header or lesson button is rendered
+
+### Requirement: A filter with no matches says so and keeps the search box
+
+The word list SHALL show a message scoped to the filter — "Ничего не найдено"
+with the hint "Попробуйте другой запрос" — when the vocabulary in the active
+scope holds words but the active search query matches none of them, and SHALL
+NOT claim the vocabulary is empty or offer the first-run call-to-action. The header,
+search box and lesson footer SHALL remain on screen, with the current query in
+the search box, so it can be edited or cleared in place.
+
+#### Scenario: Search matches nothing
+
+- **WHEN** the word list is rendered with words in the active scope and a search query that matches none of them
+- **THEN** "Ничего не найдено" and "Попробуйте другой запрос" are shown
+- **AND** the first-run text and call-to-action are absent
+- **AND** the search box is still rendered, holding the current query
+
+#### Scenario: Clearing the filter restores the list
+
+- **WHEN** the user clears a search query that matched nothing
+- **THEN** the list of words returns without a page reload
+
+### Requirement: The presenter decides which empty state applies
+
+The word list view SHALL NOT compute the distinction between an empty
+vocabulary and a filtered-out list. `pages.words.presenter` SHALL derive it from
+the row count in the active scope and the rows left after filtering, and SHALL
+hand the view ready props: the list rows, the empty-state text, hint and
+call-to-action, and whether the page chrome applies.
+
+#### Scenario: Matching rows leave no empty state
+
+- **WHEN** the presenter is given rows that survived the filter
+- **THEN** it returns those rows and no empty-state props
+
+#### Scenario: Presenter distinguishes the two empty cases
+
+- **WHEN** the presenter is given no rows and a scope total of zero
+- **THEN** it returns the first-run empty-state props
+- **WHEN** the presenter is given no rows and a non-zero scope total
+- **THEN** it returns the no-matches empty-state props
+

--- a/src/client/pages/words/actions.cljs
+++ b/src/client/pages/words/actions.cljs
@@ -5,14 +5,12 @@
 
 
 (nxr/register-action! :action/show-words
-  (fn show-words [_ {:keys [words total search]}]
+  (fn show-words [_ words]
     [[:effect/save
-      {:page/current  :page/words
-       :page/load     [:effect/load-words]
-       :words/items   (presenter/word-list-props words)
-       :words/total   total
-       :words/search  search
-       :words/editing nil}]]))
+      (merge {:page/current  :page/words
+              :page/load     [:effect/load-words]
+              :words/editing nil}
+             (presenter/page-state words))]]))
 
 
 (nxr/register-action! :action/open-word-edit

--- a/src/client/pages/words/presenter.cljs
+++ b/src/client/pages/words/presenter.cljs
@@ -3,6 +3,18 @@
    [clojure.string :as str]))
 
 
+(def ^:private first-run-state
+  {:cta  "Добавить слово"
+   :hint "Добавьте первое слово на главной странице"
+   :text "Слов пока нет"})
+
+
+(def ^:private no-matches-state
+  {:cta  nil
+   :hint "Попробуйте другой запрос"
+   :text "Ничего не найдено"})
+
+
 (defn word-item-props
   [{id :_id kind :kind value :value translation :translation retention-level :retention-level}]
   {:id          id
@@ -18,3 +30,27 @@
 (defn word-list-props
   [words]
   (mapv word-item-props words))
+
+
+(defn empty-state
+  "Props for the placeholder shown instead of the word list, or nil when there
+   are rows to render. `total` counts the words in the active scope before the
+   search filter, so an empty vocabulary and a filter that matched nothing tell
+   apart here rather than in the view."
+  [words total]
+  (when (empty? words)
+    (if (pos? total)
+      no-matches-state
+      first-run-state)))
+
+
+(defn page-state
+  "State for the word list: the rows, the placeholder that replaces them, and
+   whether the page chrome — header, search box, lesson button — applies. An
+   empty vocabulary drops the chrome; an empty filter keeps it so the query
+   stays editable."
+  [{:keys [search total words]}]
+  {:words/empty-state (empty-state words total)
+   :words/items       (word-list-props words)
+   :words/search      (or search "")
+   :words/vocabulary? (pos? total)})

--- a/src/client/pages/words/view.cljs
+++ b/src/client/pages/words/view.cljs
@@ -85,23 +85,29 @@
       "Удалить"]]]])
 
 
+(defn- empty-state
+  [{:keys [cta hint text]}]
+  [:div.vocabulary__empty-state
+   [:p.vocabulary__empty-state-text text]
+   [:p.vocabulary__empty-state-hint hint]
+   (when cta
+     [:button.vocabulary__empty-state-cta
+      {:on {:click [[:action/go-to-home]]}}
+      cta])])
+
+
 (defn page
   [state]
-  (let [{:words/keys [items search editing]} state]
+  (let [{:words/keys [items search editing vocabulary?] placeholder :words/empty-state} state]
     [:div.vocabulary
      {:data-vk-overlay true}
      (when editing (edit-dialog editing))
-     (if (empty? items)
+     (if-not vocabulary?
        [:div.vocabulary__list
         [:ul.word-list
          {:id "word-list"}
          [:li.word-list__empty.word-list__empty--no-words
-          [:div.vocabulary__empty-state
-           [:p.vocabulary__empty-state-text "Слов пока нет"]
-           [:p.vocabulary__empty-state-hint "Добавьте первое слово на главной странице"]
-           [:button.vocabulary__empty-state-cta
-            {:on {:click [[:action/go-to-home]]}}
-            "Добавить слово"]]]]]
+          (empty-state placeholder)]]]
        (list
         [:header.vocabulary__header
          [:button.vocabulary__back
@@ -121,22 +127,14 @@
             :enterkeyhint   "search"
             :placeholder    "Поиск"
             :spellcheck     "false"
-            :default-value  (or search "")
+            :default-value  search
             :on             {:input [[:action/search-words [:event.target/value]]]}}]]]
         [:div.vocabulary__list
          [:ul.word-list
           {:id "word-list"}
-          (if (seq items)
-            (for [word items] (word-list-item word))
-            [:li.word-list__empty
-             [:div.vocabulary__empty-state
-              (if (and search (not= "" search))
-                (list
-                 [:p.vocabulary__empty-state-text "Ничего не найдено"]
-                 [:p.vocabulary__empty-state-hint "Попробуйте другой запрос"])
-                (list
-                 [:p.vocabulary__empty-state-text "Слов пока нет"]
-                 [:p.vocabulary__empty-state-hint "Добавьте первое слово на главной странице"]))]])]]
+          (if placeholder
+            [:li.word-list__empty (empty-state placeholder)]
+            (for [word items] (word-list-item word)))]]
         [:footer.vocabulary__footer.page-footer
          [:div.page-footer__action
           [:button.vocabulary__start.big-button.green-button

--- a/test/client/presenter/vocabulary_test.cljs
+++ b/test/client/presenter/vocabulary_test.cljs
@@ -41,3 +41,37 @@
           items (sut/word-list-props rows)]
       (is (= 2 (count items)))
       (is (= ["word-1" "word-2"] (mapv :id items))))))
+
+
+(def ^:private rows
+  [{:_id "word-1" :value "der Hund" :translation [{:lang "ru" :value "пёс"}] :retention-level 10}])
+
+
+(deftest an-empty-vocabulary-invites-a-first-word
+  (testing "no words in scope at all"
+    (let [props (sut/page-state {:search "" :total 0 :words []})]
+      (is (= "Слов пока нет" (:text (:words/empty-state props))))
+      (is (= "Добавить слово" (:cta (:words/empty-state props)))
+          "the first-run state keeps its call to action")
+      (is (false? (:words/vocabulary? props))
+          "the page chrome is dropped — nothing to search or study"))))
+
+
+(deftest a-filter-with-no-matches-does-not-claim-the-vocabulary-is-empty
+  (testing "words in scope, none of them matching"
+    (let [props (sut/page-state {:search "zzz" :total 1 :words []})]
+      (is (= "Ничего не найдено" (:text (:words/empty-state props))))
+      (is (= "Попробуйте другой запрос" (:hint (:words/empty-state props))))
+      (is (nil? (:cta (:words/empty-state props)))
+          "no invitation to add a first word")
+      (is (true? (:words/vocabulary? props))
+          "the search box stays, so the query can be edited or cleared")
+      (is (= "zzz" (:words/search props))))))
+
+
+(deftest a-filter-with-matches-leaves-no-empty-state
+  (testing "matching rows reach the view"
+    (let [props (sut/page-state {:search "Hund" :total 1 :words rows})]
+      (is (nil? (:words/empty-state props)))
+      (is (= ["word-1"] (mapv :id (:words/items props))))
+      (is (true? (:words/vocabulary? props))))))


### PR DESCRIPTION
Closes #359.

A search that matched nothing showed the first-run state — "Слов пока нет" plus the invitation to add a first word — and took the search box with it, so the query could not be corrected or cleared in place.

The view branched on `(empty? items)`, which cannot tell an empty vocabulary from a filtered-out list. `pages.words.presenter` now derives the distinction from the scope total (counted before the search filter) and hands the view ready props: rows, the placeholder text/hint/CTA, and whether the page chrome applies. The view no longer compares anything.

## Screenshots

| Vocabulary empty (first run) | Search with no matches |
|---|---|
| ![empty vocabulary](https://raw.githubusercontent.com/u473t8/learning-app/pr-assets/gh-359/empty-vocabulary.png) | ![no matches](https://raw.githubusercontent.com/u473t8/learning-app/pr-assets/gh-359/search-no-matches.png) |

## Verification

- Presenter unit tests for the three outcomes (empty vocabulary, filter with no matches, filter with matches); `node-test` green, 187 tests / 448 assertions.
- Browser check on the local stand with three test words: searching `zzz` shows "Ничего не найдено / Попробуйте другой запрос" with the search box holding the query, the header and the lesson button; clearing the query restores all three rows in the same document (no reload); deleting the last word falls back to the first-run state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HVVV5xTnjBng67ojifJqzV
