### PR TITLE
GH-358 scope the picked mode to the picked lemma

### DIFF
--- a/openspec/changes/archive/2026-08-17-rescope-pick-mode-override/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-17-rescope-pick-mode-override/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-with-adr
+created: 2026-08-17

--- a/openspec/changes/archive/2026-08-17-rescope-pick-mode-override/proposal.md
+++ b/openspec/changes/archive/2026-08-17-rescope-pick-mode-override/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+Picking a suggestion sets a mode override that nothing ever clears, so typing on
+from the picked lemma keeps the form in the mode the pick chose: `das`, pick
+`das Haus`, append ` ist gross`, and a phrase is saved as a word (GH-358).
+
+The override cannot simply be dropped — it is what makes `das heißt` a phrase,
+which the space heuristic reads as an article pair — so it has to be scoped
+instead of removed.
+
+## What Changes
+
+- A pick's mode applies only while the entered value still is the lemma that was
+  picked. Edit the value and the heuristic decides again.
+- Sameness is the vocabulary identity already in use: normalized value. Case,
+  punctuation and surrounding whitespace do not revoke a pick, because they do
+  not make a different entry — `vocab-id` folds them the same way.
+- `add-mode` therefore takes the pick as value plus mode instead of a bare mode
+  keyword; `:home/mode-override` holds `{:mode _ :value _}`.
+- No new control and no other source of override: the form still has no manual
+  mode switch, so a pick is the only thing that can override the heuristic.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `user-phrases`: the automatic mode detection requirement gains the scope of a
+  pick — the picked mode holds for the picked lemma, and editing the value
+  re-runs the detection.
+
+## Impact
+
+- `src/client/domain/phrase.cljs` — `add-mode` signature and rule.
+- `src/client/pages/home/actions.cljs` — `select-item` records the picked value;
+  `:action/add-word` reads the pick.
+- `src/client/pages/home/presenter.cljs` — passes the pick through.
+- `test/client/domain/phrase_test.cljs` — override tests.

--- a/openspec/changes/archive/2026-08-17-rescope-pick-mode-override/specs/user-phrases/spec.md
+++ b/openspec/changes/archive/2026-08-17-rescope-pick-mode-override/specs/user-phrases/spec.md
@@ -1,0 +1,29 @@
+## MODIFIED Requirements
+
+### Requirement: Phrases are added from the home form with automatic mode detection
+The home add form SHALL detect whether the input is a word or a phrase without a manual toggle. When an already-fetched completion is the input itself, its pos SHALL decide: `phrase` selects phrase mode, anything else word mode. Otherwise input containing a space (after trim) SHALL be treated as a phrase, EXCEPT when it is an article (der/die/das/ein/eine) or `sich` followed by a single token. Selecting an autocomplete suggestion SHALL set the mode from the suggestion: multi-word pos=phrase suggestions select phrase mode, all others word mode. A selected suggestion's mode SHALL hold only while the entered value is still the selected lemma, compared by the normalization that gives a vocabulary document its id; once the value differs, detection SHALL decide again. The form SHALL offer no control over the mode: the panel legend and the field label are what state it, and a selection is the only thing that can override detection. A multi-word noun is entered as a word by typing it with its article, as the dictionary lists it.
+
+#### Scenario: Space switches to phrase mode
+- **WHEN** the user types "auf jeden Fall" into the German field
+- **THEN** the form enters phrase mode, and the legend and the field label say so
+- **AND** open suggestions are cleared and stale async completion responses do not prefill the translation
+
+#### Scenario: Article plus noun stays a word
+- **WHEN** the user types "der Tisch" or "sich freuen"
+- **THEN** the form stays in word mode and autocomplete keeps working
+
+#### Scenario: An article decides a multi-word noun
+- **WHEN** the user types "das Tiny House"
+- **THEN** the form stays in word mode, which is how a multi-word noun is entered
+
+#### Scenario: Typing on from a selected word switches to phrase mode
+- **WHEN** the user selects the suggestion "das Haus" and then appends " ist gross"
+- **THEN** the form enters phrase mode and the entry is saved as a phrase
+
+#### Scenario: A selected phrase lemma survives until it is edited
+- **WHEN** the user selects the pos=phrase suggestion "das heißt" and submits it unchanged
+- **THEN** the form is in phrase mode, although the value alone reads as an article pair
+
+#### Scenario: Mode flip preserves input
+- **WHEN** the detected mode changes while the user is typing
+- **THEN** the entered German text and translation are preserved (inputs are not remounted)

