### PR TITLE
GH-362 carry completions' translations as a JSON array

### DIFF
--- a/openspec/changes/archive/2026-08-17-dictionary-completion-translation-elements/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-17-dictionary-completion-translation-elements/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-with-adr
+created: 2026-08-17

--- a/openspec/changes/archive/2026-08-17-dictionary-completion-translation-elements/design.md
+++ b/openspec/changes/archive/2026-08-17-dictionary-completion-translation-elements/design.md
@@ -1,0 +1,141 @@
+## Context
+
+`completions-sql` aggregates a lemma's translations with
+`GROUP_CONCAT(DISTINCT t.value ORDER BY t.rank ASC)` and the adapter splits the
+result on `,`. The default separator is also ordinary content: 1100 of 301 683
+translations contain a comma. Three translations of `indem` arrive as five
+fragments.
+
+The shape of this query is load-bearing. ADR-0002 puts the dictionary behind a
+worker, so every completion is one round trip; #179 rewrote the query so only ten
+surviving lemmas ever reach the translation lookup, which took a one-letter prefix
+from ~100 ms to ~25 ms. Any fix here touches exactly that lookup and must not
+trade the win back.
+
+In-force ADRs consulted: 0001, 0002 (dictionary in SQLite/OPFS behind a worker),
+0003, 0005, 0008 (`normalize-german` is a frozen id contract — untouched here),
+0011. None constrain the choice below beyond "the query stays in the worker".
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A translation containing any punctuation survives transport as one element.
+- The client stops splitting; it receives elements and passes them on.
+- The completion cost stays where #179 left it.
+
+**Non-Goals:**
+
+- The input path. What the user types is settled in #365; `domain/vocabulary.cljs`
+  and the add-word form are untouched here.
+- Rebuilding the dictionary file, changing its schema, or the build pipeline.
+- The `", "` join the home actions use to prefill the form field. That join is on
+  the input side of the boundary and belongs to #365.
+
+## Decisions
+
+**Decision: carry the translations as a JSON array (`json_group_array`).**
+
+```sql
+(SELECT json_group_array(DISTINCT t.value ORDER BY t.rank ASC)
+ FROM translations t
+ WHERE t.lemma_id = top.id) AS translations
+```
+
+The adapter parses it with `JSON.parse` and passes the elements on.
+
+Alternatives considered:
+
+1. *A different separator inline* — `GROUP_CONCAT(DISTINCT value, char(31))`.
+   Rejected: SQLite refuses it outright, *"DISTINCT aggregates must have exactly
+   one argument"*. A custom separator and `DISTINCT` cannot be combined.
+
+2. *A different separator via a subquery* — dedupe in an inner `SELECT`, then
+   `GROUP_CONCAT(v, char(31))`. Works, and `char(31)` appears zero times across
+   all 301 683 translations today. Rejected on two counts. It reserves a
+   character, and nothing in the build pipeline enforces that reservation, so the
+   claim has to be re-verified on every dictionary rebuild — an invariant held by
+   nobody. And it measured as the most expensive of the three: the dedupe subquery
+   costs +31 % on the aggregate against +8 % for JSON (below).
+
+3. *JSON array* — chosen. Structure travels as structure. There is no character
+   to reserve, so no invariant survives past this change and no rebuild can
+   silently break it. JSON1 is compiled into the vendored WASM build (3.53.1,
+   verified by running the query against the shipped dictionary).
+
+**Why measurement, not taste.** Two runs against the shipped 37 MB dictionary in
+the real environment — Chrome, the vendored SQLite 3.53.1 WASM, its own
+`opfs-sahpool` VFS, the dictionary imported into OPFS. Variants interleaved inside
+each repetition so drift hits all three equally; medians of 61 repetitions.
+
+| prefix | `GROUP_CONCAT` (before) | `char(31)` + subquery | `json_group_array` (after) |
+|--------|------------------------:|----------------------:|---------------------------:|
+| `f`    | 47.5 ms                 | 48.0 ms               | 45.4 ms                    |
+| `fe`   | 7.5 ms                  | 7.7 ms                | 7.6 ms                     |
+| `fen`  | 1.5 ms                  | 1.5 ms                | 1.6 ms                     |
+| `sch`  | 31.0 ms                 | 31.2 ms               | 30.7 ms                    |
+| `hau`  | 4.0 ms                  | 4.6 ms                | 4.4 ms                     |
+| `a`    | 83.2 ms                 | 78.9 ms               | 82.8 ms                    |
+
+End to end the three are indistinguishable: every difference is smaller than the
+run-to-run spread, and the sign is not stable between the two runs. That is the
+expected result — the aggregate runs for ten lemmas while the prefix range scan,
+identical in all three, dominates.
+
+Isolating the aggregate for a fixed set of ten lemma ids (batches of 200 execs,
+median of 25 batches) separates it from that noise:
+
+| variant | per call | vs before |
+|---------|---------:|----------:|
+| `GROUP_CONCAT` | 0.329 ms | — |
+| `char(31)` + subquery | 0.429 ms | +30 % |
+| `json_group_array` | 0.354 ms | +8 % |
+
++0.025 ms per completions call — 0.03 % of the `a` case. The #179 property is
+untouched, and the rejected alternative is the expensive one.
+
+**What the fix actually recovers.** The shipped SQL string, extracted from
+`adapters/dictionary.cljs` and run against the shipped dictionary through the real
+WASM build and OPFS pool, compared row for row against the old query decoded the
+old way. Over the prefixes `unt`, `eigentl` and `hos`: 23 rows, 19 byte-identical,
+0 reordered, 4 repaired.
+
+| lemma | before | after |
+|---|---|---|
+| `unten` | `внизу` / ` снизу` / `ниже` | `внизу, снизу` / `ниже` |
+| `eigentlich` | `действительный` / ` настоящий` / `собственный` | `действительный, настоящий` / `собственный` |
+| `die Hose` | `брюки` / `штаны` / `смерч ` / ` (небольшое) торнадо` | `брюки` / `штаны` / `смерч , (небольшое) торнадо` |
+| `unterhalten` | one blank translation | none |
+
+**Decision: the adapter stops splitting entirely.** `(str/split "" #",")` returns
+`[""]`, so a lemma with no translations produced one blank translation; a parsed
+`[]` produces none. The split also left a leading space on every fragment after
+the first, which nothing trimmed.
+
+## Risks / Trade-offs
+
+- **JSON1 missing from a future SQLite build** → the query fails at runtime rather
+  than degrading. Mitigated by the vendored build being pinned in `package.json`
+  and fetched by `npm run fetch-sqlite`; JSON1 has been compiled in by default
+  since 3.38.
+- **A malformed JSON value** → `JSON.parse` throws inside the completions promise.
+  Not reachable through `json_group_array`, which emits well-formed JSON by
+  construction; the values themselves are escaped by SQLite.
+- **The measured absolute numbers do not match #179's 20-27 ms for `f`.** They
+  were taken on different hardware and with a live app tab in the same browser.
+  Only the before/after within one run is comparable, and that is how the table
+  above is read.
+- **Downstream still re-joins.** The home actions prefill the form with
+  `(str/join ", " translations)`, and `parse-translations` splits that again on
+  `[,;.]`. This change makes the dictionary side honest; the round trip through
+  the form is #365's subject, and until it lands a comma-carrying translation is
+  still damaged after the user's edit — but no longer before it.
+
+## Migration Plan
+
+No data migration. The dictionary file, its schema and the manifest are unchanged,
+so old and new clients read the same artifact. Rollback is reverting the commit.
+
+## Open Questions
+
+None. No in-force ADR needs revisiting.

