### PR TITLE
GH-365 keep a translation exactly as it was typed

### DIFF
--- a/openspec/changes/archive/2026-08-17-keep-typed-translation-whole/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-17-keep-typed-translation-whole/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-with-adr
+created: 2026-08-17

--- a/openspec/changes/archive/2026-08-17-keep-typed-translation-whole/proposal.md
+++ b/openspec/changes/archive/2026-08-17-keep-typed-translation-whole/proposal.md
@@ -1,0 +1,66 @@
+## Why
+
+A translation entered on the home add-word form is split on `[,;.]` before it is stored
+(`domain/vocabulary.cljs`, `parse-translations`), so the separator lives inside the data:
+`без того, чтобы` becomes two translations, and so does any aspect pair written with a dot.
+
+The split buys nothing. Grading compares the typed answer against the German `:answer`
+(`domain/lesson.cljs`, `vocab->trial`), never against the elements; display glues the vector
+back together with the same separator it was cut on. The elements are read for one thing —
+deduplication in `merge-translations` when the same word is added again. The string is cut on
+a comma so it can be joined by a comma again, and the only observable effect is that
+translations containing a comma are destroyed. Phrases already store their translation whole
+(`domain/phrase.cljs`), so words are the outlier.
+
+## What Changes
+
+- `parse-translations` keeps the entered text as one translation entry. A blank entry still
+  yields no translations, so the `:empty-translations` guard in `use-cases/vocabulary` holds.
+- The translation field accepts several lines. `Ctrl`/`Cmd`+`Enter` submits; bare `Enter`
+  inserts a newline. The submit button stays and remains the only path on a phone, where
+  neither modifier can be typed.
+- The dictionary prefill hands over the stored text rather than re-spacing it: both
+  `str/join ", "` sites in `pages/home/actions.cljs` trim the pieces the transport's split
+  left, so a stored `без того, чтобы` reaches the field as it is stored instead of gaining a
+  second space, while several translations still read as `пёс, собака`.
+- The word edit dialog's translation field becomes a `textarea` like the phrase one: an
+  `input` silently swallows the line breaks a multi-line translation carries.
+- A stored line break is shown as one: `white-space: pre-line` on the word list's translation
+  and on the lesson prompt.
+- `Enter` on the German word input is untouched — it picks the highlighted suggestion or moves
+  to the translation field (`handler-word-keydown`).
+- The document schema does not change: `:translation` stays a vector, normally holding one
+  element, and existing documents are read as they are. `update-word` shares
+  `parse-translations`, so editing follows the same rule.
+
+Given up knowingly: deduplication on re-adding a word compares whole strings instead of
+variants inside them. If a drill that accepts any one of the translations appears, or a display
+that shows them one at a time, the elements have to be recovered. Neither exists today.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `data-model`: a word's `translation` entries are whole strings, never split on punctuation —
+  the rule phrases already carry, now stated for every vocabulary document.
+- `home-add-form-focus`: the translation field's key contract — bare `Enter` inserts a newline,
+  `Ctrl`/`Cmd`+`Enter` submits, the button submits — and the prefill handing over the stored
+  text unaltered.
+
+## Impact
+
+- `src/client/domain/vocabulary.cljs` — `parse-translations`.
+- `src/client/pages/home/actions.cljs` — `:action/submit-if-enter` gives way to the shared
+  `:action/submit-if-ctrl-enter`; both prefill joins.
+- `src/client/application.cljs` — `:event.keyboard/meta?` placeholder;
+  `:action/submit-if-ctrl-enter` accepts `Cmd` and prevents the default.
+- `src/client/pages/home/view.cljs` — the translation textarea's keydown wiring.
+- `src/client/pages/words/view.cljs` — the edit dialog's translation field.
+- `resources/public/css/blocks/` — `word-edit-dialog.css`, `word-item.css`, `lesson.css`.
+- Inherited by the edit path: `use-cases/vocabulary.cljs` `update!` for word documents.
+- Tests: `test/client/domain/vocabulary_test.cljs`, `test/client/pages/home_test.cljs`.
+- Not in scope: #362, the dictionary transport that does the splitting at the source.