--- a/openspec/changes/archive/2026-08-17-rescope-pick-mode-override/tasks.md
+++ b/openspec/changes/archive/2026-08-17-rescope-pick-mode-override/tasks.md
@@ -1,0 +1,14 @@
+## 1. Domain
+
+- [x] 1.1 `add-mode` honours the pick only while the normalized value equals the picked lemma
+- [x] 1.2 Unit tests: pick held on the picked value, dropped after an edit, `das heißt` still a phrase, no pick at all unchanged
+
+## 2. Home page
+
+- [x] 2.1 `select-item` records the picked lemma alongside the mode
+- [x] 2.2 Presenter and `:action/add-word` pass the pick through unchanged
+
+## 3. Verification
+
+- [x] 3.1 `npx shadow-cljs compile node-test` — 188 tests, 445 assertions, 0 failures
+- [x] 3.2 Browser: `test/browser/picked-suggestion-mode.spec.js` types `Haus`, picks `das Haus`, appends ` ist gross`, and the panel title turns into "Добавить фразу"

--- a/openspec/specs/user-phrases/spec.md
+++ b/openspec/specs/user-phrases/spec.md
@@ -5,7 +5,7 @@ User phrases are multi-word German expressions a user authors and learns as a un
 ## Requirements
 
 ### Requirement: Phrases are added from the home form with automatic mode detection
-The home add form SHALL detect whether the input is a word or a phrase without a manual toggle. When an already-fetched completion is the input itself, its pos SHALL decide: `phrase` selects phrase mode, anything else word mode. Otherwise input containing a space (after trim) SHALL be treated as a phrase, EXCEPT when it is an article (der/die/das/ein/eine) or `sich` followed by a single token. Selecting an autocomplete suggestion SHALL set the mode from the suggestion: multi-word pos=phrase suggestions select phrase mode, all others word mode. The form SHALL offer no control over the mode: the panel legend and the field label are what state it. A multi-word noun is entered as a word by typing it with its article, as the dictionary lists it.
+The home add form SHALL detect whether the input is a word or a phrase without a manual toggle. When an already-fetched completion is the input itself, its pos SHALL decide: `phrase` selects phrase mode, anything else word mode. Otherwise input containing a space (after trim) SHALL be treated as a phrase, EXCEPT when it is an article (der/die/das/ein/eine) or `sich` followed by a single token. Selecting an autocomplete suggestion SHALL set the mode from the suggestion: multi-word pos=phrase suggestions select phrase mode, all others word mode. A selected suggestion's mode SHALL hold only while the entered value is still the selected lemma, compared by the normalization that gives a vocabulary document its id; once the value differs, detection SHALL decide again. The form SHALL offer no control over the mode: the panel legend and the field label are what state it, and a selection is the only thing that can override detection. A multi-word noun is entered as a word by typing it with its article, as the dictionary lists it.
 
 #### Scenario: Space switches to phrase mode
 - **WHEN** the user types "auf jeden Fall" into the German field
@@ -19,6 +19,14 @@ The home add form SHALL detect whether the input is a word or a phrase without a
 #### Scenario: An article decides a multi-word noun
 - **WHEN** the user types "das Tiny House"
 - **THEN** the form stays in word mode, which is how a multi-word noun is entered