--- a/openspec/changes/archive/2026-08-17-dictionary-completion-translation-elements/proposal.md
+++ b/openspec/changes/archive/2026-08-17-dictionary-completion-translation-elements/proposal.md
@@ -1,0 +1,46 @@
+## Why
+
+The completions query joins a lemma's translations into one string with
+`GROUP_CONCAT`, and the client splits that string on `,`. The separator is
+indistinguishable from the content: 1100 of the dictionary's 301 683 translations
+contain a comma themselves — including frequent lemmas such as `ohne`,
+`eigentlich`, `unten` and `indem`. For `indem`, three translations arrive as five
+fragments, two of them the bare word ` что`.
+
+Transport, not input, is the defect: whatever the suggestion carries is what the
+add-word form prefills and what gets stored, so a fragment entered once is a
+fragment forever.
+
+## What Changes
+
+- The completions SQL returns each lemma's translations as a JSON array
+  (`json_group_array`) instead of a comma-joined string.
+- The dictionary adapter parses that array and passes the elements through. It
+  no longer splits anything.
+- A lemma with no translations yields an empty sequence, where the old split of
+  `""` yielded a one-element sequence containing the empty string.
+- Values arrive verbatim: no lost commas, no leading space left by the split.
+
+Not a breaking change for callers — `:translations` was already a sequence of
+strings and stays one.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `sqlite-dictionary-worker`: the completion result requirement gains an explicit
+  guarantee that a translation containing the separator survives transport intact,
+  and the existing cost requirement is restated so the fix cannot be traded for
+  the short-prefix regression #179 removed.
+
+## Impact
+
+- `src/client/adapters/dictionary.cljs` — the SQL and the row decoding.
+- Requires SQLite with JSON1; the vendored WASM build (3.53.1) has it.
+- No change to the dictionary file, its schema, or the build pipeline.
+- No change to `domain/vocabulary.cljs` or the add-word form; the input half is
+  settled separately in #365.