--- a/openspec/changes/archive/2026-08-17-keep-typed-translation-whole/specs/data-model/spec.md
+++ b/openspec/changes/archive/2026-08-17-keep-typed-translation-whole/specs/data-model/spec.md
@@ -1,0 +1,40 @@
+## MODIFIED Requirements
+
+### Requirement: Vocabulary documents are stored
+The system SHALL store vocabulary documents with translations and ISO 8601 timestamps for creation and modification. A translation SHALL be stored as it was entered: the entered text becomes one `translation` entry and SHALL NOT be split on punctuation. `translation` stays a vector, so a document written before this rule keeps its several entries and is read as it is.
+
+#### Scenario: Vocabulary document shape
+- **WHEN** a vocabulary word is stored
+- **THEN** the document includes `type`, `value`, `translation`, `created-at`, and `modified-at`
+
+Example:
+```json
+{
+  "type": "vocab",
+  "value": "der Hund",
+  "translation": [{"lang": "en", "value": "dog"}],
+  "created-at": "2026-01-20T10:00:00.000Z",
+  "modified-at": "2026-01-20T10:10:00.000Z"
+}
+```
+
+#### Scenario: A translation containing punctuation stays whole
+- **WHEN** a word is added with the translation `без того, чтобы`
+- **THEN** its `translation` holds one entry whose value is `без того, чтобы`
+- **AND** the same holds for a translation containing `;`, `.` or `/`
+
+#### Scenario: A translation spanning several lines stays whole
+- **WHEN** a word is added with a translation typed over several lines
+- **THEN** its `translation` holds one entry carrying the line breaks as typed
+
+#### Scenario: An edited translation follows the same rule
+- **WHEN** an existing word document's translation is replaced with `без того, чтобы`
+- **THEN** its `translation` holds one entry whose value is `без того, чтобы`
+
+#### Scenario: A blank translation stores nothing
+- **WHEN** a word is submitted with a translation that is empty or only whitespace
+- **THEN** no translation entry is produced and the add is rejected as empty
+
+#### Scenario: Documents written before the rule are read unchanged
+- **WHEN** a stored word document holds several `translation` entries
+- **THEN** it is read as it is, with no migration and no merging of its entries

--- a/openspec/changes/archive/2026-08-17-keep-typed-translation-whole/specs/home-add-form-focus/spec.md
+++ b/openspec/changes/archive/2026-08-17-keep-typed-translation-whole/specs/home-add-form-focus/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: The translation field takes several lines and submits on a modifier
+The translation field SHALL accept a multi-line translation. A bare `Enter` SHALL insert a newline and SHALL NOT submit the form; `Ctrl`+`Enter` or `Cmd`+`Enter` SHALL submit it. The submit button SHALL keep submitting the form, since it is the only path on a phone, where neither modifier can be typed. `Enter` on the German word input keeps its own meaning and SHALL NOT be affected.
+
+#### Scenario: Enter inserts a newline
+- **WHEN** the translation field has focus
+- **AND** the user presses `Enter` with no modifier
+- **THEN** the form is not submitted
+- **AND** the field takes a newline
+
+#### Scenario: Ctrl+Enter submits
+- **WHEN** the translation field has focus
+- **AND** the user presses `Enter` while `Ctrl` is held
+- **THEN** the form is submitted
+- **AND** the keystroke's default action is suppressed, so the form is submitted once
+
+#### Scenario: Cmd+Enter submits
+- **WHEN** the translation field has focus
+- **AND** the user presses `Enter` while `Cmd` (meta) is held
+- **THEN** the form is submitted
+
+#### Scenario: The button submits without a keyboard
+- **WHEN** the user activates the add button
+- **THEN** the form is submitted, whatever the translation field holds
+
+#### Scenario: The German input keeps its Enter
+- **WHEN** the German word input has focus
+- **AND** the user presses `Enter`
+- **THEN** the existing behaviour applies — the highlighted suggestion is picked, or the form submits when there is none
+
+### Requirement: The prefilled translation is the dictionary's text as stored
+When the dictionary fills the translation field — on a suggestion arriving for an untouched field, or on the user picking a suggestion — the field SHALL receive the dictionary's translation text as the dictionary holds it. The transport splits a lemma's translations on `,` and leaves the following space on the next piece, so the form SHALL trim the pieces before rejoining them on `, `. What the field shows is what gets stored, so the reconstruction SHALL neither drop nor double a space.
+
+#### Scenario: A stored translation containing a comma is prefilled whole
+- **WHEN** the dictionary's translation for a lemma is `без того, чтобы`
+- **AND** that lemma's suggestion fills the translation field
+- **THEN** the field holds `без того, чтобы`, with no doubled space after the comma
+
+#### Scenario: Several translations stay readable
+- **WHEN** a lemma has the translations `пёс` and `собака`
+- **THEN** the field holds `пёс, собака`
+
+#### Scenario: Picking a suggestion fills the same text
+- **WHEN** the user picks a suggestion from the list
+- **THEN** the translation field receives that entry's translation text by the same rule