+
+#### Scenario: Typing on from a selected word switches to phrase mode
+- **WHEN** the user selects the suggestion "das Haus" and then appends " ist gross"
+- **THEN** the form enters phrase mode and the entry is saved as a phrase
+
+#### Scenario: A selected phrase lemma survives until it is edited
+- **WHEN** the user selects the pos=phrase suggestion "das heißt" and submits it unchanged
+- **THEN** the form is in phrase mode, although the value alone reads as an article pair
 
 #### Scenario: Mode flip preserves input
 - **WHEN** the detected mode changes while the user is typing

--- a/src/client/domain/phrase.cljs
+++ b/src/client/domain/phrase.cljs
@@ -84,10 +84,17 @@
 
 
 (defn add-mode
-  "The add form's mode: an explicit override wins, otherwise the value itself
-   decides against the completions on screen."
-  [value completions override]
-  (or override
+  "The add form's mode. A picked suggestion settles it for the lemma picked —
+   `das heißt` is a phrase the article exception would call a word, and the
+   suggestions it came from are gone by then — but only while the value still
+   is that lemma. Typing on turns it into something nobody picked, so the value
+   decides again against the completions on screen (GH-358). Same lemma means
+   the same normalized value: that is what makes one vocabulary document."
+  [value completions {picked-mode :mode picked-value :value}]
+  (or (when (and picked-mode
+                 (= (vocabulary/normalize-value value)
+                    (vocabulary/normalize-value picked-value)))
+        picked-mode)
       (if (phrase-value? value completions) :phrase :word)))
 
 

--- a/src/client/pages/home/actions.cljs
+++ b/src/client/pages/home/actions.cljs
@@ -149,11 +149,14 @@
   ;; Picking a suggestion decides the mode by its pos, overriding the space
   ;; heuristic: a multi-word pos=phrase lemma is a phrase, anything else a
   ;; word. Click payloads carry a precomputed :phrase?, keyboard selection
-  ;; hands the raw completion with :pos — accept either.
+  ;; hands the raw completion with :pos — accept either. The lemma is stored
+  ;; with it: the decision was about that lemma and expires when the value
+  ;; stops being it (GH-358).
   [[:effect/save
-    {:home/mode-override (if (or (:phrase? item) (phrase/phrase-suggestion? item))
-                           :phrase
-                           :word)
+    {:home/mode-override {:mode  (if (or (:phrase? item) (phrase/phrase-suggestion? item))
+                                   :phrase
+                                   :word)
+                          :value lemma}
      :home/suggestions   empty-suggestions
      :home/translation   (str/join ", " translations)
      ;; A deliberate pick owns the field: later dictionary answers must not

--- a/test/browser/picked-suggestion-mode.spec.js
+++ b/test/browser/picked-suggestion-mode.spec.js
@@ -1,0 +1,49 @@
+const { test, expect } = require('@playwright/test');
+
+// GH-358: picking a suggestion used to freeze the mode for the rest of the
+// edit, so a phrase typed onto a picked word was saved as a word. The pick
+// still decides for the lemma it was made for — that is what tells `das heißt`
+// from an article pair — and stops deciding as soon as the value is something
+// else.
+//
+// The dictionary is the fixture the backend serves from
+// LEARNING_APP__DICTIONARY_DIR (see README.md); `das Haus` is one of its
+// lemmas, and it is an article pair, so nothing but the pick keeps it a word
+// once its own suggestion list is gone.
+
+const options = (page) => page.getByRole('option');
+
+// The value field's label follows the mode, so it is addressed by id: the
+// element is the same one throughout (inputs are not remounted).
+const valueField = (page) => page.locator('#new-word-value');
+
+// The visually hidden legend carries the same words as the panel title, so
+// only the role tells them apart.
+const panelTitle = (page, name) => page.getByRole('heading', { name });
+
+test('typing on from a picked suggestion switches the form to phrase mode', async ({ page }) => {
+  await page.goto('/home');
+
+  const field = valueField(page);
+  await expect(field).toBeVisible();
+
+  // The dictionary lives in a Worker that fetches and imports SQLite; a
+  // suggestion appearing is the only honest signal that it is ready.
+  await field.pressSequentially('Haus');
+  const picked = options(page).filter({ hasText: 'das Haus' }).first();
+  await expect(picked).toBeVisible();
+  await picked.click();
+
+  await expect(field).toHaveValue('das Haus');
+  await expect(panelTitle(page, 'Добавить слово')).toBeVisible();
+  await expect(page.getByLabel('Слово (немецкий)')).toHaveValue('das Haus');
+
+  // The click hands focus to the translation field, so typing on means going
+  // back to the end of the value.
+  await field.click();
+  await page.keyboard.press('End');
+  await page.keyboard.type(' ist gross');
+
+  await expect(panelTitle(page, 'Добавить фразу')).toBeVisible();
+  await expect(page.getByLabel('Фраза (немецкий)')).toHaveValue('das Haus ist gross');
+});

--- a/test/client/domain/phrase_test.cljs
+++ b/test/client/domain/phrase_test.cljs
@@ -66,12 +66,30 @@
     (is (false? (sut/phrase-suggestion? {:lemma "sich freuen" :pos "verb"})))))
 
 
-(deftest add-mode-override-wins
-  (testing "override beats the heuristic in both directions"
-    (is (= :word (sut/add-mode "auf jeden Fall" [] :word)))
-    (is (= :phrase (sut/add-mode "Fenster" [] :phrase)))
+(deftest add-mode-without-a-pick-follows-the-value
+  (testing "nothing picked leaves the heuristic alone"
     (is (= :phrase (sut/add-mode "auf jeden Fall" [] nil)))
-    (is (= :word (sut/add-mode "Fenster" [] nil)))))
+    (is (= :word (sut/add-mode "Fenster" [] nil)))
+    (is (= :word (sut/add-mode "" [] nil)))))
+
+
+(deftest add-mode-pick-beats-the-heuristic-on-its-own-lemma
+  (testing "a pick decides both directions for the lemma it was made for"
+    (is (= :word (sut/add-mode "auf jeden Fall" [] {:mode :word :value "auf jeden Fall"})))
+    ;; the suggestions are cleared by the pick, so nothing but the pick knows
+    ;; this article pair is a phrase
+    (is (= :phrase (sut/add-mode "das heißt" [] {:mode :phrase :value "das heißt"}))))
+  (testing "the value is the vocabulary identity, not the typed characters"
+    (is (= :phrase (sut/add-mode "Das Heißt " [] {:mode :phrase :value "das heißt"})))))
+
+
+(deftest add-mode-pick-expires-when-the-value-is-edited
+  (testing "typing a phrase onto a picked word re-runs the heuristic (GH-358)"
+    (is (= :phrase (sut/add-mode "das Haus ist gross" [] {:mode :word :value "das Haus"}))))
+  (testing "the picked lemma itself still decides while it is unchanged"
+    (is (= :word (sut/add-mode "das Haus" [] {:mode :word :value "das Haus"}))))
+  (testing "shortening away from a picked phrase falls back to the value"
+    (is (= :word (sut/add-mode "das" [] {:mode :phrase :value "das heißt"})))))
 
 
 (deftest update-phrase-replaces-translation-whole

--- a/test/client/pages/home_test.cljs
+++ b/test/client/pages/home_test.cljs
@@ -10,6 +10,8 @@
    [nexus.registry :as nxr]
    [pages.home.actions]
    [pages.home.effects]
+   [pages.home.presenter :as presenter]
+   [use-cases.phrase :as phrase]
    [use-cases.vocabulary :as vocabulary]))
 
 
@@ -49,6 +51,10 @@
   {:lemma "Hut" :translations ["шляпа"] :exact? true})
 
 
+(def haus
+  {:lemma "das Haus" :pos "noun" :translations ["дом"] :exact? true})
+
+
 (defn- test-system
   "System whose stub dictionary answers from `completions-by-prefix`;
    unknown prefixes (including the empty one) answer [], like the adapter."
@@ -64,6 +70,12 @@
 (defn- suggestion-items
   [store]
   (get-in @store [:home/suggestions :suggestions/items]))
+
+
+(defn- form-legend
+  "What the form says it is about to save — the only place the mode shows."
+  [store]
+  (get-in (presenter/page-props @store) [:form :copy :legend]))
 
 
 (defn- debounce-elapsed
@@ -181,6 +193,38 @@
       (nxr/dispatch system {} [[:action/select-suggestion (assoc hund :focus-id nil)]])
       (nxr/dispatch system {} [[:action/update-suggestions {:completions [hut] :value "Hund"}]])
       (is (= "пёс, собака" (:home/translation @store))))))