--- a/openspec/changes/archive/2026-08-17-dictionary-completion-translation-elements/specs/sqlite-dictionary-worker/spec.md
+++ b/openspec/changes/archive/2026-08-17-dictionary-completion-translation-elements/specs/sqlite-dictionary-worker/spec.md
@@ -1,36 +1,4 @@
-# sqlite-dictionary-worker Specification
-
-## Purpose
-TBD - created by archiving change replicant-nexus-migration. Update Purpose after archive.
-## Requirements
-### Requirement: Dictionary SQLite runs in a Dedicated Worker
-The system SHALL run the SQLite dictionary (`opfs-sahpool` VFS) inside a Dedicated Worker; the main thread SHALL NOT access SQLite synchronously.
-
-#### Scenario: Worker initialises on boot
-- **WHEN** the main thread boots
-- **THEN** it spawns the dictionary Dedicated Worker
-- **AND** the worker initialises official SQLite WASM and `opfs-sahpool`
-- **AND** it fetches `/dictionary/manifest`
-- **AND** if the local pool does not contain the current hash file, the worker fetches and imports it
-- **AND** it opens the dictionary database
-
-#### Scenario: Worker initialisation failure is non-fatal
-- **WHEN** the dictionary worker fails to initialise (e.g. network unavailable, OPFS quota)
-- **THEN** the error is logged
-- **AND** autocomplete does not block the UI
-
-### Requirement: Main thread queries the worker via postMessage RPC
-The system SHALL provide a worker proxy on the main thread that sends SQL exec messages to the worker and returns Promises resolved by matching request id.
-
-#### Scenario: Exec call over RPC
-- **WHEN** the dictionary repo needs completions for a prefix
-- **THEN** it sends a SQL `exec` request with a unique request id to the worker proxy
-- **AND** the Promise resolves when the worker posts the matching response
-
-#### Scenario: Completion before worker ready
-- **WHEN** the home suggest effect runs before the worker has finished initialising
-- **THEN** it does not issue the SQL request
-- **AND** no completion suggestions are written
+## MODIFIED Requirements
 
 ### Requirement: Worker completion result supports home autocomplete
 The system SHALL return completion rows that the home add-word form can render and use to prefill translation. Each row's translations SHALL be carried as discrete elements from the query to the caller, so that no character occurring inside a translation can change how many translations a lemma has. The client SHALL NOT split a completion's translations on any separator.
@@ -75,4 +43,3 @@ The completions SQL SHALL select the ten winning lemmas before joining translati
 - **WHEN** the translation aggregate is changed
 - **THEN** its cost is measured against the shipped dictionary on the prefixes `f`, `fe`, `fen`, `sch`, `hau` and `a`
 - **AND** the before and after figures are recorded with the change
-