--- a/openspec/changes/archive/2026-08-17-keep-typed-translation-whole/tasks.md
+++ b/openspec/changes/archive/2026-08-17-keep-typed-translation-whole/tasks.md
@@ -1,0 +1,36 @@
+## 1. Keep the entered text whole
+
+- [x] 1.1 `domain/vocabulary.cljs`: `parse-translations` returns one entry holding the trimmed
+  entered text, and nothing for blank input.
+- [x] 1.2 Cover it in `test/client/domain/vocabulary_test.cljs`: a comma, a semicolon, a dot and
+  a slash survive; several lines survive; blank yields no entries; `update-word` inherits the
+  rule.
+
+## 2. Keys on the translation field
+
+- [x] 2.1 `application.cljs`: add the `:event.keyboard/meta?` placeholder and let
+  `:action/submit-if-ctrl-enter` accept `Cmd` as well as `Ctrl`, suppressing the default so the
+  form submits once.
+- [x] 2.2 `pages/home/actions.cljs`: drop `:action/submit-if-enter`.
+- [x] 2.3 `pages/home/view.cljs`: wire the translation textarea's keydown to
+  `:action/submit-if-ctrl-enter` with `key`, `ctrl?` and `meta?`. Leave the German input alone.
+
+## 3. Prefill hands over the stored text
+
+- [x] 3.1 `pages/home/actions.cljs`: both prefill sites trim the pieces the transport's split
+  left before rejoining them, so the dictionary's text arrives as it is stored.
+- [x] 3.2 Add a `test/client/pages/home_test.cljs` case for a stored translation containing a
+  comma.
+
+## 3a. A line break survives the round trip
+
+- [x] 3a.1 `pages/words/view.cljs`: the edit dialog's translation field becomes a `textarea`
+  for words too, with the same `Ctrl`/`Cmd`+`Enter` submit; an `input` swallows line breaks.
+- [x] 3a.2 CSS: `--multiline` carries the autogrow rules the phrase modifier used to hold, and
+  `white-space: pre-line` on the word list's translation and the lesson prompt.
+
+## 4. Verify
+
+- [x] 4.1 `npx shadow-cljs compile node-test && node target/node-tests.js` green.
+- [x] 4.2 In a real browser: `Enter` in the translation field inserts a newline,
+  `Ctrl`+`Enter` submits, the button submits, and a translation with a comma is stored whole.

--- a/openspec/specs/data-model/spec.md
+++ b/openspec/specs/data-model/spec.md
@@ -2,7 +2,7 @@
 The data model spec defines the required document shapes stored in the local database.
 ## Requirements
 ### Requirement: Vocabulary documents are stored
-The system SHALL store vocabulary documents with translations and ISO 8601 timestamps for creation and modification.
+The system SHALL store vocabulary documents with translations and ISO 8601 timestamps for creation and modification. A translation SHALL be stored as it was entered: the entered text becomes one `translation` entry and SHALL NOT be split on punctuation. `translation` stays a vector, so a document written before this rule keeps its several entries and is read as it is.
 
 #### Scenario: Vocabulary document shape
 - **WHEN** a vocabulary word is stored