+
+
+(deftest typing-on-from-a-picked-word-switches-to-phrase-mode
+  (testing "GH-358: the pick decides for its own lemma, the value decides after an edit"
+    (let [{:keys [store] :as system} (test-system {})]
+      (nxr/dispatch system {} [[:action/select-suggestion (assoc haus :focus-id nil)]])
+      (is (= "Добавить слово" (form-legend store)))
+      (nxr/dispatch system {} [[:action/update-word "das Haus ist gross"]])
+      (is (= "Добавить фразу" (form-legend store))))))
+
+
+(deftest typing-on-from-a-picked-word-is-saved-as-a-phrase
+  (async-testing "GH-358: the submitted document follows the re-evaluated mode"
+    (let [saved-as (atom nil)]
+      (with-redefs [phrase/add!      (fn [_ _ _]
+                                       (reset! saved-as :phrase)
+                                       (js/Promise.resolve {:word-id "p1" :created? true}))
+                    vocabulary/add!  (fn [_ _ _]
+                                       (reset! saved-as :word)
+                                       (js/Promise.resolve {:word-id "w1" :created? true}))
+                    vocabulary/count (fn [_]
+                                       (js/Promise.resolve 1))]
+        (let [system (test-system {})]
+          (nxr/dispatch system {} [[:action/select-suggestion (assoc haus :focus-id nil)]])
+          (nxr/dispatch system {} [[:action/update-word "das Haus ist gross"]])
+          (nxr/dispatch system
+                        {}
+                        [[:action/add-word
+                          {:value       "das Haus ist gross"
+                           :translation "дом большой"}]])
+          (await (debounce-elapsed))
+          (is (= :phrase @saved-as)))))))
 
 
 (deftest stale-answer-is-ignored


### PR DESCRIPTION
Closes #358.

Picking a suggestion set `:home/mode-override` and nothing ever cleared it, so
typing on from a picked word kept the form in word mode and the entry went to
the database as a word.

The override could not simply be dropped: it is what makes `das heißt` a
phrase, which the article exception reads as a word, and the suggestion list it
came from is gone by then. So it is scoped instead — the pick decides for the
lemma it was made for and stops deciding once the value is something else.
Sameness is the vocabulary identity already in use (`normalize-value`), so
case, punctuation and a trailing space do not revoke a pick; they do not make a
different document either.

A pick is still the only source of an override — the form has no manual mode
control.

## Verification

- `npx shadow-cljs compile node-test` — 188 tests, 445 assertions, 0 failures.
  New: `add-mode` unit tests (pick held on its own lemma, dropped after an
  edit, `das heißt` unchanged) and two home-page tests, one on the legend the
  presenter produces, one on which use case the submit reaches.
- `npx playwright test --project=desktop` — 18 passed, including the new
  `test/browser/picked-suggestion-mode.spec.js`: type `Haus`, pick `das Haus`,
  append ` ist gross`, panel title turns into "Добавить фразу".
- Mutation-checked both ways: with the old rule restored, the three new unit
  assertions and the browser spec fail; with the fix, all green.

Before the append (picked lemma, word mode) and after:

![picked word](https://raw.githubusercontent.com/u473t8/learning-app/pr-assets/gh-358/picked-word.png)
![typed on into a phrase](https://raw.githubusercontent.com/u473t8/learning-app/pr-assets/gh-358/typed-on-phrase.png)

Not covered: the mobile Playwright project was not run (this change touches no
layout), and nothing here was tried on a phone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HVVV5xTnjBng67ojifJqzV