--- a/openspec/changes/archive/2026-08-17-dictionary-completion-translation-elements/tasks.md
+++ b/openspec/changes/archive/2026-08-17-dictionary-completion-translation-elements/tasks.md
@@ -1,0 +1,15 @@
+## 1. Transport
+
+- [x] 1.1 Replace `GROUP_CONCAT(DISTINCT t.value ORDER BY t.rank ASC)` in `completions-sql` with `json_group_array(DISTINCT t.value ORDER BY t.rank ASC)`
+- [x] 1.2 Update the query's docstring: record why the separator was ambiguous and that the #179 shape is unchanged
+- [x] 1.3 Decode the JSON array in `adapters.dictionary/completions` and drop the `str/split`, including the now-unused `clojure.string` require
+
+## 2. Tests
+
+- [x] 2.1 Add a node test over the row-decoding step, covering a translation containing a comma, order preservation, and a lemma with no translations
+- [x] 2.2 Run `npx shadow-cljs compile node-test && node target/node-tests.js` and confirm the existing home suggestion tests still pass
+
+## 3. Verification
+
+- [x] 3.1 Run the new SQL against the shipped 37 MB dictionary in the real WASM/OPFS environment and diff old against new over whole result sets, confirming that only the damaged rows change
+- [x] 3.2 Measure medians over at least 21 repetitions for prefixes `f`, `fe`, `fen`, `sch`, `hau`, `a` before and after, and record them in `design.md`

--- a/src/client/adapters/dictionary.cljs
+++ b/src/client/adapters/dictionary.cljs
@@ -1,6 +1,5 @@
 (ns adapters.dictionary
   (:require
-   [clojure.string :as str]
    [db.sqlite :as sqlite]
    [utils :as utils]))
 
@@ -17,7 +16,16 @@
    for the surviving ten alone. The previous shape joined and GROUP_CONCATed
    every in-range lemma — thousands on a one-letter prefix — and discarded all
    but ten after sorting, which is why short prefixes cost ~100x more.
-   Measured in #179: prefix f 95-119 ms -> 20-27 ms."
+   Measured in #179: prefix f 95-119 ms -> 20-27 ms.
+
+   Translations travel as a JSON array, not a joined string. GROUP_CONCAT's
+   separator is also content: 1100 of the dictionary's translations contain a
+   comma, so splitting the join tore `тем, что` into `тем` and ` что` and gave
+   `indem` five translations where it has three. A reserved separator would work
+   only as long as nobody's rebuild introduces the character, and nothing
+   enforces that; an array has no separator to reserve. Measured against the
+   shipped dictionary in #362: the aggregate costs +0.025 ms per call, which is
+   0.03% of the one-letter prefix, and the #179 shape above is untouched."
   "WITH top AS (
      SELECT l.id, l.value, l.pos, l.rank
      FROM (SELECT DISTINCT lemma_id
@@ -35,7 +43,7 @@
      EXISTS (SELECT 1
              FROM surface_forms sf
              WHERE sf.normalized_form = ? AND sf.lemma_id = top.id) AS has_exact,
-     (SELECT GROUP_CONCAT(DISTINCT t.value ORDER BY t.rank ASC)
+     (SELECT json_group_array(DISTINCT t.value ORDER BY t.rank ASC)
       FROM translations t
       WHERE t.lemma_id = top.id) AS translations
    FROM top
@@ -47,8 +55,20 @@
   (sqlite/ready? db))
 
 
+(defn- completion
+  "One completion map from a result row. Translations arrive as the JSON array
+   built by completions-sql, so they are read as elements and passed on — a
+   translation carrying a comma stays one translation, and a lemma with none
+   gets none rather than a blank."
+  [{:keys [has_exact lemma pos translations]}]
+  {:exact?       (pos? has_exact)
+   :lemma        lemma
+   :pos          pos
+   :translations (js->clj (js/JSON.parse (or translations "[]")))})
+
+
 (defn ^:async completions
-  "Returns a vec of completion maps {:lemma :translations :exact? :pos} from SQLite."
+  "Returns a sequence of completion maps {:lemma :translations :exact? :pos} from SQLite."
   [db prefix]
   (if (ready? db)
     (let [prefix-start (utils/normalize-german (or prefix ""))]
@@ -64,9 +84,5 @@
                                              :rowMode     "object"}))
                           :keywordize-keys
                           true)]
-          (for [{:keys [lemma translations has_exact pos]} rows]
-            {:lemma        lemma
-             :pos          pos
-             :translations (str/split (or translations "") #",")
-             :exact?       (pos? has_exact)}))))
+          (map completion rows))))
     []))