@@ -18,6 +18,27 @@ Example:
   "modified-at": "2026-01-20T10:10:00.000Z"
 }
 ```
+
+#### Scenario: A translation containing punctuation stays whole
+- **WHEN** a word is added with the translation `без того, чтобы`
+- **THEN** its `translation` holds one entry whose value is `без того, чтобы`
+- **AND** the same holds for a translation containing `;`, `.` or `/`
+
+#### Scenario: A translation spanning several lines stays whole
+- **WHEN** a word is added with a translation typed over several lines
+- **THEN** its `translation` holds one entry carrying the line breaks as typed
+
+#### Scenario: An edited translation follows the same rule
+- **WHEN** an existing word document's translation is replaced with `без того, чтобы`
+- **THEN** its `translation` holds one entry whose value is `без того, чтобы`
+
+#### Scenario: A blank translation stores nothing
+- **WHEN** a word is submitted with a translation that is empty or only whitespace
+- **THEN** no translation entry is produced and the add is rejected as empty
+
+#### Scenario: Documents written before the rule are read unchanged
+- **WHEN** a stored word document holds several `translation` entries
+- **THEN** it is read as it is, with no migration and no merging of its entries
 
 ### Requirement: A vocabulary document carries its kind
 The system SHALL store phrases as vocabulary documents: `type` `"vocab"`, the content-addressed `_id` of ADR-0008 (`vocab:` plus the normalized value, spaces preserved), and `kind` `"phrase"`. A document without `kind` SHALL be read as a word, so documents written before phrases existed need no migration. A phrase's `value` SHALL have its whitespace collapsed and its `translation` entries SHALL be whole strings, never split on punctuation. Review documents SHALL reference phrases through the existing `word-id` field.
@@ -213,3 +234,4 @@ storage layer's default result limit.
 
 - **WHEN** a migration runs against a source database that holds no documents
 - **THEN** it completes without error and copies nothing
+

--- a/openspec/specs/home-add-form-focus/spec.md
+++ b/openspec/specs/home-add-form-focus/spec.md
@@ -96,3 +96,48 @@ Suggestions SHALL appear within ~150 ms of a typing pause, and continuous typing
 - **WHEN** keystrokes arrive faster than the debounce
 - **THEN** lookups coalesce and the visible list never blanks between answers
 
+### Requirement: The translation field takes several lines and submits on a modifier
+The translation field SHALL accept a multi-line translation. A bare `Enter` SHALL insert a newline and SHALL NOT submit the form; `Ctrl`+`Enter` or `Cmd`+`Enter` SHALL submit it. The submit button SHALL keep submitting the form, since it is the only path on a phone, where neither modifier can be typed. `Enter` on the German word input keeps its own meaning and SHALL NOT be affected.
+
+#### Scenario: Enter inserts a newline
+- **WHEN** the translation field has focus
+- **AND** the user presses `Enter` with no modifier
+- **THEN** the form is not submitted
+- **AND** the field takes a newline
+
+#### Scenario: Ctrl+Enter submits
+- **WHEN** the translation field has focus
+- **AND** the user presses `Enter` while `Ctrl` is held
+- **THEN** the form is submitted
+- **AND** the keystroke's default action is suppressed, so the form is submitted once
+
+#### Scenario: Cmd+Enter submits
+- **WHEN** the translation field has focus
+- **AND** the user presses `Enter` while `Cmd` (meta) is held
+- **THEN** the form is submitted
+
+#### Scenario: The button submits without a keyboard
+- **WHEN** the user activates the add button
+- **THEN** the form is submitted, whatever the translation field holds
+
+#### Scenario: The German input keeps its Enter
+- **WHEN** the German word input has focus
+- **AND** the user presses `Enter`
+- **THEN** the existing behaviour applies — the highlighted suggestion is picked, or the form submits when there is none
+
+### Requirement: The prefilled translation is the dictionary's text as stored
+When the dictionary fills the translation field — on a suggestion arriving for an untouched field, or on the user picking a suggestion — the field SHALL receive the dictionary's translation text as the dictionary holds it. The transport splits a lemma's translations on `,` and leaves the following space on the next piece, so the form SHALL trim the pieces before rejoining them on `, `. What the field shows is what gets stored, so the reconstruction SHALL neither drop nor double a space.
+
+#### Scenario: A stored translation containing a comma is prefilled whole
+- **WHEN** the dictionary's translation for a lemma is `без того, чтобы`
+- **AND** that lemma's suggestion fills the translation field
+- **THEN** the field holds `без того, чтобы`, with no doubled space after the comma
+
+#### Scenario: Several translations stay readable
+- **WHEN** a lemma has the translations `пёс` and `собака`
+- **THEN** the field holds `пёс, собака`
+
+#### Scenario: Picking a suggestion fills the same text
+- **WHEN** the user picks a suggestion from the list
+- **THEN** the translation field receives that entry's translation text by the same rule
+

--- a/resources/public/css/blocks/lesson.css
+++ b/resources/public/css/blocks/lesson.css
@@ -151,6 +151,9 @@
   line-height: var(--text-body-line-height-spacious);
   margin: 12px 0;
   padding: 0.625rem 0.875rem;
+  /* The prompt is the translation as it was typed, line breaks included
+     (GH-365). */
+  white-space: pre-line;
   width: fit-content;
 }
 

--- a/resources/public/css/blocks/word-edit-dialog.css
+++ b/resources/public/css/blocks/word-edit-dialog.css
@@ -55,7 +55,7 @@
   display: none;
 }
 
-.word-edit-dialog__input--phrase {
+.word-edit-dialog__input--multiline {
   box-sizing: border-box;
   field-sizing: content;
   height: auto;
@@ -63,6 +63,9 @@
   min-height: 48px;
   overflow-y: auto;
   resize: none;
+}
+
+.word-edit-dialog__input--phrase {
   width: 100%;
 }
 

--- a/resources/public/css/blocks/word-item.css
+++ b/resources/public/css/blocks/word-item.css
@@ -49,6 +49,9 @@
 .word-item__translation {
   color: rgb(var(--color-wolf));
   font-size: 15px;
+  /* A translation is stored as it was typed, line breaks included (GH-365).
+     `pre-line` keeps them and still collapses the runs of spaces HTML would. */
+  white-space: pre-line;
 }
 
 .word-item__arrow {

--- a/src/client/application.cljs
+++ b/src/client/application.cljs
@@ -236,6 +236,11 @@
     (some-> (:replicant/dom-event dispatch-data) .-ctrlKey)))
 
 
+(nxr/register-placeholder! :event.keyboard/meta?
+  (fn [dispatch-data]
+    (some-> (:replicant/dom-event dispatch-data) .-metaKey)))
+
+
 (nxr/register-placeholder! :event.keyboard/shift?
   (fn [dispatch-data]
     (some-> (:replicant/dom-event dispatch-data) .-shiftKey)))
@@ -247,10 +252,15 @@
       (= (.-target e) (.-currentTarget e)))))
 
 
+;; The modifier is what tells a submit from a newline in a multi-line field, so
+;; `Cmd` counts too — it is the one a Mac keyboard offers. The default is
+;; suppressed because a browser that submits on `Ctrl`+`Enter` by itself would
+;; submit the form twice.
 (nxr/register-action! :action/submit-if-ctrl-enter
-  (fn submit-if-ctrl-enter [_ {:keys [key ctrl?]}]
-    (when (and (= "Enter" key) ctrl?)
-      [[:effect/request-submit]])))
+  (fn submit-if-ctrl-enter [_ {:keys [key ctrl? meta?]}]
+    (when (and (= "Enter" key) (or ctrl? meta?))
+      [[:effect/prevent-default]
+       [:effect/request-submit]])))
 
 
 (nxr/register-action! :action/open-sync-menu

--- a/src/client/domain/vocabulary.cljs
+++ b/src/client/domain/vocabulary.cljs
@@ -10,11 +10,17 @@
 
 
 (defn parse-translations
+  "The entered text is one translation. It used to be split on `[,;.]`, which put
+   the separator inside the data — `без того, чтобы` became two translations —
+   while nothing read the pieces: grading compares against the German value and
+   display glued them back with the separator they were cut on. Phrases never
+   split; words no longer do either. Still a vector, so documents written before
+   this are read as they are."
   [s]
-  (->> (str/split (str s) #"[,;.]")
-       (map str/trim)
-       (remove str/blank?)
-       (mapv (fn [v] {:lang "ru" :value v}))))
+  (let [value (str/trim (str s))]
+    (if (str/blank? value)
+      []
+      [{:lang "ru" :value value}])))
 
 
 (defn merge-translations

--- a/src/client/pages/home/actions.cljs
+++ b/src/client/pages/home/actions.cljs
@@ -8,6 +8,21 @@
 (def ^:private empty-suggestions nil)
 
 
+(defn- prefill-text
+  "The text a completion puts into the translation field. The dictionary hands
+   its translations over as one `GROUP_CONCAT` string that the adapter splits on
+   `,` (#362), which leaves the space after the comma on the next piece. Trimming
+   before rejoining gives the stored text back: `без того, чтобы` arrives whole
+   instead of as `без того,  чтобы`, and several translations still read as
+   `пёс, собака`. It matters more than it used to — whatever the field holds is
+   now stored as one translation, so what is shown here is what is saved."
+  [translations]
+  (->> translations
+       (map str/trim)
+       (remove str/blank?)
+       (str/join ", ")))
+
+
 (nxr/register-action! :action/go-to-home
   (fn go-to-home [_]
     [[:effect/navigate :page/home]]))
@@ -82,7 +97,7 @@
         [[:effect/save
           (cond-> {:home/suggestions (suggestions completions)}
             (not (:home/translation-typed? state))
-            (assoc :home/translation (str/join ", " translations)))]]))))
+            (assoc :home/translation (prefill-text translations)))]]))))
 
 
 (nxr/register-action! :action/show-word-error
@@ -109,13 +124,6 @@
         (and (str/blank? value) (not (:home/translation-typed? state)))
         (assoc :home/translation ""))]
      [:effect/suggest-completions value]]))
-
-
-(nxr/register-action! :action/submit-if-enter
-  (fn submit-if-enter [_ {:keys [key shift?]}]
-    (when (and (= "Enter" key) (not shift?))
-      [[:effect/prevent-default]
-       [:effect/request-submit]])))
 
 
 (nxr/register-action! :action/update-translation
@@ -155,7 +163,7 @@
                            :phrase
                            :word)
      :home/suggestions   empty-suggestions
-     :home/translation   (str/join ", " translations)
+     :home/translation   (prefill-text translations)
      ;; A deliberate pick owns the field: later dictionary answers must not
      ;; overwrite what the user chose.
      :home/translation-typed? true
@@ -190,7 +198,9 @@
          [:effect/save {:home/suggestions empty-suggestions}]]
 
         ;; No suggestions on screen: Enter moves on to the translation field —
-        ;; the phrase flow's typing rhythm (phrase, Enter, translation, Enter).
+        ;; the phrase flow's typing rhythm (phrase, Enter, translation, and
+        ;; then Ctrl/Cmd+Enter or the button, since Enter belongs to the text
+        ;; in a field that takes several lines).
         (and (zero? n) (= key "Enter"))
         [[:effect/prevent-default]
          [:effect/focus focus-id]]))))

--- a/src/client/pages/home/view.cljs
+++ b/src/client/pages/home/view.cljs
@@ -87,9 +87,13 @@
           :on           {:focus   [[:effect/autogrow-target]]
                          :input   [[:action/update-translation [:event.target/value]]
                                    [:effect/autogrow-target]]
-                         :keydown [[:action/submit-if-enter
-                                    {:key    [:event.keyboard/key]
-                                     :shift? [:event.keyboard/shift?]}]]}}]]]
+                         ;; A translation may span several lines, so a bare
+                         ;; Enter belongs to the text. Submitting takes a
+                         ;; modifier — or the button, the only path on a phone.
+                         :keydown [[:action/submit-if-ctrl-enter
+                                    {:key   [:event.keyboard/key]
+                                     :ctrl? [:event.keyboard/ctrl?]
+                                     :meta? [:event.keyboard/meta?]}]]}}]]]
       [:button.home__add-form-submit.big-button.big-button--request-stable
        {:type "submit"} "ДОБАВИТЬ"]]]))
 

--- a/src/client/pages/words/view.cljs
+++ b/src/client/pages/words/view.cljs
@@ -45,34 +45,30 @@
      {:class (when phrase? "word-edit-dialog__inputs--phrase")}
      [:span.word-edit-dialog__value {:lang "de"} value]
      [:span.word-edit-dialog__arrow {:aria-hidden "true"} "→"]
-     (if phrase?
-       [:textarea.word-edit-dialog__input.word-edit-dialog__input--phrase
-        {:name         "translation"
-         :rows         2
-         :autocapitalize "none"
-         :autocomplete "off"
-         :autocorrect  "off"
-         :enterkeyhint "done"
-         :lang         "ru"
-         :placeholder  "Перевод"
-         :spellcheck   "false"
-         :autofocus    true
-         :replicant/on-mount [[:action/move-cursor-to-end]]
-         :on           {:input [[:effect/autogrow-target]]}}
-        ;; textarea ignores a value attribute — the default rides as child text
-        translation]
-       [:input.word-edit-dialog__input
-        {:name           "translation"
-         :autocapitalize "none"
-         :autocomplete   "off"
-         :autocorrect    "off"
-         :enterkeyhint   "done"
-         :lang           "ru"
-         :placeholder    "Перевод"
-         :spellcheck     "false"
-         :default-value  translation
-         :autofocus      true
-         :replicant/on-mount [[:action/move-cursor-to-end]]}])]
+     ;; A textarea for both kinds: a word's translation may span several lines
+     ;; too (GH-365), and an `input` silently swallows the line breaks it is
+     ;; given. Enter therefore belongs to the text here — Ctrl/Cmd+Enter and
+     ;; the save button submit, as on the add form.
+     [:textarea.word-edit-dialog__input.word-edit-dialog__input--multiline
+      {:name         "translation"
+       :rows         (if phrase? 2 1)
+       :class        (when phrase? "word-edit-dialog__input--phrase")
+       :autocapitalize "none"
+       :autocomplete "off"
+       :autocorrect  "off"
+       :enterkeyhint "done"
+       :lang         "ru"
+       :placeholder  "Перевод"
+       :spellcheck   "false"
+       :autofocus    true
+       :replicant/on-mount [[:action/move-cursor-to-end]]
+       :on           {:input   [[:effect/autogrow-target]]
+                      :keydown [[:action/submit-if-ctrl-enter
+                                 {:key   [:event.keyboard/key]
+                                  :ctrl? [:event.keyboard/ctrl?]
+                                  :meta? [:event.keyboard/meta?]}]]}}
+      ;; textarea ignores a value attribute — the default rides as child text
+      translation]]
     [:div.word-edit-dialog__actions
      [:button.word-edit-dialog__save {:type "submit"} "Сохранить"]
      [:button.word-edit-dialog__cancel

--- a/test/client/domain/vocabulary_test.cljs
+++ b/test/client/domain/vocabulary_test.cljs
@@ -21,6 +21,44 @@
       (is (= "лиса" (-> updated :translation first :value))))))
 
 
+(deftest a-translation-is-kept-as-it-was-typed
+  (testing "punctuation belongs to the translation, not to a separator (GH-365)"
+    (is (= [{:lang "ru" :value "без того, чтобы"}]
+           (sut/parse-translations "без того, чтобы")))
+    (is (= [{:lang "ru" :value "хотя..,но.."}]
+           (sut/parse-translations "хотя..,но..")))
+    (is (= [{:lang "ru" :value "решать; решить"}]
+           (sut/parse-translations "решать; решить")))
+    (is (= [{:lang "ru" :value "и/или"}]
+           (sut/parse-translations "и/или"))))
+  (testing "several lines are one translation"
+    (is (= [{:lang "ru" :value "пёс\nсобака"}]
+           (sut/parse-translations "пёс\nсобака"))))
+  (testing "surrounding whitespace is dropped"
+    (is (= [{:lang "ru" :value "пёс"}]
+           (sut/parse-translations "  пёс  "))))
+  (testing "nothing typed is no translation, so the add form can refuse it"
+    (is (= [] (sut/parse-translations "")))
+    (is (= [] (sut/parse-translations "   ")))
+    (is (= [] (sut/parse-translations nil)))))
+
+
+(deftest editing-keeps-the-translation-as-it-was-typed
+  (testing "the edit path shares parse-translations, so it inherits the rule"
+    (let [word    (sut/new-word "ohne" [{:lang "ru" :value "без"}])
+          updated (sut/update-word word "без того, чтобы")]
+      (is (= [{:lang "ru" :value "без того, чтобы"}] (:translation updated))))))
+
+
+(deftest a-word-written-before-the-rule-is-read-as-it-is
+  (testing "several stored entries survive a merge untouched — no migration"
+    (let [stored [{:lang "ru" :value "пёс"} {:lang "ru" :value "собака"}]]
+      (is (= [{:lang "ru" :value "пёс"}
+              {:lang "ru" :value "собака"}
+              {:lang "ru" :value "пёс, собака"}]
+             (sut/merge-translations stored (sut/parse-translations "пёс, собака")))))))
+
+
 (deftest new-review-doc-creates-review-document
   (testing "user reviews a word"
     (let [review (sut/new-review "word-1" true "пёс")]

--- a/test/client/pages/home_test.cljs
+++ b/test/client/pages/home_test.cljs
@@ -49,6 +49,12 @@
   {:lemma "Hut" :translations ["шляпа"] :exact? true})
 
 
+(def ohne
+  "One stored translation, `без того, чтобы`, as the transport delivers it —
+   `GROUP_CONCAT`ed and split back on `,` by the adapter (#362)."
+  {:lemma "ohne" :translations ["без того" " чтобы"] :exact? true})
+
+
 (defn- test-system
   "System whose stub dictionary answers from `completions-by-prefix`;
    unknown prefixes (including the empty one) answer [], like the adapter."
@@ -190,6 +196,21 @@
       (nxr/dispatch system {} [[:action/update-suggestions {:completions [hund] :value "auf"}]])
       (is (nil? (suggestion-items store)))
       (is (nil? (:home/translation @store))))))
+
+
+(deftest a-prefill-hands-over-the-stored-text
+  (async-testing "the form invents no separator: what it shows is stored as one translation (GH-365)"
+    (let [{:keys [store] :as system} (test-system {"ohne" [ohne]})]
+      (nxr/dispatch system {} [[:action/update-word "ohne"]])
+      (await (debounce-elapsed))
+      (is (= "без того, чтобы" (:home/translation @store))))))
+
+
+(deftest a-picked-suggestion-hands-over-the-stored-text
+  (testing "picking the entry fills the field with the same text"
+    (let [{:keys [store] :as system} (test-system {})]
+      (nxr/dispatch system {} [[:action/select-suggestion (assoc ohne :focus-id nil)]])
+      (is (= "без того, чтобы" (:home/translation @store))))))
 
 
 (deftest an-empty-answer-leaves-the-translation-blank


### PR DESCRIPTION
Closes #365.

`parse-translations` split the entered text on `[,;.]`, so `без того, чтобы` became two
translations. Nothing read the pieces — grading compares the typed answer against the German
`:answer`, display glued them back with the same separator — so the split's only observable
effect was the damage. Phrases already stored their translation whole; words now do too.

## What changed

- `parse-translations` keeps the entered text as one entry; blank still yields none, so the
  `:empty-translations` guard holds. `update-word` shares it, so editing follows the same rule.
- The translation field takes several lines. `Enter` inserts a newline; `Ctrl`/`Cmd`+`Enter`
  submits, through the shared `:action/submit-if-ctrl-enter` (now `Cmd`-aware and
  default-suppressing, so no browser can submit twice). The button is untouched and stays the
  only path on a phone. `Enter` on the German input keeps its own meaning.
- The dictionary prefill trims the pieces the transport's split left before rejoining them:
  a stored `без того, чтобы` no longer gains a second space, and `пёс, собака` still reads as
  `пёс, собака`. #362 removes the split at the source.
- The word edit dialog's translation field becomes a `textarea` like the phrase one — an
  `input` silently swallows the line breaks it is handed, which would have thrown away a
  multi-line translation on the next save. Its autogrow rules moved from the `--phrase`
  modifier to a `--multiline` one that both kinds carry.
- `white-space: pre-line` on the word-list translation and the lesson prompt, so a stored line
  break is shown as one.

The document schema does not change: `:translation` stays a vector, normally holding one
element, and documents written before this are read as they are.

## Given up knowingly

Deduplication on re-adding a word compares whole strings instead of variants inside them. If a
drill that accepts any one of the translations appears, or a display that shows them one at a
time, the elements have to be recovered. Neither exists today.

## Verified

Node tests green (`npx shadow-cljs compile node-test`). New cases: a comma, `;`, `.` and `/`
survive; several lines survive; blank yields no entries; the edit path inherits the rule; a
document with several stored entries is left alone; the prefill reconstructs
`без того, чтобы`.

In a real browser, against a build of this branch served on a scratch backend, driven through
CDP with real key events:

| Checked | Result |
|---|---|
| `Enter` in the translation field | inserts a newline, form not submitted (submit count 0) |
| `Ctrl`+`Enter` | submits exactly once |
| `Cmd`+`Enter` | submits exactly once |
| `ДОБАВИТЬ` button | submits |
| `Enter` on the German input | still moves focus to the translation field |
| Stored document | one entry, `без того, чтобы\nвторой вариант` — comma and newline intact |
| `первый; второй. третий/четвёртый` | stored as one entry |
| Edit dialog | opens as a `textarea` holding both lines; `Ctrl`+`Enter` saves; the saved entry keeps its comma |
| Phrase edit dialog | unchanged geometry after the CSS split (column, full width, `field-sizing: content`, 48–144 px) |

![add form](https://raw.githubusercontent.com/u473t8/learning-app/pr-assets/gh-365/add-form-multiline.jpg)
![word list](https://raw.githubusercontent.com/u473t8/learning-app/pr-assets/gh-365/word-list.jpg)
![edit dialog](https://raw.githubusercontent.com/u473t8/learning-app/pr-assets/gh-365/edit-dialog.jpg)

## Not proven

- A real phone. The mobile path — `Enter` inserting a newline on a soft keyboard, the button
  being the only way to submit — was checked only in a desktop browser at a 412×800 mobile
  viewport, not on hardware.
- Safari. `field-sizing: content` and the autogrow effect were exercised in Chrome only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HVVV5xTnjBng67ojifJqzV