--- a/test/client/adapters/dictionary_test.cljs
+++ b/test/client/adapters/dictionary_test.cljs
@@ -1,0 +1,106 @@
+(ns client.adapters.dictionary-test
+  "Completion rows carry translations as elements (GH-362). The dictionary
+   used to hand back one GROUP_CONCAT string and the adapter split it on `,`,
+   which tore every translation that contains a comma — 1100 of them — into
+   pieces. The query now emits a JSON array and the adapter reads elements."
+  (:require-macros
+   [client.support.test :refer [async-testing]])
+  (:require
+   [adapters.dictionary :as sut]
+   [cljs.test :refer-macros [deftest is]]))
+
+
+(defn- stub-db
+  "A dictionary db whose worker answers every exec with `rows`, recording the
+   exec options it was handed in `calls`."
+  [rows calls]
+  {:proxy #js {:exec (fn [opts]
+                       (swap! calls conj opts)
+                       (js/Promise.resolve (clj->js rows)))}
+   :state (atom {:ready? true})})
+
+
+(defn- row
+  [lemma translations]
+  {"lemma"        lemma
+   "pos"          "noun"
+   "has_exact"    1
+   "translations" (js/JSON.stringify (clj->js translations))})
+
+
+(deftest a-translation-containing-a-comma-stays-one-translation
+  (async-testing "a comma inside a translation does not split it"
+    (let [rows   [(row "indem" ["тем, что" "благодаря тому, что" "в то время как"])]
+          result (await (sut/completions (stub-db rows (atom [])) "indem"))]
+      (is (= [["тем, что" "благодаря тому, что" "в то время как"]]
+             (mapv :translations result))
+          "three stored translations stay three, character for character"))))
+
+
+(deftest translation-order-follows-the-query
+  (async-testing "translations keep the order the query returned them in"
+    (let [rows   [(row "Fenster" ["окно" "витрина" "форточка"])]
+          result (await (sut/completions (stub-db rows (atom [])) "fenster"))]
+      (is (= ["окно" "витрина" "форточка"]
+             (:translations (first result)))))))
+
+
+(deftest a-lemma-without-translations-gets-none
+  (async-testing "an empty array yields no translations, not one blank one"
+    (let [rows   [(row "Hund" [])]
+          result (await (sut/completions (stub-db rows (atom [])) "hund"))]
+      (is (= [] (:translations (first result)))))))
+
+
+(deftest a-missing-translations-column-gets-none
+  (async-testing "a null translations cell yields no translations"
+    (let [rows   [{"lemma" "Hund" "pos" "noun" "has_exact" 0 "translations" nil}]
+          result (await (sut/completions (stub-db rows (atom [])) "hund"))]
+      (is (= [] (:translations (first result)))))))
+
+
+(deftest a-completion-carries-lemma-pos-and-exactness
+  (async-testing "the rest of the row survives the rewrite"
+    (let [rows   [{"lemma"        "Haus"
+                   "pos"          "noun"
+                   "has_exact"    1
+                   "translations" "[\"дом\"]"}
+                  {"lemma"        "Hausaufgabe"
+                   "pos"          "noun"
+                   "has_exact"    0
+                   "translations" "[\"домашнее задание\"]"}]
+          result (await (sut/completions (stub-db rows (atom [])) "haus"))]
+      (is (= [{:exact? true :lemma "Haus" :pos "noun" :translations ["дом"]}
+              {:exact?       false
+               :lemma        "Hausaufgabe"
+               :pos          "noun"
+               :translations ["домашнее задание"]}]
+             (vec result))))))
+
+
+(deftest a-prefix-matching-nothing-yields-nothing
+  (async-testing "no matching lemmas means no completions"
+    (is (= [] (vec (await (sut/completions (stub-db [] (atom [])) "xyzq")))))))
+
+
+(deftest the-prefix-range-is-bound-normalized
+  (async-testing "the umlaut prefix is normalized and bounded before binding"
+    (let [calls (atom [])]
+      (await (sut/completions (stub-db [] calls) "Über"))
+      (is (= ["ueber" "ueberz" "ueber"]
+             (vec (.-bind ^js (first @calls))))))))
+
+
+(deftest a-blank-prefix-asks-nothing
+  (async-testing "a blank prefix never reaches the worker"
+    (let [calls (atom [])]
+      (is (= [] (await (sut/completions (stub-db [] calls) "   "))))
+      (is (= [] @calls)))))
+
+
+(deftest an-unready-dictionary-asks-nothing
+  (async-testing "an unready dictionary answers empty without an exec"
+    (let [calls (atom [])
+          db    (assoc (stub-db [] calls) :state (atom {:ready? false}))]
+      (is (= [] (await (sut/completions db "hund"))))
+      (is (= [] @calls)))))


### PR DESCRIPTION
Closes #362.

## The defect

`completions-sql` joined a lemma's translations with `GROUP_CONCAT` and the client split the result on `,`. The separator is also content — 1100 of 301 683 translations contain a comma — so every one of them was torn into pieces, and a lemma with no translations got one blank.

Diffing the old query decoded the old way against the new one, over whole result sets from the shipped dictionary:

| lemma | before | after |
|---|---|---|
| `unten` | `внизу` / ` снизу` / `ниже` | `внизу, снизу` / `ниже` |
| `eigentlich` | `действительный` / ` настоящий` / `собственный` | `действительный, настоящий` / `собственный` |
| `die Hose` | `брюки` / `штаны` / `смерч ` / ` (небольшое) торнадо` | `брюки` / `штаны` / `смерч , (небольшое) торнадо` |
| `unterhalten` | one blank translation | none |

23 rows compared: 19 byte-identical, 0 reordered, 4 repaired.

## Why `json_group_array`

`GROUP_CONCAT(DISTINCT value, char(31))` does not compile — *"DISTINCT aggregates must have exactly one argument"*. That leaves a separator plus a dedupe subquery, or a JSON array.

The separator variant needs a character reserved forever. `char(31)` is free across all 301 683 translations today, but nothing in the build pipeline enforces that, so the claim has to be re-verified on every rebuild by somebody who remembers to. A JSON array has no separator, so there is no invariant to keep. It also measured cheaper than the subquery.

## Cost

#179 fixed this query's shape so only ten surviving lemmas reach the translation lookup. That is exactly the part this change touches, so it was re-measured: shipped 37 MB dictionary, the vendored SQLite 3.53.1 WASM build, its own `opfs-sahpool` VFS in a real browser, variants interleaved inside each repetition, medians of 61.

| prefix | `GROUP_CONCAT` (before) | `char(31)` + subquery | `json_group_array` (after) |
|--------|------------------------:|----------------------:|---------------------------:|
| `f`    | 47.5 ms | 48.0 ms | 45.4 ms |
| `fe`   | 7.5 ms  | 7.7 ms  | 7.6 ms  |
| `fen`  | 1.5 ms  | 1.5 ms  | 1.6 ms  |
| `sch`  | 31.0 ms | 31.2 ms | 30.7 ms |
| `hau`  | 4.0 ms  | 4.6 ms  | 4.4 ms  |
| `a`    | 83.2 ms | 78.9 ms | 82.8 ms |

End to end the three are indistinguishable — every difference is smaller than the run-to-run spread and its sign is not stable between runs, because the prefix range scan dominates and is identical in all three.

Isolating the aggregate for a fixed set of ten lemma ids (batches of 200 execs, median of 25 batches) separates it from that noise:

| variant | per call | vs before |
|---------|---------:|----------:|
| `GROUP_CONCAT` | 0.329 ms | — |
| `char(31)` + subquery | 0.429 ms | +30 % |
| `json_group_array` | 0.354 ms | +8 % |

+0.025 ms per completions call, 0.03 % of the one-letter prefix. The rejected alternative is the expensive one.

The absolute figures are higher than #179's 20-27 ms for `f` — different hardware, and a live app tab in the same browser. Only the before/after within one run is comparable.

## Not in scope

The input half. The home form still prefills with `(str/join ", " translations)` and `parse-translations` splits that again on `[,;.]`; that round trip is #365's subject. This change makes the dictionary side honest so #365 has something intact to store.

## Verification

- `npx shadow-cljs compile node-test` — 193 tests, 448 assertions, 0 failures. New `test/client/adapters/dictionary_test.cljs` covers the comma case, order, the empty lemma, a null cell, prefix normalization, and the two paths that never reach the worker. Confirmed the suite fails when an expectation is flipped, so the async assertions really run.
- The shipped SQL string, extracted from the source, run against the shipped dictionary through the real WASM build and OPFS pool — the table above.

Not verified: no browser click-through of the add-word form, and no measurement on the owner's phone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HVVV5xTnjBng67ojifJqzV